### PR TITLE
Remove prehistoric AA abi

### DIFF
--- a/abi.dd
+++ b/abi.dd
@@ -662,10 +662,7 @@ $(SECTION4 Return Value,
 	$(LI Dynamic arrays are returned with the pointer in EDX
 	and the length in EAX.)
 
-	$(LI Associative arrays are returned in EAX with garbage
-	returned in EDX. The EDX value will probably be removed in
-	the future; it's there for backwards compatibility with
-	an earlier implementation of AA's.)
+	$(LI Associative arrays are returned in EAX.)
 
 	$(V2 $(LI References are returned as pointers in EAX.))
 


### PR DESCRIPTION
The ABI referred to seems to have been removed just over ten years ago, in DMD 0.023!
Compilers from that era no longer even exist. The fact that EDX contains garbage is
irrelevant, it's a scratch register anyway.
