### PR TITLE
Added a macro for references to core: CXREF.

### DIFF
--- a/std.ddoc
+++ b/std.ddoc
@@ -282,6 +282,7 @@ GLOSSARY = $(LINK2 ../glossary.html#$0, $0)
 DDOC_PSYMBOL = <a name="$0"></a>$(U $0)
 DDOC_DECL  = $(DT <div class="d_decl">$0</div>)
 XREF = <a href="std_$1.html#$2">$(D std.$1.$2)</a>
+CXREF = <a href="core_$1.html#$2">$(D core.$1.$2)</a>
 LREF = <a href="#$1">$(D $1)</a>
 BUGZILLA = $(LINK2 http://d.puremagic.com/issues/show_bug.cgi?id=$0, Bugzilla $0)
 PRE = <pre>$0</pre>


### PR DESCRIPTION
XREF only works with std, and as far as I can tell, there is no macro for references to core. So, I added CXREF for referring to the documentation for core. If you'd prefer a different name, feel free to change it, but I think that we need a macro for referring to the documentation for core, and CXREF is the best that I could think of.
