### PR TITLE
char[] -> string

### DIFF
--- a/function.dd
+++ b/function.dd
@@ -1480,9 +1480,9 @@ void test() {
 
 ----
 void main() { ... }
-void main(char[][] args) { ... }
+void main(string[] args) { ... }
 int main() { ... }
-int main(char[][] args) { ... }
+int main(string[] args) { ... }
 ----
 
 <h2>$(LNAME2 interpretation, Compile Time Function Execution (CTFE))</h2>


### PR DESCRIPTION
Replace usage of char[] for main() arguments in the docs.
