### PR TITLE
Change link in "your code here" box to use the new web interface

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -37,7 +37,7 @@ void main() {
 
 $(TAG2 div, id="your-code-info" style="display:block; position:relative; width: 50%; margin-left:auto; top:-2.5em; bottom:0em; background:white; border:1px solid #ccc; font-size:80%; padding:0px 5px 0px 5px; line-height:1.4em;",
 Got a brief example illustrating D? Submit your code to the
-$(LINK2 http://digitalmars.com/NewsGroup.html, digitalmars.D forum)$(COMMA)
+$(LINK2 http://forum.dlang.org/group/digitalmars.D, digitalmars.D forum)$(COMMA)
 specifying <span class="nobr">"[your code here]"</span> in the title. Upon approval$(COMMA) it will be showcased
 on a random schedule on D&#145;s homepage.
 )


### PR DESCRIPTION
Just some effort in pushing migration towards the new web interface. The old link sent you to a page which is more convenient for users of conventional NG readers  though - but I'm not sure if the new interface has such a page.

Maybe the [forum front page](http://forum.dlang.org/) should be revamped a little, currently it has problems such as including the DigitalMars C++ forums and the order in which the forums are listed.

(ping @CyberShadow)
