### PR TITLE
Fix "Page wiki" button to have a proper tooltip.

### DIFF
--- a/std.ddoc
+++ b/std.ddoc
@@ -128,7 +128,7 @@ PAGE_TOOLS=
 			local clone.
 		</span>
 	</a>
-	<a href="http://www.prowiki.org/wiki4d/wiki.cgi?DocComments/$(WIKI)" class="button">
+	<a href="http://www.prowiki.org/wiki4d/wiki.cgi?DocComments/$(WIKI)" class="tip button">
 		Page wiki
 		<span>
 	        View or edit the community-maintained wiki page associated with this page.


### PR DESCRIPTION
The tip CSS class got left off so the tooltip <span> is just used like any other span making the button huge.
