### PR TITLE
Add predefined version for Android

### DIFF
--- a/version.dd
+++ b/version.dd
@@ -248,6 +248,7 @@ version($(I identifier)) // add in version code if version
 	$(TR $(TD $(B SysV3)) $(TD System V Release 3))
 	$(TR $(TD $(B SysV4)) $(TD System V Release 4))
 	$(TR $(TD $(B Hurd)) $(TD GNU Hurd))
+	$(TR $(TD $(B Android)) $(Android))
 	$(TR $(TD $(B Cygwin)) $(TD The Cygwin environment))
 	$(TR $(TD $(B MinGW)) $(TD The MinGW environment))
 	$(TR $(TD $(B X86)) $(TD Intel and AMD 32-bit processors))


### PR DESCRIPTION
As gdc can now build basic D programs for Android, a new version identifier is needed.
