### PR TITLE
Fix template-mixin virtual function example, needs 'override'

### DIFF
--- a/template-mixin.dd
+++ b/template-mixin.dd
@@ -91,7 +91,7 @@ class Bar {
 }
 
 class Code : Bar {
-  override void func() { writefln("Code.func()"); }
+  $(V2 override) void func() { writefln("Code.func()"); }
 }
 
 void test() {


### PR DESCRIPTION
Derived class definition of func() needs 'override'
