### PR TITLE
Provide default statement in duffs_device switch

### DIFF
--- a/template-mixin.dd
+++ b/template-mixin.dd
@@ -157,7 +157,7 @@ $(V2 mixin) template duffs_device(alias id1, alias id2, alias s)
         case 3:      s(); $(V2 goto case;)
         case 2:      s(); $(V2 goto case;)
         case 1:      s(); continue;
-        default:     assert("Impossible");
+        default:     assert(0, "Impossible");
                 } while (--n > 0);
       }
     }


### PR DESCRIPTION
Without the default statement, compiler errors out with: Error: non-final switch statement without a default is deprecated
