### PR TITLE
Bug  7370 : FAQ errors about purity, implementation ease, and open source

### DIFF
--- a/faq.dd
+++ b/faq.dd
@@ -65,6 +65,7 @@ $(D_S $(TITLE),
 	$(ITEMR ide, Where can I get an IDE for D?)
 	$(ITEMR q4, Why is [expletive deleted] printf left in?)
 	$(ITEMR q5, Is D open source?)
+	$(ITEMR q5_2, Why does the standard library use the boost license? Why not public domain?)
 	$(ITEMR q6, Why $(I no) fall through on switch statements?)
 	$(ITEMR q7, Why should I use D instead of Java?)
 	$(ITEMR q7_2, Doesn't C++ support strings, etc. with STL?)
@@ -236,6 +237,16 @@ $(ITEM q5, Is D open source?)
 	$(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
 	The $(B gdc) and $(B ldc) D compilers are completely open sourced.
 	)
+
+$(ITEM q5_2, Why does the standard library use the boost license? Why not public domain?)
+
+    $(P Although most jurisdictions use the concept of Public Domain, some
+    (eg, Japan) do not.
+    The $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License)
+    avoids this problem. It was chosen because, unlike almost all other open
+    source licenses, it does not demand that the license text be included on
+    distributions in binary form.
+    )
 
 $(ITEM q6, Why $(I no) fall through on switch statements?)
 


### PR DESCRIPTION
Fix the most glaringly out-of-date stuff on that page. I've also added something about the boost licence, since it is a question that comes up frequently.
