### PR TITLE
Fix for issue# 8470.

### DIFF
--- a/lex.dd
+++ b/lex.dd
@@ -337,7 +337,7 @@ $(GNAME EscapeSequence):
     $(B \) $(GLINK OctalDigit) $(GLINK OctalDigit) $(GLINK OctalDigit)
     $(B \u) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit)
     $(B \U) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit)
-    $(GLINK2 entity, NamedCharacterEntity)
+    $(B \) $(GLINK2 entity, NamedCharacterEntity)
 
 $(GNAME HexString):
     $(B x") $(GLINK HexStringChars) $(B ") $(GLINK StringPostfix)<sub>opt</sub>


### PR DESCRIPTION
The escape sequence with NamedCharacterEntity in it is missing a \ in lex.html.
