### PR TITLE
Couple improvments to runnable examples

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -718,32 +718,33 @@ div.runCode {
 	margin: 1em 0 1em 3em;
 }
 
-div.d_code_output, textarea.d_code_stdin, textarea.d_code_args
+textarea.d_code_output, textarea.d_code_stdin, textarea.d_code_args
 {
 	text-align: left;
 	border: none;
 	width: 98%;
-	font-size: 12px;
+	font-size: 1.09em;
 	font-family: monospace;
 	padding: 5px;
 	margin: 1px;
-	max-height: 150px;
-	overflow: auto;
 	word-wrap: break-word;	
-	height: 150px;
+	height: auto;
 	background: white;
+	margin-left: 2px;
+	outline: none;
 }
 
-div.d_code_output_div, div.d_code_stdin, div.d_code_args
+div.d_code_output, div.d_code_stdin, div.d_code_args
 {
 	border: 1px solid #CCC;
 	background: white;
 	display: none;
+	height: auto;
+	width: 100%;
 }
 
 .CodeMirror-lines {background: white;}
-.CodeMirror {line-height: 1.2em; font-size: 1.2em;
-	border: 1px solid #CCC;}
+.CodeMirror {line-height: 1.2em; font-size: 1.2em;border: 1px solid #CCC;}
 .cm-s-eclipse span.cm-word {color: #006;}
 .cm-s-eclipse span.cm-meta {color: #FF1717;}
 .cm-s-eclipse span.cm-keyword { color: blue; }

--- a/doc.ddoc
+++ b/doc.ddoc
@@ -15,7 +15,7 @@ DDOC=
 <title>$(TITLE) - D Programming Language</title>
 <link rel="stylesheet" type="text/css" href="css/style.css" />
 <link rel="stylesheet" type="text/css" href="css/print.css" media="print" />
-<script src="http://code.jquery.com/jquery.min.js" type="text/javascript"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
 <script src="/js/codemirror.js"></script>
 <script src="/js/d.js"></script>
 <script src="/js/run.js" type="text/javascript"></script>
@@ -386,10 +386,11 @@ D_PSYMBOL = <span class="d_psymbol">$0</span>
 D_PARAM   = <span class="d_param">$0</span>
 D_RUN_CODE = <noscript>$1</noscript>
 <div class="runCode">
+<div style="display: none;" class="d_code_src">$2</div>
 <textarea class="d_code">$2</textarea>
 <div class="d_code_stdin"><span class="d_code_title">Standard input</span><br /><textarea class="d_code_stdin">$3</textarea></div>
 <div class="d_code_args"><span class="d_code_title">Command line arguments</span><br /><textarea class="d_code_args">$4</textarea></div>
-<div class="d_code_output_div"><span class="d_code_title">Application output</span><div class="d_code_output">Running...</div></div>
+<div class="d_code_output"><span class="d_code_title">Application output</span><br /><textarea class="d_code_output" readonly>Running...</textarea></div>
 <input type="button" class="editButton" value="Edit">
 <input type="button" class="argsButton" value="Args">
 <input type="button" class="inputButton" value="Input">

--- a/index.dd
+++ b/index.dd
@@ -5,23 +5,11 @@ $(D_S D Programming Language,
 $(SECTION3 The D programming language. Modern
 convenience. Modeling power. Native efficiency.,
 
-<script>
-function showHideYourCodeHere()
-{
-    var obj = document.getElementById('your-code-info');
-    if(obj.style.display=='block'){
-        obj.style.display='none';
-    }else{
-      obj.style.display = 'block';
-  }
-}
-</script>
-
 <div style="text-align: right; font-size: 11px; margin-bottom: -35px; margin-right: 5px; position: relative; z-index: 10000">
 <a href="http://forum.dlang.org/group/digitalmars.D" target="_blank" class="tip button">
     [your code here]
     <span>
-        Got a brief example illustrating D? Submit your code to the digitalmars.D forum specifying "[your code here]" in the title. Upon approval it will be showcased on a random schedule on D&#145;s homepage.
+        Got a brief example illustrating D? Submit your code to the digitalmars.D forum specifying "[your code here]" in the title. Upon approval it will be showcased on a random schedule on D's homepage.
     </span>
 </a>
 </div>
@@ -61,11 +49,6 @@ void main() {
 }),
 $(ARGS Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tristique rutrum sem, nec convallis enim bibendum ut. Donec ac dolor tortor, sit amet consequat turpis. In hac habitasse platea dictumst. Fusce lacus dolor, sodales ac consequat eu, ultricies et leo. In commodo scelerisque urna non posuere. Sed justo ipsum, consectetur nec sodales in, faucibus ut nunc. Phasellus nunc metus, mollis eu malesuada at, scelerisque eget nulla. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus ac velit vel massa faucibus sagittis ut quis lectus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam convallis dolor quis nunc viverra suscipit. Nam egestas pretium enim, sit amet tincidunt orci condimentum sit amet. Duis accumsan elit vehicula nisl tincidunt hendrerit. Nunc nec augue velit, ac lacinia nunc.),
 $(ARGS))
-
-$(TAG2 div, id="your-code-info" style="display:block; position:relative; width: 50%; margin-left:auto; top:-2.5em; bottom:0em; background:white; border:1px solid #ccc; font-size:80%; padding:0px 5px 0px 5px; line-height:1.4em;",
-
-)
-<script>showHideYourCodeHere();</script>
 
 D is a language with C-like syntax and static typing. It pragmatically combines
 efficiency, control, and modeling power, with safety and programmer productivity.

--- a/js/d.js
+++ b/js/d.js
@@ -154,62 +154,8 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     for (var i = 0; i < words.length; ++i) obj[words[i]] = true;
     return obj;
   }
-  var cKeywords = "auto if break int case long char register continue return default short do sizeof " +
-    "double static else struct entry switch extern typedef float union for unsigned " +
-    "goto while enum void const signed volatile";
 
-  function cppHook(stream, state) {
-    if (!state.startOfLine) return false;
-    stream.skipToEnd();
-    return "meta";
-  }
-
-  // C#-style strings where "" escapes a quote.
-  function tokenAtString(stream, state) {
-    var next;
-    while ((next = stream.next()) != null) {
-      if (next == '"' && !stream.eat('"')) {
-        state.tokenize = null;
-        break;
-      }
-    }
-    return "string";
-  }
-
-  CodeMirror.defineMIME("text/x-csrc", {
-    name: "clike",
-    keywords: words(cKeywords),
-    blockKeywords: words("case do else for if switch while struct"),
-    atoms: words("null"),
-    hooks: {"#": cppHook}
-  });
-  CodeMirror.defineMIME("text/x-c++src", {
-    name: "clike",
-    keywords: words(cKeywords + " asm dynamic_cast namespace reinterpret_cast try bool explicit new " +
-                    "static_cast typeid catch operator template typename class friend private " +
-                    "this using const_cast inline public throw virtual delete mutable protected " +
-                    "wchar_t"),
-    blockKeywords: words("catch class do else finally for if struct switch try while"),
-    atoms: words("true false null"),
-    hooks: {"#": cppHook}
-  });
-  CodeMirror.defineMIME("text/x-java", {
-    name: "clike",
-    keywords: words("abstract assert boolean break byte case catch char class const continue default " + 
-                    "do double else enum extends final finally float for goto if implements import " +
-                    "instanceof int interface long native new package private protected public " +
-                    "return short static strictfp super switch synchronized this throw throws transient " +
-                    "try void volatile while"),
-    blockKeywords: words("catch class do else finally for if switch try while"),
-    atoms: words("true false null"),
-    hooks: {
-      "@": function(stream, state) {
-        stream.eatWhile(/[\w\$_]/);
-        return "meta";
-      }
-    }
-  });
-  CodeMirror.defineMIME("text/x-csharp", {
+  CodeMirror.defineMIME("text/x-d", {
     name: "clike",
     keywords: words("abstract alias align assert auto body bool break byte case cast catch cdouble cent cfloat" +
                     " char class const continue creal dchar debug default delegate delete deprecated double dstring" +
@@ -222,14 +168,6 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
     atoms: words("asm catch class debug do else exit failure finally for foreach foreach_reverse if struct switch synchronized unittest version try while with "),
 
     hooks: {
-      "@": function(stream, state) {
-        if (stream.eat('"')) {
-          state.tokenize = tokenAtString;
-          return tokenAtString(stream, state);
-        }
-        stream.eatWhile(/[\w\$_]/);
-        return "meta";
-      }
     }
   });
 }());

--- a/js/run.js
+++ b/js/run.js
@@ -1,6 +1,15 @@
+/**
+Runnable examples functionality
+
+Copyright: Damian Ziemba 2012
+
+License:   http://boost.org/LICENSE_1_0.txt, Boost License 1.0
+
+Authors:   Andrei Alexandrescu, Damian Ziemba
+*/
 String.prototype.nl2br = function()
-{
-    return this.replace(/\n/g, "<br />");
+{      
+    return this.replace(/\n/g, "<br />");     
 }
 
 function showHideAnswer(zis)
@@ -20,46 +29,55 @@ function showHideAnswer(zis)
     }
 }
 
-function parseOutput(data)
+function parseOutput(data, o, oTitle)
 {
-    output = "";
-    var json = jQuery.parseJSON(data);
-    if (json == null)
+    var xml = $(data);
+    if (xml == null || xml.find("response") == null)
     {
-        output = "<h5>Temporarily unavaible</h5>";
-        return output;
+        o.text("Temporarily unavaible");
+        return;
     }
 
-    /* 
-    * Escape html/script/etc
-    */
-    var cout = $('<div/>').text(json["compilation"]["stdout"]).html();
-    var stdout = $('<div/>').text(json["runtime"]["stdout"]).html();
-    var stderr = $('<div/>').text(json["runtime"]["stderr"]).html();
+    var output = "";
+    var cout = xml.find("response").find("compilation").find("stdout").text();
+    var stdout = xml.find("response").find("runtime").find("stdout").text();
+    var stderr = xml.find("response").find("runtime").find("stderr").text();
+    var ctime = parseInt(xml.find("response").find("compilation").find("time").text());
+    var rtime = parseInt(xml.find("response").find("runtime").find("time").text());
+    var cstatus = parseInt(xml.find("response").find("compilation").find("status").text());
+    var rstatus = parseInt(xml.find("response").find("runtime").find("status").text());
+    var cerr = xml.find("response").find("compilation").find("err").text();
+    var rerr = xml.find("response").find("runtime").find("err").text();
 
-    if (json["compilation"]["status"] != 0)
+    if (cstatus != 0)
     {
-        output = '<b>Compilation failure: </b><br /><div class="outputWindow">'+ cout + "</div>";
+        oTitle.text("Compilation output ("+cstatus+": "+cerr+")");
+        if ($.browser.msie)
+            o.html(cout.nl2br());
+        else
+            o.text(cout);
+        
+        return;
     }
     else
     {
+        oTitle.text("Application output");// (compile "+ctime+"ms, run "+rtime+"ms)");
         if ( cout != "")
-        {
-            output = '<b>Compilation output: </b><br />'
-                + '<div class="outputWindow">' + cout + "</div><br />";
-        }
-        output += (stdout == "" && stderr == "" ? 
-            '<div class="outputWindow">-- No output --</div>' : '<div class="outputWindow">'+stdout);
+            output = 'Compilation output: \n' + cout + "\n";
+        
+        output += (stdout == "" && stderr == "" ? '-- No output --' : stdout);
 
         if (stderr != "") 
-        {
             output += stderr;
-        }
 
-        output += "</div>";
+        if (rstatus != 0)
+            oTitle.text("Application output ("+rstatus+": "+rerr+")");
     }
 
-    return output.nl2br();
+    if ($.browser.msie)
+        o.html(output.nl2br());
+    else
+        o.text(output);
 }
 
 $(document).ready(function() 
@@ -67,37 +85,38 @@ $(document).ready(function()
     $('textarea[class=d_code]').each(function(index) {
         var thisObj = $(this);
 
-        var p = thisObj.parent();
-        var codeStr = thisObj.val();
-        p.css("display", "block");
-        var originalSource = thisObj.val();
+        var parent = thisObj.parent();
+        parent.css("display", "block");
         
-
         var editor = CodeMirror.fromTextArea(thisObj[0], {
-                lineNumbers: false,
-                tabSize: 4,
-                indentUnit: 4,
-                indentWithTabs: true,
-                mode: "text/x-csharp",
-                lineWrapping: true,
-                theme: "eclipse",
-                readOnly: false,
-                onChange: function (editor, event) {
-                   codeStr = editor.getValue();
-                },
+            lineNumbers: false,
+            tabSize: 4,
+            indentUnit: 4,
+            indentWithTabs: true,
+            mode: "text/x-d",
+            lineWrapping: true,
+            theme: "eclipse",
+            readOnly: false,
+            matchBrackets: true
         });
+        var height = function(diff) {
+            return (parseInt(code.css('height')) - diff) + 'px';
+        };
+        if ($.browser.webkit)
+            editor.setValue(parent.children("div.d_code_src").text());
 
-        var runBtn = p.children("input.runButton");
-        var editBtn = p.children("input.editButton");
-        var inputBtn = p.children("input.inputButton");
-        var resetBtn = p.children("input.resetButton");
-        var argsBtn = p.children("input.argsButton");
-        var stdinDiv = p.children("div.d_code_stdin");
-        var argsDiv = p.children("div.d_code_args");
-        var outputDiv = p.children("div.d_code_output_div");
+        var runBtn = parent.children("input.runButton");
+        var editBtn = parent.children("input.editButton");
+        var inputBtn = parent.children("input.inputButton");
+        var resetBtn = parent.children("input.resetButton");
+        var argsBtn = parent.children("input.argsButton");
+        var stdinDiv = parent.children("div.d_code_stdin");
+        var argsDiv = parent.children("div.d_code_args");
+        var outputDiv = parent.children("div.d_code_output");
 
         var code = $(editor.getWrapperElement());
-        var output = outputDiv.children("div.d_code_output");
+        var output = outputDiv.children("textarea.d_code_output");
+        var outputTitle = outputDiv.children("span.d_code_title");
         var stdin = stdinDiv.children("textarea.d_code_stdin");
         var args = argsDiv.children("textarea.d_code_args");
 
@@ -107,42 +126,40 @@ $(document).ready(function()
             argsDiv.css('display', 'none');
             outputDiv.css('display', 'none');
             code.css('display', 'none');
-
-            inputBtn.removeClass('test');
-            argsBtn.removeClass('test');
-            runBtn.removeClass('test');
-            editBtn.removeClass('test');
         };
 
-        var originalStdin = stdin.val();
-        var originalArgs = args.val();
-
         argsBtn.click(function(){
+            args.css('height', height(37));
             hideAllWindows();
             argsDiv.css('display', 'block');
-            $(this).addClass('test');
+            args.focus();
         });
 
         inputBtn.click(function(){
+            stdin.css('height', height(37));
             hideAllWindows();
             stdinDiv.css('display', 'block');
-            $(this).addClass('test');
+            stdin.focus();
         });
         editBtn.click(function(){
             hideAllWindows();
             code.css('display', 'block');
-            $(this).addClass('test');
+            editor.focus();
         });
 
         runBtn.click(function(){
             $(this).attr("disabled", true);
             hideAllWindows();
+            output.css('height', height(37));
             outputDiv.css('display', 'block');
+            outputTitle.text("Application output");
             output.html("Running...");
-
+            output.focus();
+            
             $.ajax({
                 type: 'POST',
                 url: "/process.php",
+                dataType: "xml",
                 data: 
                 {
                     'code' : encodeURIComponent(editor.getValue()), 
@@ -151,12 +168,12 @@ $(document).ready(function()
                 },
                 success: function(data) 
                 {
-                    output.html(parseOutput(data));
+                    parseOutput(data, output, outputTitle);
                     runBtn.attr("disabled", false);
                 },
                 error: function() 
                 {
-                    output.html("<h5>Temporarily unavaible</h5>");
+                    output.html("Temporarily unavaible");
                     runBtn.attr("disabled", false);
                 }
             });

--- a/process.php
+++ b/process.php
@@ -1,4 +1,13 @@
 <?php
+/**
+Runnable examples functionality
+
+Copyright: Damian Ziemba 2012
+
+License:   http://boost.org/LICENSE_1_0.txt, Boost License 1.0
+
+Authors:   Andrei Alexandrescu, Damian Ziemba
+*/
 
 if (!isset($_POST))
     $_POST = $HTTP_POST_VARS;
@@ -6,12 +15,32 @@ if (!isset($_POST))
 if (!isset($_POST["code"]))
     return;
 
-$url = 'http://dpaste.dzfl.pl/request/';
-
 $code = $_POST['code'];
 $stdin = $_POST['stdin'];
 $args = $_POST['args'];
 
-echo file_get_contents($url ."?compiler=dmd&ptr=64&code={$code}&stdin=$stdin&args=$args");
+$str = "compiler=dmd2&code=$code&stdin=$stdin&args=$args";
 
+$result = "";
+$fp = fsockopen("dpaste.dzfl.pl", 80, $errno,$errstr, 15); 
+if ($fp)
+{ 
+    fputs($fp, "POST /request/?xml HTTP/1.1\r\n"); 
+    fputs($fp, "Host: dpaste.dzfl.pl\r\n"); 
+    fputs($fp, "Content-type: application/x-www-form-urlencoded\r\n"); 
+    fputs($fp, "Content-length: ".strlen($str)."\r\n"); 
+    fputs($fp, "Connection: close\r\n\r\n"); 
+    fputs($fp, $str."\r\n\r\n"); 
+    while(!feof($fp)) 
+        $result .= fgets($fp,4096); 
+    fclose($fp); 
+}
+$pos = strpos($result, '<?xml ');
+
+if ($pos !== false) {
+    header("Content-Type: application/xml");
+    echo substr($result, $pos, -5);
+}
+else
+    echo $result;
 ?>


### PR DESCRIPTION
- workaround for bug in Webkit-based browsers reported by David (klickverbot)
- switch to xml from json (long response strings)
- focus frames
- return status
- license
- other goodies

Demo: http://dlang.dzfl.pl
