### PR TITLE
Remove incorrect statement on array passing.

### DIFF
--- a/memory.dd
+++ b/memory.dd
@@ -40,7 +40,7 @@ $(D_S Memory Management,
 
 	$(P Consider the case of passing an array to a function, possibly
 	modifying the contents of the array, and returning the modified
-	array. Since arrays are passed by reference, not by value,
+	array. As the contents of an array are accessed through a reference,
 	a crucial issue is who owns the contents of the array?
 	For example, a function to convert an array of characters to
 	upper case:


### PR DESCRIPTION
This confuses people that don't understand that arrays are passed by value, even though they contain a reference.
