### PR TITLE
Updated covariant implicit array conversions.

### DIFF
--- a/arrays.dd
+++ b/arrays.dd
@@ -1049,34 +1049,35 @@ writefln("the string is '%s'", str);
 
 <h3>$(LNAME2 implicit-conversions, Implicit Conversions)</h3>
 
-        $(P A pointer $(D $(I T)*) can be implicitly converted to
-        one of the following:)
-
-        $(UL
-        $(LI $(D void*))
+        $(P In this section $(I T) refers to any type. When $(I T) is a
+        class type, $(I U) refers to the base class of $(I T) or any interface
+        that $(I T) implements. These implicit conversions are in addition to
+        any other conversions specified in the language reference.
         )
 
+        $(P A pointer $(D $(I T)*) can be implicitly converted to $(D void*).
+        )
+
+$(V1
         $(P A static array $(D $(I T)[$(I dim)]) can be implicitly
-        converted to
-        one of the following:
-        )
-
-        $(UL
-        $(LI $(D $(I T)[]))
-        $(LI $(D $(I U)[]))
-        $(LI $(D void[]))
+        converted to $(D void[]) and $(D $(I T)[]).
         )
 
         $(P A dynamic array $(D $(I T)[]) can be implicitly converted to
-        one of the following:
+        $(D void[]).
+        )
+)
+$(V2
+        $(P A static array $(D $(I T)[$(I dim)]) can be implicitly
+        converted to $(D void[]), $(D $(I T)[]), $(D const($(I T))[]), and
+        $(D const($(I U))[]).
         )
 
-        $(UL
-        $(LI $(D $(I U)[]))
-        $(LI $(D void[]))
+        $(P A dynamic array $(D $(I T)[]) can be implicitly converted to
+        $(D void[]) and $(D const($(I U))[]).
         )
+)
 
-        $(P Where $(I U) is a base class of $(I T).)
 
 <hr>
 <h1>$(LNAME2 associative, Associative Arrays)</h1>


### PR DESCRIPTION
This is to reflect recent changes to DMD for 2.057. In particular, T[] is no longer convertible to U[] when T is a subtype of U. Some const-related conversions are allowed however.
