### PR TITLE
Add Android as a standard version identifier.

### DIFF
--- a/version.dd
+++ b/version.dd
@@ -248,6 +248,7 @@ version($(I identifier)) // add in version code if version
 	$(TR $(TD $(B SysV3)) $(TD System V Release 3))
 	$(TR $(TD $(B SysV4)) $(TD System V Release 4))
 	$(TR $(TD $(B Hurd)) $(TD GNU Hurd))
+	$(TR $(TD $(B Android)) $(TD The Android platform))
 	$(TR $(TD $(B Cygwin)) $(TD The Cygwin environment))
 	$(TR $(TD $(B MinGW)) $(TD The MinGW environment))
 	$(TR $(TD $(B X86)) $(TD Intel and AMD 32-bit processors))


### PR DESCRIPTION
Johannes Pfau recently submitted a bunch of Android fixes to GDC*, so I feel we need to standardize this version identifier ASAP.
- https://bitbucket.org/goshawk/gdc/changeset/24e84023cfe6
