### PR TITLE
fixed "leake" to "leaked"

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -251,7 +251,7 @@ $(VERSION 055, Sep 4, 2011, =================================================,
 	$(LI $(BUGZILLA 6563): wrong code when using at least 8 XMM regs)
 	$(LI $(BUGZILLA 6577): 'Cannot initialize member' error line number)
 	$(LI $(BUGZILLA 6601): Regression(2.053): CTFE segfault taking address of function template)
-	$(LI $(BUGZILLA 6602): Invalid template instantiations leake by is(typeof())/__traits(compiles, )/Type::trySemantic)
+	$(LI $(BUGZILLA 6602): Invalid template instantiations leaked by is(typeof())/__traits(compiles, )/Type::trySemantic)
     )
 )
 


### PR DESCRIPTION
typo in DMD 2.055 changelog
