### PR TITLE
Add std.uuid module

### DIFF
--- a/std.ddoc
+++ b/std.ddoc
@@ -235,6 +235,7 @@ NAVIGATION_PHOBOS=
 	$(LI <a href="std_uni.html" title="Unicode classification">std.uni</a>)
 	$(LI <a href="std_uri.html" title="Encode and decode Uniform Resource Identifiers (URIs)">std.uri</a>)
 	$(LI <a href="std_utf.html" title="Encode and decode utf character encodings">std.utf</a>)
+	$(LI <a href="std_uuid.html" title="Generate and use UUIDs">std.uuid</a>)
 	$(LI <a href="std_variant.html" title="Stores all types in a uniform, dynamically-checked representation">std.variant</a>)
 	$(LI <a href="std_xml.html" title="XML file processing">std.xml</a>)
 	$(LI <a href="std_zip.html" title="Read/write zip archives">std.zip</a>)


### PR DESCRIPTION
Add links for the std.uuid module to the side bar. The phobos pull request for std.uuid is here:
https://github.com/D-Programming-Language/phobos/pull/651
This should be merged after the phobos pull request has been merged.
