### PR TITLE
C syntax for declaring pointers to functions deprecated? Right?

### DIFF
--- a/type.dd
+++ b/type.dd
@@ -384,7 +384,7 @@ int delegate(int) dg;	// dg is a delegate to a function
 -------------------
 
 	$(P The C style syntax for declaring pointers to functions is
-	also supported:
+	deprecated:
 	)
 
 -------------------


### PR DESCRIPTION
As I understand the C syntax for declaring pointers to functions is actually deprecated (like I see  in declaration.dd)
