### PR TITLE
Added a paragraph about octal integers in D2.

### DIFF
--- a/lex.dd
+++ b/lex.dd
@@ -755,6 +755,11 @@ $(GNAME HexLetter):
 
 	$(V1 $(P Octal integers are a sequence of octal digits preceded by a $(SINGLEQUOTE 0).))
 
+	$(V2 $(P C-style octal integer notation was deemed too easy to mix up with decimal notation.
+	The above is only fully supported in string literals.
+	D still supports octal integer literals interpreted at compile time through the $(FULL_XREF conv, octal)
+	template, as in $(D octal!167).))
+
 	$(P Hexadecimal integers are a sequence of hexadecimal digits preceded
 	by a $(SINGLEQUOTE 0x).
 	)
@@ -1148,4 +1153,6 @@ Macros:
 	TITLE=Lexical
 	WIKI=Lex
         CATEGORY_SPEC=$0
+
+	FULL_XREF = <a href="phobos/std_$1.html#$2">$(D std.$1.$2)</a>
 


### PR DESCRIPTION
There only existed a paragraph about octals in the D1 version, so I added some info about how it works in the D2 version.
