### PR TITLE
Add getting rid of Win9x support to deprecate.dd

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -31,6 +31,7 @@ $(SPEC_S Deprecated Features,
 	$(TROW $(DEPLINK volatile),                                               2.013, N/A,    2.013,  &nbsp;, &nbsp;)
 	$(TROW $(DEPLINK Non-final switch statements without a default case),     2.054, N/A,    2.054,  &nbsp;, &nbsp;)
 	$(TROW $(DEPLINK Hiding base class functions),                            2.054, N/A,    2.054,  &nbsp;, &nbsp;)
+	$(TROW $(DEPLINK Windows 3.x and Windows 9x support),                     2.058, N/A,    N/A,    N/A,    2.058 )
 
     $(TROW $(DEPLINK .min property for floating point types),                 future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
     $(TROW $(DEPLINK imaginary and complex types),                            future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
@@ -497,6 +498,17 @@ class B : A
 <h4>Rationale</h4>
 	$(P This is an error that is already detected at runtime, and is being extended to compile time.
     )
+
+
+
+<h3>$(DEPNAME Windows 3.x and Windows 9x support)</h3>
+	There is some code in Phobos for Windows 3.x/9x support.
+<h4>Corrective Action</h4>
+	$(P Upgrade Windows or switch to another supported OS.
+	)
+<h4>Rationale</h4>
+	$(P Supporting such outdated and rarely used OS-es isn't worth the trouble.
+	)
 
 
 


### PR DESCRIPTION
A try to change deprecate.dd according to D-Programming-Language/phobos#406 in spite of my poor English.
