### PR TITLE
Fix for issue# 8185.

### DIFF
--- a/function.dd
+++ b/function.dd
@@ -46,13 +46,17 @@ int foo();
 $(V2
 <h3>$(LNAME2 pure-functions, Pure Functions)</h3>
 
-        $(P Pure functions are functions that produce the same
-        result for the same arguments.
+        $(P Pure functions are functions which cannot access global or static, mutable
+        state save through their arguments. This can enable optimizations based on the fact
+        that a pure function is guaranteed to mutate nothing which isn't passed to it,
+        and in cases where the compiler can guarantee that a pure function cannot
+        alter its arguments, it can enable full, functional purity (i.e. the guarantee
+        that the function will always return the same result for the same arguments).
         To that end, a pure function:
         )
 
         $(UL
-        $(LI does not read or write any global mutable state)
+        $(LI does not read or write any global or static mutable state)
         $(LI cannot call functions that are not pure)
         $(LI can override an impure function, but an impure function
         cannot override a pure one)


### PR DESCRIPTION
This clarifies the definition of pure, since so many people seem to have
a hard time understanding that _all_ that pure means is that the
function cannot access global or static, mutable state or call impure
functions. Everything else with regards to pure is a matter of
implementation-specific optimizations - which does in some cases relate
to full, functional purity, but pure itself does not indicate anything
of the sort.
