### PR TITLE
Interfacing to C incorrect.

### DIFF
--- a/interfaceToC.dd
+++ b/interfaceToC.dd
@@ -59,8 +59,7 @@ int myDfunction(char[] s) {
 	keywords from the declaration.)
 
 	$(LI Strings are not 0 terminated in D. See "Data Type Compatibility"
-	for more information about this. However, string literals in D are
-	0 terminated.)
+	for more information about this.)
 
 	)
 


### PR DESCRIPTION
I might be mistaken, but I don't think string literals are null-terminated, but the interfacing-to-C guide says so.
