### PR TITLE
mangled name specification is wrong

### DIFF
--- a/abi.dd
+++ b/abi.dd
@@ -520,19 +520,19 @@ $(I ArgClose)
     $(B Z)     $(GREEN // not variadic)
 
 $(I TypeIdent):
-    $(B I) $(I LName)
+    $(B I) $(I QualifiedName)
 
 $(I TypeClass):
-    $(B C) $(I LName)
+    $(B C) $(I QualifiedName)
 
 $(I TypeStruct):
-    $(B S) $(I LName)
+    $(B S) $(I QualifiedName)
 
 $(I TypeEnum):
-    $(B E) $(I LName)
+    $(B E) $(I QualifiedName)
 
 $(I TypeTypedef):
-    $(B T) $(I LName)
+    $(B T) $(I QualifiedName)
 
 $(I TypeDelegate):
     $(B D) $(I TypeFunction)


### PR DESCRIPTION
TypeIdent:                LName

should be 

TypeIdent:                QualifiedName

as should TypeClass, TypeStruct, TypeEnum, and TypeTypedef.
This corresponds to dmd's behavior as well as core.demangle.
