### PR TITLE
Move a link to "Modern COM Programming in D" to a COM section

### DIFF
--- a/interface.dd
+++ b/interface.dd
@@ -251,6 +251,12 @@ $(SECTION2 $(LNAME2 COM-Interfaces, COM Interfaces),
 	$(LI The first member of the $(D vtbl[]) is not the pointer
 	to the InterfaceInfo, but the first virtual function pointer.)
 	)
+
+$(V2
+	$(P For more information, see
+	$(LINK2 http://lunesu.com/uploads/ModernCOMProgramminginD.pdf, Modern COM Programming in D)
+	)
+)
 )
 
 $(V2
@@ -290,10 +296,6 @@ class Ifoo
 	for its member functions, rather than the D calling convention.)
 	$(LI The first member of the $(D vtbl[]) is not the pointer
 	to the $(D Interface), but the first virtual function pointer.)
-	)
-
-	$(P For more information, see
-	$(LINK2 http://lunesu.com/uploads/ModernCOMProgramminginD.pdf, Modern COM Programming in D)
 	)
 )
 )


### PR DESCRIPTION
Have no idea why it was in C++ section.
