### PR TITLE
Fixed note about isSafe in changelog for 2.060.

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -24,10 +24,11 @@ $(VERSION 060, Aug 2, 2012, =================================================,
              pass a range by reference.)
         $(LI std.traits: Added KeyType, ValueType, isScalarType, isBasicType, and
              SetFunctionAttributes templates.)
-        $(LI std.traits: isSafe now checks for @safe only rather than @safe and @trusted.
-             Use isSafelyCallable to check for both. Due to bug# 8362, isSafe was badly
-             broken prior to 2.060 anyway, so any code using isSafe should probably be examined.)
         $(LI std.utf: Added overload of codeLength which operates on a string.)
+        $(LI std.traits: areAllSafe has been scheduled for deprecation. Please use
+             allSatisfy(isSafe, ...) instead.)
+        $(LI clear has been renamed to destroy, and clear (as an alias to destroy) has
+             been scheduled for deprpecation.)
         $(LI Capitalized std.traits.pointerTarget to PointerTarget. Old one is
              scheduled for deprecation.)
         $(LI std.algorithm.indexOf - which was scheduled for deprecation - has been deprecated (it was


### PR DESCRIPTION
I also added a note about clear being renamed to destroy, since that
never managed to make it into the changelog.
