### PR TITLE
A couple of z-order fixes for Github ribbon

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -334,6 +334,13 @@ body.chm div#tools
 	margin-right: 0;
 }
 
+span#wiki
+{
+	position: relative;
+	right: 0;
+	z-index: 2;
+}
+
 div#twitter
 {
 	color: white;


### PR DESCRIPTION
The search submit button and the "comment on this page" wiki link were both below the ribbon's z index.  This places them above so you can actually click them.
