### PR TITLE
Update the list of version identifiers

### DIFF
--- a/version.dd
+++ b/version.dd
@@ -244,7 +244,6 @@ version($(I identifier)) // add in version code if version
 	$(TR $(TD $(B Solaris)) $(TD Solaris))
 	$(TR $(TD $(B Posix)) $(TD All POSIX systems (includes Linux, FreeBSD, OS X, Solaris, etc.)))
 	$(TR $(TD $(B AIX)) $(TD IBM Advanced Interactive eXecutive OS))
-	$(TR $(TD $(B darwin)) $(TD The Darwin operating system (deprecated; use OSX)))
 	$(TR $(TD $(B SkyOS)) $(TD The SkyOS operating system))
 	$(TR $(TD $(B SysV3)) $(TD System V Release 3))
 	$(TR $(TD $(B SysV4)) $(TD System V Release 4))
@@ -280,6 +279,14 @@ version($(I identifier)) // add in version code if version
 	$(V2 $(TR $(TD $(B D_Version2)) $(TD This is a D version 2 compiler)))
 	$(TR $(TD $(B none)) $(TD Never defined; used to just disable a section of code))
 	$(TR $(TD $(B all)) $(TD Always defined; used as the opposite of $(B none)))
+	)
+
+	$(P The following identifiers are defined, but are deprecated:
+	)
+
+	$(TABLE2 Predefined Version Identifiers,
+	$(TR $(TH Version Identifier) $(TH Description))
+	$(TR $(TD $(B darwin)) $(TD The Darwin operating system; use $(B OSX) instead))
 	)
 
 	$(P Others will be added as they make sense and new implementations appear.


### PR DESCRIPTION
This includes a number of things:
- Reorders the list to be easier to navigate.
- Adds several compiler identifiers (GNU, LDC, SDC, etc).
- Adds operating system identifiers from GDC and LDC.
- Adds CPU architectures supported in GDC and LDC.
- Explicitly list 'darwin' as a deprecated identifier.

The point of these changes is to get these things standardized across compilers to make porting of code easier for users.
