### PR TITLE
Tidy up of titles in documenation.

### DIFF
--- a/attribute.dd
+++ b/attribute.dd
@@ -13,7 +13,7 @@ $(GNAME Attribute):
     $(GLINK2 pragma, Pragma)
     $(LINK2 #deprecated, $(B deprecated))
     $(GLINK ProtectionAttribute)
-    $(B static)
+    $(LINK2 #static, $(B static))
     $(B extern)
     $(B final)
     $(B synchronized)
@@ -136,7 +136,7 @@ extern (Windows):
     );
 ---------------
 
-<h2>$(LNAME2 align, Align Attribute)</h2>
+<h2>$(LNAME2 align, $(CODE align) Attribute)</h2>
 
 $(GRAMMAR
 $(GNAME AlignAttribute):
@@ -199,7 +199,7 @@ align (1) struct S {
         It is not inherited from a base class.
         )
 
-<h2>$(LNAME2 deprecated, Deprecated Attribute)</h2>
+<h2>$(LNAME2 deprecated, $(CODE deprecated) Attribute)</h2>
 
         $(P It is often necessary to deprecate a feature in a library,
         yet retain it for backwards compatibility. Such
@@ -271,7 +271,7 @@ $(GNAME ProtectionAttribute):
         is analogous to exporting definitions from a DLL.
         )
 
-<h2>$(LNAME2 const, Const Attribute)</h2>
+<h2>$(LNAME2 const, $(CODE const) Attribute)</h2>
 
         $(P The $(B const) attribute declares constants that can be
         evaluated at compile time. For example:
@@ -341,15 +341,15 @@ class C
 )
 
 $(V2
-<h2>$(LNAME2 immutable, immutable Attribute)</h2>
+<h2>$(LNAME2 immutable, $(CODE immutable) Attribute)</h2>
 
-<h2>$(LNAME2 gshared, __gshared Attribute)</h2>
+<h2>$(LNAME2 gshared, $(CODE __gshared) Attribute)</h2>
 
-<h2>$(LNAME2 shared, shared Attribute)</h2>
+<h2>$(LNAME2 shared, $(CODE shared) Attribute)</h2>
 
-<h2>$(LNAME2 inout, inout Attribute)</h2>
+<h2>$(LNAME2 inout, $(CODE inout) Attribute)</h2>
 
-<h2>$(LNAME2 disable, @disable Attribute)</h2>
+<h2>$(LNAME2 disable, $(CODE @disable) Attribute)</h2>
 
         $(P A reference to a declaration marked with the $(CODE @disable) attribute causes
         a compile time error.
@@ -376,7 +376,7 @@ void main() {
 ---
 )
 
-<h2>$(LNAME2 override, Override Attribute)</h2>
+<h2>$(LNAME2 override, $(CODE override) Attribute)</h2>
 
         $(P The $(B override) attribute applies to virtual functions.
         It means that the function must override a function with the
@@ -400,7 +400,7 @@ class Foo2 : Foo {
 }
 ---------------
 
-<h2>Static Attribute</h2>
+<h2>$(LNAME2 static, $(CODE static) Attribute)</h2>
 
         $(P The $(B static) attribute applies to functions and data.
         It means that the declaration does not apply to a particular
@@ -444,7 +444,7 @@ private int y = 4; // y is local to module foo
 ---------------
 
 
-<h2>$(LNAME2 auto, Auto Attribute)</h2>
+<h2>$(LNAME2 auto, $(CODE auto) Attribute)</h2>
 
         $(P The $(B auto) attribute is used when there are no other attributes
         and type inference is desired.
@@ -454,7 +454,7 @@ private int y = 4; // y is local to module foo
 auto i = 6.8;   // declare i as a double
 ---
 
-<h2>$(LNAME2 scope, Scope Attribute)</h2>
+<h2>$(LNAME2 scope, $(CODE scope) Attribute)</h2>
 
 $(P
         The $(B scope) attribute is used for local variables and for class
@@ -481,7 +481,7 @@ $(P
         if a compelling reason to appears.
 )
 
-<h2>$(LNAME2 abstract, Abstract Attribute)</h2>
+<h2>$(LNAME2 abstract, $(CODE abstract) Attribute)</h2>
 
 $(P
         If a class is abstract, it cannot be instantiated

--- a/class.dd
+++ b/class.dd
@@ -445,7 +445,7 @@ class Foo {
         by the gc.
         )
 
-<h3>Static Constructors</h3>
+<h3>$(CODE static) Constructors</h3>
 
 $(GRAMMAR
 $(GNAME StaticConstructor):
@@ -535,7 +535,7 @@ class Foo {
 }
 ------
 
-<h3>Static Destructors</h3>
+<h3>$(CODE static) Destructors</h3>
 
 $(GRAMMAR
 $(GNAME StaticDestructor):
@@ -578,7 +578,7 @@ class Foo {
 ------
 
 $(V2
-<h3>Shared Static Constructors</h3>
+<h3>$(CODE shared static) Constructors</h3>
 
 $(GRAMMAR
 $(GNAME SharedStaticConstructor):
@@ -589,7 +589,7 @@ $(GNAME SharedStaticConstructor):
         and are intended for initializing any shared global data.
         )
 
-<h3>Shared Static Destructors</h3>
+<h3>$(CODE shared static) Destructors</h3>
 
 $(GRAMMAR
 $(GNAME SharedStaticDestructor):
@@ -788,7 +788,7 @@ delete f;
         )
 
 $(V2
-<h3>$(LNAME2 AliasThis, Alias This)</h3>
+<h3>$(LNAME2 AliasThis, $(CODE alias this))</h3>
 
 $(GRAMMAR
 $(GNAME AliasThis):
@@ -827,7 +827,7 @@ void test() {
 ---
 )
 
-<h3>$(LNAME2 auto, Scope Classes)</h3>
+<h3>$(LNAME2 auto, $(CODE scope) Classes)</h3>
 
         A scope class is a class with the $(B scope) attribute, as in:
 
@@ -855,7 +855,7 @@ void func() {
         (if any) for it is automatically called. This holds true even if
         the scope was exited via a thrown exception.
 
-<h3>$(LNAME2 final, Final Classes)</h3>
+<h3>$(LNAME2 final, $(CODE final) Classes)</h3>
 
         $(P Final classes cannot be subclassed:)
 
@@ -1095,7 +1095,7 @@ new ($(I ArgumentList)) $(I Identifier) ($(I ArgumentList));
         )
 
 $(V2
-$(SECTION3 <a name="ConstClass">Const, Immutable and Shared Classes</a>
+$(SECTION3 <a name="ConstClass">$(CODE const)&#44; $(CODE immutable)&#44; and $(CODE shared) Classes</a>,
         $(P If a $(I ClassDeclaration) has a $(CODE const), $(CODE immutable)
         or $(CODE shared) storage class, then it is as if each member of the class
         was declared with that storage class.

--- a/const3.dd
+++ b/const3.dd
@@ -33,7 +33,7 @@ $(D_S Const and Immutable,
 	immutable, and likewise for const.
 	)
 
-$(SECTION2 Immutable Storage Class,
+$(SECTION2 $(CODE immutable) Storage Class,
 
 	$(P
 	The simplest immutable declarations use it as a storage class.
@@ -108,7 +108,7 @@ s = "bar";   // error, s is immutable
 	)
 )
 
-$(SECTION2 Const Storage Class,
+$(SECTION2 $(CODE const) Storage Class,
 
 	$(P
 	A const declaration is exactly like an immutable declaration,
@@ -193,7 +193,7 @@ $(TR $(TD $(ORANGE orange)) $(TD implicit conversion))
 )
 )
 
-$(SECTION2 Immutable Type,
+$(SECTION2 $(CODE immutable) Type,
 
 	$(P
 	Data that will never change its value can be typed as immutable.
@@ -274,7 +274,7 @@ auto p = s.idup;
 p[0] = ...;	  // error, p[] is immutable
 ---
 
-<h2>Removing Immutable With A Cast</h2>
+<h2>Removing $(CODE immutable) with a Cast</h2>
 
 	$(P
 	The immutable type can be removed with a cast:
@@ -305,7 +305,7 @@ int* q = cast(int*)p;
 )
 
 
-$(SECTION2 Immutable Member Functions,
+$(SECTION2 $(CODE immutable) Member Functions,
 
 	$(P
 	Immutable member functions are guaranteed that the object
@@ -355,7 +355,7 @@ struct S {
 )
 
 
-$(SECTION2 Const Type,
+$(SECTION2 $(CODE const) Type,
 
 	$(P
 	Const types are like immutable types, except that const
@@ -365,7 +365,7 @@ $(SECTION2 Const Type,
 )
 
 
-$(SECTION2 Const Member Functions,
+$(SECTION2 $(CODE const) Member Functions,
 
 	$(P
 	Const member functions are functions that are not allowed to
@@ -385,10 +385,10 @@ $(SECTION2 Implicit Conversions,
 )
 
 
-$(SECTION2 Comparing D Immutable and Const with C++ Const,
+$(SECTION2 Comparing D $(CODE immutable) and $(CODE const) with C++ $(CODE const),
 
 	<table border=2 cellpadding=4 cellspacing=0 class="comp">
-	<caption>Const, Immutable Comparison</caption>
+	<caption>$(CODE const), $(CODE immutable) Comparison</caption>
 
 	<thead>
 	$(TR

--- a/dbc.dd
+++ b/dbc.dd
@@ -30,7 +30,7 @@ $(COMMENT <img src="images/d4.gif" alt="Contracts make D bug resistant" border=0
 	out of date, wrong, or non-existent. Moving the contracts into the code makes them
 	verifiable against the program.)
 
-<h2>Assert Contract</h2>
+<h2>$(CODE assert) Contract</h2>
 
 	The most basic contract is the
 	$(GLINK2 expression, AssertExpression).
@@ -119,7 +119,7 @@ void func()
 	In an out statement, $(I result) is initialized and set to the
 	return value of the function.
 
-<h2>In, Out and Inheritance</h2>
+<h2>$(CODE in), $(CODE out) and Inheritance</h2>
 
 	$(P If a function in a derived class overrides a function in its
 	super class, then only one of

--- a/declaration.dd
+++ b/declaration.dd
@@ -389,7 +389,7 @@ $(V1
         )
 )
 
-<h3>Alias Declarations</h3>
+<h3>$(CODE alias) Declarations</h3>
 
         $(P
         A symbol can be declared as an $(I alias) of another symbol.
@@ -504,7 +504,7 @@ alias S.i b; // ok
 b = 4;       // sets S.i to 4
 -----------
 
-<h3><a name="extern">Extern Declarations</a></h3>
+<h3><a name="extern">$(CODE extern) Declarations</a></h3>
 
         Variable declarations with the storage class $(B extern) are
         not allocated storage within the module.
@@ -513,7 +513,7 @@ b = 4;       // sets S.i to 4
         The primary usefulness of this is to connect with global
         variable declarations in C files.
 
-<h3><a name="typeof">typeof</a></h3>
+<h3><a name="typeof">$(CODE typeof)</a></h3>
 
 $(GRAMMAR
 $(GNAME Typeof):
@@ -590,7 +590,7 @@ $(B typeof(this)) r;   // error, no enclosing struct or class
         template code.
         )
 
-<h3>Void Initializations</h3>
+<h3>$(CODE void) Initializations</h3>
 
 $(GRAMMAR
 $(GNAME VoidInitializer):

--- a/expression.dd
+++ b/expression.dd
@@ -538,7 +538,7 @@ if (c < null)  // error
   ...
 ---
 
-<h2>In Expressions</h2>
+<h2>$(CODE in) Expressions</h2>
 
 $(GRAMMAR
 $(GNAME InExpression):
@@ -710,7 +710,7 @@ $(GNAME UnaryExpression):
 )
 
 
-<h3>New Expressions</h3>
+<h3>$(CODE new) Expressions</h3>
 
 $(GRAMMAR
 $(GNAME NewExpression):
@@ -783,7 +783,7 @@ foreach (ref a; bar)
         or using the class specific allocator.
         )
 
-<h3>Delete Expressions</h3>
+<h3>$(CODE delete) Expressions</h3>
 
 $(GRAMMAR
 $(GNAME DeleteExpression):
@@ -823,7 +823,7 @@ $(GNAME DeleteExpression):
         is called.
         )
 
-<h3>Cast Expressions</h3>
+<h3>$(CODE cast) Expressions</h3>
 
 $(GRAMMAR
 $(GNAME CastExpression):
@@ -1064,7 +1064,7 @@ $(V2      $(GLINK2 traits, TraitsExpression))
         $(I Identifier) is looked up at module scope, rather than the current
         lexically nested scope.
 
-<h3>$(LNAME2 this, this)</h3>
+<h3>$(LNAME2 this, $(CODE this))</h3>
 
         $(P Within a non-static member function, $(B this) resolves to
         a reference to the object for which the function was called.
@@ -1095,7 +1095,7 @@ void main() {
 -------------
 
 
-<h3>$(LNAME2 super, super)</h3>
+<h3>$(LNAME2 super, $(CODE super))</h3>
 
         $(P $(B super) is identical to $(B this), except that it is
         cast to $(B this)'s base class.
@@ -1106,7 +1106,7 @@ void main() {
         to $(B super), a non-virtual call is made.
         )
 
-<h3>$(LNAME2 null, null)</h3>
+<h3>$(LNAME2 null, $(CODE null))</h3>
 
         $(P $(B null) represents the null value for
         pointers, pointers to functions, delegates,
@@ -1120,7 +1120,7 @@ void main() {
         but no longer exact.
         )
 
-<h3>true, false</h3>
+<h3>$(CODE true), $(CODE false)</h3>
 
         These are of type $(B bool) and when cast to another integral
         type become the values 1 and 0,
@@ -1415,7 +1415,7 @@ double test() {
         function, a function literal cannot.
 
 
-<h3>Assert Expressions</h3>
+<h3>$(CODE assert) Expressions</h3>
 
 $(GRAMMAR
 $(GNAME AssertExpression):
@@ -1465,7 +1465,7 @@ Error: AssertError Failure test.d(3) an error message
 )
 
 
-<h3>Mixin Expressions</h3>
+<h3>$(CODE mixin) Expressions</h3>
 
 $(GRAMMAR
 $(GNAME MixinExpression):
@@ -1484,7 +1484,7 @@ int foo(int x) {
 }
 ---
 
-<h3>Import Expressions</h3>
+<h3>$(CODE import) Expressions</h3>
 
 $(GRAMMAR
 $(GNAME ImportExpression):
@@ -1511,7 +1511,7 @@ void foo() {
 }
 ---
 
-<h3>Typeid Expressions</h3>
+<h3>$(CODE typeid) Expressions</h3>
 
 $(GRAMMAR
 $(GNAME TypeidExpression):
@@ -1558,7 +1558,7 @@ void main() {
 ---
 )
 
-<h3>IsExpression</h3>
+<h3>$(CODE is) Expression</h3>
 
 $(GRAMMAR
 $(GNAME IsExpression):

--- a/function.dd
+++ b/function.dd
@@ -30,7 +30,7 @@ $(GNAME BodyStatement):
         )
 
 $(V2
-<h3>$(LNAME2 pure-functions, Pure Functions)</h3>
+<h3>$(LNAME2 pure-functions, $(CODE pure) Functions)</h3>
 
         $(P Pure functions are functions that produce the same
         result for the same arguments.
@@ -82,7 +82,7 @@ pure int foo(int i,
 ---
 
 
-<h3>$(LNAME2 nothrow-functions, Nothrow Functions)</h3>
+<h3>$(LNAME2 nothrow-functions, $(CODE nothrow) Functions)</h3>
 
         $(P Nothrow functions do not throw any exceptions derived
         from class $(I Exception).
@@ -90,7 +90,7 @@ pure int foo(int i,
 
         $(P Nothrow functions are covariant with throwing ones.)
 
-<h3>$(LNAME2 ref-functions, Ref Functions)</h3>
+<h3>$(LNAME2 ref-functions, $(CODE ref) Functions)</h3>
 
         $(P Ref functions allow functions to return by reference.
         This is analogous to ref function parameters.
@@ -105,7 +105,7 @@ ref int foo() {
 foo() = 3;  // reference returns can be lvalues
 ---
 
-<h3>$(LNAME2 auto-functions, Auto Functions)</h3>
+<h3>$(LNAME2 auto-functions, $(CODE auto) Functions)</h3>
 
         $(P Auto functions have their return type inferred from any
         $(GLINK2 statement, ReturnStatement)s
@@ -129,7 +129,7 @@ auto foo(int i) {
 ---
 
 $(V2
-<h3>$(LNAME2 auto-ref-functions, Auto Ref Functions)</h3>
+<h3>$(LNAME2 auto-ref-functions, $(CODE auto ref) Functions)</h3>
 
         $(P Auto ref functions infer their return type just as
         $(LINK2 #auto-functions, auto functions) do.
@@ -157,7 +157,7 @@ auto ref foo(ref int x) { return x; return 3; }  // error, ref return, 3 is not 
 )
 
 $(V2
-<h3>$(LNAME2 inout-functions, Inout Functions)</h3>
+<h3>$(LNAME2 inout-functions, $(CODE inout) Functions)</h3>
 
         $(P Functions that deal with mutable, const, or immutable types with
         equanimity often need to transmit their type to the return value:
@@ -244,7 +244,7 @@ void foo() {
 ---
 )
 
-<h3>$(LNAME2 virtual-functions, Virtual Functions)</h3>
+<h3>$(LNAME2 virtual-functions, $(CODE virtual) Functions)</h3>
 
         $(P Virtual functions are functions that are called indirectly
         through a function
@@ -783,7 +783,7 @@ foo(4);   // same as foo(4, 3);
         )
 
 
-<h3>C-style Variadic Functions</h3>
+<h3>C-Style Variadic Functions</h3>
 
         A C-style variadic function is declared as taking
         a parameter of ... after the required function parameters.
@@ -831,7 +831,7 @@ int foo(int x, int y, ...) {
 import $(B std.c.stdarg);
 ------
 
-<h3>D-style Variadic Functions</h3>
+<h3>D-Style Variadic Functions</h3>
 
         Variadic functions with argument and type info are declared as taking
         a parameter of ... after the required function parameters.
@@ -1469,7 +1469,7 @@ void test() {
         $(P See $(GLINK2 expression, FunctionLiteral)s.
         )
 
-<h2>main() Function</h2>
+<h2>$(CODE main()) Function</h2>
 
         $(P For console programs, $(D main()) serves as the entry point.
         It gets called after all the module initializers are run, and

--- a/interface.dd
+++ b/interface.dd
@@ -216,7 +216,7 @@ interface I
 ---
 )
 
-$(SECTION2 $(LNAME2 ConstInterface, Const and Immutable Interfaces),
+$(SECTION2 $(LNAME2 ConstInterface, $(CODE const) and $(CODE immutable) Interfaces),
 	$(P If an interface has $(CODE const) or $(CODE immutable) storage
 	class, then all members of the interface are
 	$(CODE const) or $(CODE immutable).

--- a/module.dd
+++ b/module.dd
@@ -81,7 +81,7 @@ $(V2
 
 	)
 
-<h3>Module Declaration</h3>
+<h3>$(CODE module) Declaration</h3>
 
 	$(P The $(I ModuleDeclaration) sets the name of the module and what
 	package it belongs to. If absent, the module name is taken to be the
@@ -131,7 +131,7 @@ module c.stdio;    // this is module $(B stdio) in the $(B c) package
 	minimize problems moving projects between dissimilar file systems.
 	)
 
-<h2><a name="ImportDeclaration">Import Declaration</a></h2>
+<h2><a name="ImportDeclaration">$(CODE import) Declaration</a></h2>
 
 	$(P
 	Symbols from one module are made available in another module
@@ -245,7 +245,7 @@ void test()
 }
 ---
 
-<h3>Public Imports</h3>
+<h3>$(CODE public) Imports</h3>
 
 	$(P By default, imports are $(I private). This means that
 	if module A imports module B, and module B imports module
@@ -282,7 +282,7 @@ foo();	// error, foo() is undefined
 bar();	// ok, calls B.bar()
 ---
 
-<h3>Static Imports</h3>
+<h3>$(CODE static) Imports</h3>
 
 	$(P Basic imports work well for programs with relatively few modules
 	and imports. If there are a lot of imports, name collisions
@@ -445,12 +445,12 @@ $(V2
 )
 
 
-<h3>Order of Unit tests</h3>
+<h3>Order of Unit Tests</h3>
 
 	Unit tests are run in the lexical order in which they appear
 	within a module.
 
-<h2>$(LNAME2 MixinDeclaration, Mixin Declaration)</h2>
+<h2>$(LNAME2 MixinDeclaration, $(CODE mixin) Declaration)</h2>
 
 $(GRAMMAR
 $(GNAME MixinDeclaration):

--- a/pragma.dd
+++ b/pragma.dd
@@ -51,7 +51,7 @@ pragma(ident) { // influence block of statements
         is up to the individual pragma semantics.
         )
 
-<h2><a name="Predefined-Pragmas">Predefined Pragmas</a></h2>
+<h2><a name="Predefined-Pragmas">Predefined $(CODE pragma)s</a></h2>
 
         $(P All implementations must support these, even if by just ignoring
         them:
@@ -93,7 +93,7 @@ pragma(startaddress, foo);
 
     )
 
-<h2>Vendor Specific Pragmas</h2>
+<h2>Vendor Specific $(CODE pragma)s</h2>
 
         $(P Vendor specific pragma $(I Identifier)s can be defined if they
         are prefixed by the vendor's trademarked name, in a similar manner
@@ -120,7 +120,7 @@ version (DigitalMars)
 )
 
 Macros:
-        TITLE=Pragmas
+        TITLE=$(CODE pragma)s
         WIKI=Pragma
         CATEGORY_SPEC=$0
 

--- a/property.dd
+++ b/property.dd
@@ -65,7 +65,7 @@ $(TR $(TH Property)	$(TH Description))
 $(TR $(TD $(LINK2 #classinfo, .classinfo))	$(TD Information about the dynamic type of the class))
 )
 
-$(SECTION2 $(LNAME2 init, .init) Property,
+$(SECTION2 $(LNAME2 init, $(CODE .init) Property),
 
 	$(P $(B .init) produces a constant expression that is the default
 	initializer. If applied to a type, it is the default initializer
@@ -98,7 +98,7 @@ Foo.init.b  // is 7
 ----------------
 )
 
-$(SECTION2 $(LNAME2 stringof, .stringof) Property,
+$(SECTION2 $(LNAME2 stringof, $(CODE .stringof) Property),
 
 	$(P $(B .stringof) produces a constant string that is the
 	source representation of its prefix.
@@ -132,7 +132,7 @@ void main() {
 ----------------
 )
 
-$(SECTION2 $(LNAME2 sizeof, .sizeof Property),
+$(SECTION2 $(LNAME2 sizeof, $(CODE .sizeof) Property),
 
 	$(P $(CODE $(I e).sizeof) gives the size in bytes of the expression
 	$(I e).
@@ -160,7 +160,7 @@ void test() {
 
 )
 
-$(SECTION2 $(LNAME2 alignof, .alignof Property),
+$(SECTION2 $(LNAME2 alignof, $(CODE .alignof) Property),
 
 	$(P $(CODE .alignof) gives the aligned size of an expression or type.
 	For example, an aligned size of 1 means that it is aligned on
@@ -168,7 +168,7 @@ $(SECTION2 $(LNAME2 alignof, .alignof Property),
 	)
 )
 
-$(SECTION2 $(LNAME2 classinfo, .classinfo) Property,
+$(SECTION2 $(LNAME2 classinfo, $(CODE .classinfo) Property),
 
 	$(P $(CODE .classinfo) provides information about the dynamic type
 	of a class object.

--- a/statement.dd
+++ b/statement.dd
@@ -211,7 +211,7 @@ struct S { }  // declare struct s
 alias int myint;
 ----
 
-<h2>$(LNAME2 IfStatement, If Statement)</h2>
+<h2>$(LNAME2 IfStatement, $(CODE if) Statement)</h2>
 
         If statements provide simple conditional execution of statements.
 
@@ -273,7 +273,7 @@ else
 writefln(m.pre);         // error, m undefined
 ---
 
-<h2>$(LNAME2 WhileStatement, While Statement)</h2>
+<h2>$(LNAME2 WhileStatement, $(CODE while) Statement)</h2>
 
 $(GRAMMAR
 $(I WhileStatement):
@@ -301,7 +301,7 @@ while (i < 10) {
         A $(GLINK ContinueStatement)
         will transfer directly to evaluating $(EXPRESSION) again.
 
-<h2>$(LNAME2 DoStatement, Do Statement)</h2>
+<h2>$(LNAME2 DoStatement, $(CODE do) Statement)</h2>
 
 $(V1
 $(GRAMMAR
@@ -336,7 +336,7 @@ do {
         A $(GLINK ContinueStatement)
         will transfer directly to evaluating $(EXPRESSION) again.
 
-<h2>$(LNAME2 ForStatement, For Statement)</h2>
+<h2>$(LNAME2 ForStatement, $(CODE for) Statement)</h2>
 
         For statements implement loops with initialization,
         test, and increment clauses.
@@ -409,7 +409,7 @@ for (int i = 0; i < 10; i++)
         The $(I Initialize) may be omitted. $(I Test) may also be
         omitted, and if so, it is treated as if it evaluated to true.
 
-<h2>$(LNAME2 ForeachStatement, Foreach Statement)</h2>
+<h2>$(LNAME2 ForeachStatement, $(CODE foreach) Statement)</h2>
 
         A foreach statement loops over the contents of an aggregate.
 
@@ -451,7 +451,7 @@ $(P
         in the $(PS0).
 )
 
-<h3>Foreach over Arrays</h3>
+<h3>$(CODE foreach) over Arrays</h3>
 
 $(P
         If the aggregate is a static or dynamic array, there
@@ -483,7 +483,7 @@ foreach (int i, char c; a)
         order.
         )
 
-<h3>Foreach over Arrays of Characters</h3>
+<h3>$(CODE foreach) over Arrays of Characters</h3>
 
         $(P If the aggregate expression is a static or dynamic array of
         $(B char)s, $(B wchar)s, or $(B dchar)s, then the $(I Type) of
@@ -535,7 +535,7 @@ $(CONSOLE
 'y'
 )
 
-<h3>Foreach over Associative Arrays</h3>
+<h3>$(CODE foreach) over Associative Arrays</h3>
 
         $(P If the aggregate expression is an associative array, there
         can be one or two variables declared. If one, then the variable
@@ -562,7 +562,7 @@ foreach (string s, double d; a)
 --------------
 
 $(V2
-<h3>$(LNAME2 foreach_with_ranges, Foreach over Structs and Classes with Ranges)</h3>
+<h3>$(LNAME2 foreach_with_ranges, $(CODE foreach) over Structs and Classes with Ranges)</h3>
 
         $(P Iteration over struct and class objects can be done with
         ranges, which means the following properties and methods must be defined:
@@ -618,7 +618,7 @@ for (auto __r = range; !__r.empty; __r.popBack())
         )
 )
 
-<h3>Foreach over Structs and Classes with opApply</h3>
+<h3>$(CODE foreach) over Structs and Classes with $(CODE opApply)</h3>
 
         $(P
         If it is a struct or class object, the $(B foreach) is defined by
@@ -698,14 +698,14 @@ $(CONSOLE
 82
 )
 
-<h3>Foreach over Delegates</h3>
+<h3>$(CODE foreach) over $(CODE delegate)s</h3>
 
         $(P If $(I Aggregate) is a delegate, the type signature of
         the delegate is of the same as for $(B opApply). This enables
         many different named looping strategies to coexist in the same
         class or struct.)
 
-<h3>Foreach over Tuples</h3>
+<h3>$(CODE foreach) over Tuples</h3>
 
 $(P
         If the aggregate expression is a tuple, there
@@ -750,7 +750,7 @@ long
 double
 )
 
-<h3>Foreach Ref Parameters</h3>
+<h3>$(CODE foreach) $(CODE ref) Parameters</h3>
 
         $(P $(B ref) can be used to update the original elements:
         )
@@ -783,7 +783,7 @@ $(CONSOLE
         the type of the $(I Aggregate).
         )
 
-<h3>Foreach Restrictions</h3>
+<h3>$(CODE foreach) Restrictions</h3>
 
         $(P The aggregate itself must not be resized, reallocated, free'd,
         reassigned or destructed
@@ -803,7 +803,7 @@ a = null;         $(V1            )// ok
 --------------
 
 $(V2
-<h2>$(LNAME2 ForeachRangeStatement, Foreach Range Statement)</h2>
+<h2>$(LNAME2 ForeachRangeStatement, $(CODE foreach) Range Statement)</h2>
 
         A foreach range statement loops over the specified range.
 
@@ -857,7 +857,7 @@ foo0123456789
 )
 )
 
-<h3>Break and Continue out of Foreach</h3>
+<h3>$(CODE break) and $(CODE continue) out of $(CODE foreach)</h3>
 
 
         $(P A $(GLINK BreakStatement) in the body of the foreach will exit the
@@ -865,7 +865,7 @@ foo0123456789
         next iteration.
         )
 
-<h2>$(LNAME2 SwitchStatement, Switch Statement)</h2>
+<h2>$(LNAME2 SwitchStatement, $(CODE switch) Statement)</h2>
 
         A switch statement goes to one of a collection of case
         statements depending on the value of the switch
@@ -1031,7 +1031,7 @@ switch (name) {
         )
 
 $(V2
-<h2>$(LNAME2 FinalSwitchStatement, Final Switch Statement)</h2>
+<h2>$(LNAME2 FinalSwitchStatement, $(CODE final switch) Statement)</h2>
 
 $(GRAMMAR
 $(I FinalSwitchStatement):
@@ -1052,7 +1052,7 @@ $(I FinalSwitchStatement):
 
 )
 
-<h2>$(LNAME2 ContinueStatement, Continue Statement)</h2>
+<h2>$(LNAME2 ContinueStatement, $(CODE continue) Statement)</h2>
 
 $(GRAMMAR
 $(I ContinueStatement):
@@ -1090,7 +1090,7 @@ for (i = 0; i < 10; i++)
 }
 ---
 
-<h2>$(LNAME2 BreakStatement, Break Statement)</h2>
+<h2>$(LNAME2 BreakStatement, $(CODE break) Statement)</h2>
 
 $(GRAMMAR
 $(I BreakStatement):
@@ -1125,7 +1125,7 @@ for (i = 0; i < 10; i++)
 }
 ---
 
-<h2>$(LNAME2 ReturnStatement, Return Statement)</h2>
+<h2>$(LNAME2 ReturnStatement, $(CODE return) Statement)</h2>
 
 $(GRAMMAR
 $(I ReturnStatement):
@@ -1180,7 +1180,7 @@ int foo(int x)
 }
 ---
 
-<h2>$(LNAME2 GotoStatement, Goto Statement)</h2>
+<h2>$(LNAME2 GotoStatement, $(CODE goto) Statement)</h2>
 
 $(GRAMMAR
 $(I GotoStatement):
@@ -1237,7 +1237,7 @@ switch (x)
         It is illegal for a $(I GotoStatement) to be used to skip
         initializations.
 
-<h2>$(LNAME2 WithStatement, With Statement)</h2>
+<h2>$(LNAME2 WithStatement, $(CODE with) Statement)</h2>
 
         The with statement is a way to simplify repeated references
         to the same object.
@@ -1315,7 +1315,7 @@ void main() {
 ---
 )
 
-<h2>$(LNAME2 SynchronizedStatement, Synchronized Statement)</h2>
+<h2>$(LNAME2 SynchronizedStatement, $(CODE synchronized) Statement)</h2>
 
         $(P The synchronized statement wraps a statement with
         a mutex to synchronize access among multiple threads.
@@ -1358,7 +1358,7 @@ synchronized { ... }
         $(P This implements a standard critical section.
         )
 
-<h2>$(LNAME2 TryStatement, Try Statement)</h2>
+<h2>$(LNAME2 TryStatement, $(CODE try) Statement)</h2>
 
         Exception handling is done with the try-catch-finally statement.
 
@@ -1480,7 +1480,7 @@ done
         This restriction may be relaxed in future versions.
         )
 
-<h2>$(LNAME2 ThrowStatement, Throw Statement)</h2>
+<h2>$(LNAME2 ThrowStatement, $(CODE throw) Statement)</h2>
 
         Throw an exception.
 
@@ -1633,7 +1633,7 @@ $(CONSOLE
         return; nor may it be entered with a goto.
 
 $(V1
-<h2>$(LNAME2 VolatileStatement, Volatile Statement)</h2>
+<h2>$(LNAME2 VolatileStatement, $(CODE volatile) Statement)</h2>
 
         No code motion occurs across volatile statement boundaries.
 
@@ -1654,7 +1654,7 @@ $(I VolatileStatement):
         use synchronized statements.
 )
 
-<h2>$(LNAME2 asm, Asm Statement)</h2>
+<h2>$(LNAME2 asm, $(CODE asm) Statement)</h2>
 
         Inline assembler is supported with the asm statement:
 
@@ -1733,14 +1733,14 @@ else
         between them by the compiler.
         )
 
-<h2>$(LNAME2 PragmaStatement, Pragma Statement)</h2>
+<h2>$(LNAME2 PragmaStatement, $(CODE pragma) Statement)</h2>
 
 $(GRAMMAR
 $(I PragmaStatement):
     $(GLINK2 pragma, Pragma) $(PSSEMI)
 )
 
-<h2>$(LNAME2 MixinStatement, Mixin Statement)</h2>
+<h2>$(LNAME2 MixinStatement, $(CODE mixin) Statement)</h2>
 
 $(GRAMMAR
 $(I MixinStatement):

--- a/struct.dd
+++ b/struct.dd
@@ -539,7 +539,7 @@ $(TR $(TD .offsetof) $(TD Offset in bytes of field from beginning of struct))
 )
 
 $(V2
-$(SECTION3 <a name="ConstStruct">Const and Invariant Structs</a>,
+$(SECTION3 <a name="ConstStruct">$(CODE const)&#44; $(CODE immutable)&#44; and $(CODE shared) Structs</a>,
 
         $(P A struct declaration can have a storage class of
         $(CODE const), $(CODE immutable) or $(CODE shared). It has an equivalent

--- a/template.dd
+++ b/template.dd
@@ -364,7 +364,7 @@ alias TFoo!(char, int, int) foo4; // instantiates #4
 
 
 $(V2
-<h2>Template This Parameters</h2>
+<h2>Template $(CODE this) Parameters</h2>
 
 $(GRAMMAR
 $(GNAME TemplateThisParameter):
@@ -455,7 +455,7 @@ void main() {
 ------
 
 
-<h2>$(LNAME2 aliasparameters, Template Alias Parameters)</h2>
+<h2>$(LNAME2 aliasparameters, Template $(CODE alias) Parameters)</h2>
 
 $(GRAMMAR
 $(GNAME TemplateAliasParameter):
@@ -879,7 +879,7 @@ auto $(B Square)(T)(T t) {
         )
 )
 
-<h3>$(LNAME2 auto-ref-parameters, Function Templates with Auto Ref Parameters)</h3>
+<h3>$(LNAME2 auto-ref-parameters, Function Templates with $(CODE auto ref) Parameters)</h3>
 
         $(P An auto ref function template parameter becomes a ref parameter
         if its corresponding argument is an lvalue, otherwise it becomes

--- a/type.dd
+++ b/type.dd
@@ -344,7 +344,7 @@ ulong  u4 = cast(long)-1; // ok, -1 can be represented in a ulong
 )
 
 
-$(SECTION2 bool,
+$(SECTION2 $(CODE bool),
 
     $(P The bool type is a 1 byte size type that can only hold the
     value $(D_KEYWORD true) or $(D_KEYWORD false).

--- a/version.dd
+++ b/version.dd
@@ -62,7 +62,7 @@ $(GNAME Condition):
     $(GLINK StaticIfCondition)
 )
 
-<h2>$(LNAME2 version, Version Condition)</h2>
+<h2>$(LNAME2 version, $(CODE version) Condition)</h2>
 
 $(GRAMMAR
 $(GNAME VersionCondition):
@@ -120,7 +120,7 @@ $(V2	$(P The $(B version(unittest)) is satisfied if and only if the code is
 	)
 )
 
-<h3>$(LNAME2 VersionSpecification, Version Specification)</h3>
+<h3>$(LNAME2 VersionSpecification, $(CODE version) Specification)</h3>
 
 $(GRAMMAR
 $(GNAME VersionSpecification):
@@ -216,7 +216,7 @@ version($(I identifier)) // add in version code if version
 	)
 
 
-<h3><a name="PredefinedVersions">Predefined Versions</a></h3>
+<h3><a name="PredefinedVersions">Predefined $(CODE version)s</a></h3>
 
 	$(P Several environmental version identifiers and identifier
 	name spaces are predefined for consistent usage.
@@ -323,7 +323,7 @@ version(DigitalMars_funky_extension)
 	)
 
 
-<h2>$(LNAME2 debug, Debug Condition)</h2>
+<h2>$(LNAME2 debug, $(CODE debug) Condition)</h2>
 
 $(GRAMMAR
 $(GNAME DebugCondition):
@@ -364,7 +364,7 @@ class Foo {
 ------
 
 
-<h3>Debug Specification</h3>
+<h3>$(CODE debug) Specification</h3>
 
 $(GRAMMAR
 $(GNAME DebugSpecification):
@@ -405,7 +405,7 @@ debug($(I identifier)) { } // add in debug code if debug keyword is $(I identifi
 	$(D -debug=$(I n)) and $(D -debug=$(I identifier)).
 	)
 
-<h2>$(LNAME2 staticif, Static If Condition)</h2>
+<h2>$(LNAME2 staticif, $(CODE static if) Condition)</h2>
 
 $(GRAMMAR
 $(GNAME StaticIfCondition):
@@ -485,7 +485,7 @@ INT!(17) c;  // error, static assert trips
 	)
 
 
-<h2>$(LNAME2 static-assert, $(LNAME2 StaticAssert, Static Assert))</h2>
+<h2>$(LNAME2 static-assert, $(LNAME2 StaticAssert, $(CODE static assert)))</h2>
 
 $(GRAMMAR
 $(GNAME StaticAssert):


### PR DESCRIPTION
Keywords should not be capitalized in titles. They should have the same capitalization as they do in the language.

I have also formatted them as $(CODE) to highlight the fact that they are keywords.
