### PR TITLE
Win32 curl download link

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -284,7 +284,7 @@ $(SECTION2 Other Downloads,
 	)
 
 	$(LI
-	 <a href="$(DLMARS curl-$(CURLV)-dmd-win32.zip)" title="Download DMD2 compatible cURL">
+	 <a href="$(DLGITHUB curl-$(CURLV)-dmd-win32.zip)" title="Download DMD2 compatible cURL">
 	 $(DOWNLOADIMG) DMD2 compatible cURL $(CURLV)</a>
 	)
     )


### PR DESCRIPTION
@WalterBright This pull request relies on [curl-7.24.0-dmd-win32.zip](http://gnuk.net/d/curl-7.24.0-dmd-win32.zip) being uploaded to `ftp://ftp.digitalmars.com/` before it should be merged.
