### PR TITLE
Update links for gdc download/sources.

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -238,11 +238,15 @@ $(BR)
 	$(TH Product)
 	)
 
+	$(TR
+	 $(TD $(LINK2 https://github.com/D-Programming-GDC/GDC, GDC))
+	 $(TD all)
+	 $(TD GDC)
+	)
 
 	$(TR
-	 $(TDXX $(LINK2 http://sourceforge.net/project/showfiles.php?group_id=154306, GDC))
-	 $(TD $(LINK2 http://bitbucket.org/goshawk/gdc/wiki/Home, GDC))
-	 $(TD all)
+	 $(TD $(LINK2 https://bitbucket.org/goshawk/gdc/downloads, GDC))
+	 $(TD $(WIN32))
 	 $(TD GDC)
 	)
 


### PR DESCRIPTION
Updates links to point to the new github repository.  Downloads for MinGW are still on bitbucket for the time being.
