### PR TITLE
interfaceToC: c_long is not "long long" in 32bit

### DIFF
--- a/interfaceToC.dd
+++ b/interfaceToC.dd
@@ -190,16 +190,28 @@ $(V1
 )
 
 $(V2
-    $(TR
+	$(TR
 	$(TD $(B c_long (in core.stdc.config)))
-	$(TD $(B long long))
+	$(TD $(B long))
 	$(TD $(B long))
 	)
 
 	$(TR
 	$(TD $(B c_ulong (in core.stdc.config)))
-	$(TD $(B unsigned long long))
 	$(TD $(B unsigned long))
+	$(TD $(B unsigned long))
+	)
+
+	$(TR
+	$(TD $(B long))
+	$(TD $(B long long))
+	$(TD $(B long (or long long)))
+	)
+
+	$(TR
+	$(TD $(B ulong))
+	$(TD $(B unsigned long long))
+	$(TD $(B unsigned long (or unsigned long long)))
 	)
 )
 	$(TR


### PR DESCRIPTION
The "Interfacing to C" page says c_long is the same as "long long" in 32bit, but this is not true. AFAIR "long long" must be at least 64bits, in practice it is always 64bit. This pull request fixes the c_[u]long entries and adds new entries for [u]long --> [unsigned] long long
