### PR TITLE
Remove MinGW32 and MinGW64.

### DIFF
--- a/version.dd
+++ b/version.dd
@@ -251,8 +251,6 @@ version($(I identifier)) // add in version code if version
 	$(TR $(TD $(B Android)) $(TD The Android platform))
 	$(TR $(TD $(B Cygwin)) $(TD The Cygwin environment))
 	$(TR $(TD $(B MinGW)) $(TD The MinGW environment))
-	$(TR $(TD $(B MinGW32)) $(TD The MinGW environment (32-bit)))
-	$(TR $(TD $(B MinGW64)) $(TD The MinGW environment (64-bit)))
 	$(TR $(TD $(B X86)) $(TD Intel and AMD 32-bit processors))
 	$(TR $(TD $(B X86_64)) $(TD AMD and Intel 64-bit processors))
 	$(TR $(TD $(B ARM)) $(TD The Advanced RISC Machine architecture (32-bit)))


### PR DESCRIPTION
After some discussion over at LDC, it was agreed upon that these two identifiers didn't add significant enough value to be part of the standard version identifier set, as the information they provide is available via `MinGW`, `D_LP64`, `Win32`, `Win64`, etc.
