### PR TITLE
clear -> destroy

### DIFF
--- a/class.dd
+++ b/class.dd
@@ -813,14 +813,14 @@ new(1,2) Foo(a);        // calls new(Foo.sizeof,1,2)
 
 <h3>$(LNAME2 deallocators, Class Deallocators)</h3>
 $(B Note): Class deallocators and the delete operator are deprecated in D2. 
-Use the $(B clear) function to finalize an object by calling its destructor. 
+Use the $(B destroy) function to finalize an object by calling its destructor. 
 The memory of the object is $(B not) immediately deallocated, instead the GC 
 will collect the memory of the object at an undetermined point after finalization:
     
 ------
 class Foo { int x; this() { x = 1; } }
 Foo foo = new Foo;
-clear(foo);
+destroy(foo);
 assert(foo.x == int.init);  // object is still accessible
 ------
     

--- a/deprecate.dd
+++ b/deprecate.dd
@@ -564,10 +564,10 @@ auto a = new Class();
 delete a;
 ---
 <h4>Corrective Action</h4>
-	$(P Use object.clear() instead.
+	$(P Use $(LINK2 phobos/object.html#destroy, object.destroy()) instead.
 ---
 auto a = new Class();
-clear(a);
+destroy(a);
 ---
 	)
 <h4>Rationale</h4>


### PR DESCRIPTION
Replace uses of deprecated clear() function with destroy().

Also add a link to object.destroy in deprecate.html.
