### PR TITLE
Documenting that pragma(msg, ...) goes to stderr.

### DIFF
--- a/pragma.dd
+++ b/pragma.dd
@@ -60,8 +60,8 @@ pragma(ident) { // influence block of statements
     $(DL
 
     $(DT $(B msg))
-    $(DD Prints a message while compiling, the $(ASSIGNEXPRESSION)s must
-        be string literals:
+    $(DD Prints a message to the standard error stream while compiling, the
+        $(ASSIGNEXPRESSION)s must be string literals:
 -----------------
 pragma(msg, "compiling...");
 -----------------


### PR DESCRIPTION
Was confirmed by Walter. Now it is documented.

See: http://d.puremagic.com/issues/show_bug.cgi?id=5031
