### PR TITLE
Fix the vertical alignment of the "D Programming Language" header in Opera

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -235,7 +235,7 @@ div#header
 
 img#logo
 {
-	vertical-align: bottom;
+	vertical-align: text-bottom;
 }
 
 /*div#d-language a*/

--- a/doc.ddoc
+++ b/doc.ddoc
@@ -86,8 +86,9 @@ function showHideAnswer(zis)
 		</form>
 	</div>
 	<div id="header">
-		<a href="/"><img id="logo" width="125" height="95" border="0" alt="D Logo" src="/images/dlogo.png"></a>
-		<a id="d-language" href="/">D Programming Language</a>
+		<a id="d-language" href="/">
+		<img id="logo" width="125" height="95" border="0" alt="D Logo" src="images/dlogo.png">
+		D Programming Language</a>
 	</div>
 </div>
 


### PR DESCRIPTION
The text was glued to the top of the page in Opera. Almost no visual change in other major modern browsers.
