### PR TITLE
Bug 6734 - Removing erroneous q{ @ } example for lex.dd

### DIFF
--- a/lex.dd
+++ b/lex.dd
@@ -566,7 +566,6 @@ q"/abc/def/"    // error
 q{foo}              // "foo"
 q{/*}*/ }           // "/*}*/ "
 q{ foo(q{hello}); } // " foo(q{hello}); "
-q{ @ }              // error, @ is not a valid D token
 q{ __TIME__ }       // " __TIME__ ", i.e. it is not replaced with the time
 q{ __EOF__ }        // error, as __EOF__ is not a token, it's end of file
 ---


### PR DESCRIPTION
See http://d.puremagic.com/issues/show_bug.cgi?id=6734

I have assumed that, since DMD compiles q{ @ } as expected, that the documentation is incorrect. This small adjustment fixes this.
