### PR TITLE
Fix for issue# 8479.

### DIFF
--- a/entity.dd
+++ b/entity.dd
@@ -7,7 +7,11 @@ $(GNAME NamedCharacterEntity):
     $(B &amp;) $(GLINK2 lex, Identifier) $(B ;)
 )
 
-	$(P These are the character entity names supported by D.
+	$(P D supports the full list of named character entities from HTML 5. However,
+        dmd does not yet support named entities which contain multiple code points.
+        Below is a $(I partial) list of the named character entities. See the
+        $(LINK2 http://www.w3.org/TR/html5/named-character-references.html, HTML 5 Spec)
+        for the full list.
 	)
 
 	$(P $(B Note:) Not all will display properly in the $(B Symbol)
@@ -271,13 +275,13 @@ $(GNAME NamedCharacterEntity):
    $(TR	$(TD rceil)	$(TD 8969)	$(TD &rceil;))
    $(TR	$(TD lfloor)	$(TD 8970)	$(TD &lfloor;))
    $(TR	$(TD rfloor)	$(TD 8971)	$(TD &rfloor;))
-   $(TR	$(TD lang)	$(TD 9001)	$(TD &lang;))
-   $(TR	$(TD rang)	$(TD 9002)	$(TD &rang;))
    $(TR	$(TD loz)	$(TD 9674)	$(TD &loz;))
    $(TR	$(TD spades)	$(TD 9824)	$(TD &spades;))
    $(TR	$(TD clubs)	$(TD 9827)	$(TD &clubs;))
    $(TR	$(TD hearts)	$(TD 9829)	$(TD &hearts;))
    $(TR	$(TD diams)	$(TD 9830)	$(TD &diams;))
+   $(TR	$(TD lang)	$(TD 10216)	$(TD &lang;))
+   $(TR	$(TD rang)	$(TD 10217)	$(TD &rang;))
 
 	)
 


### PR DESCRIPTION
> dmd and the spec do not match with regards to the list of named character entities that they support

rang and lang changed between HTML 4 and HTML 5. All the rest stayed the
same, hence why those two lines changed. There are plenty of additions
as well, but I left the table as it was (aside from the fix for rang and
lang) and just gave a link to the HTML 5 spec for the full list.
