### PR TITLE
Revert "Add canonical link for main site"

### DIFF
--- a/doc.ddoc
+++ b/doc.ddoc
@@ -16,7 +16,6 @@ DDOC=
 <link rel="stylesheet" type="text/css" href="css/style.css" />
 <link rel="stylesheet" type="text/css" href="css/print.css" media="print" />
 <link rel="shortcut icon" href="favicon.ico" />
-<link rel="canonical" href="http://dlang.org/$(DOCFILENAME)" />
 
 <script src="/js/hyphenate_selectively.js" type="text/javascript"></script>
 


### PR DESCRIPTION
This reverts commit 17612cc3585f43993c12e52621142c90f657e6e4.

Reason: Doesn't work with the release process used to update the actual site.
