### PR TITLE
Using the more portable version of the shebang

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -14,7 +14,7 @@ convenience. Modeling power. Native efficiency.,
 </a>
 </div>
 ----
-#!/usr/bin/rdmd
+#!/usr/bin/env rdmd
 // Computes average line length for standard input.
 import std.stdio;
 
@@ -90,7 +90,7 @@ void main() {
 $(LI Built-in linear and associative arrays, slices, and ranges make daily
 programming simple and pleasant for tasks, both small and large. $(EXAMPLE 3,
 ----
-#!/usr/bin/rdmd
+#!/usr/bin/env rdmd
 import std.range, std.stdio;
 
 // Compute average line length for stdin
@@ -125,7 +125,7 @@ interface Printable {
 
 // Interface implementation
 class Widget : Printable {
-   void print(uint level) 
+   void print(uint level)
    in{ }
    body{ }
 }
@@ -414,7 +414,7 @@ $(COMMENT: Japanese by Kazuhiro Inaba, Portugese by Christian Hartung)
 
 $(P This is an example D program illustrating some of the capabilities:)
 ----
-#!/usr/bin/rdmd
+#!/usr/bin/env rdmd
 /* shebang is supported */
 
 /* Hello World in D

--- a/rdmd.dd
+++ b/rdmd.dd
@@ -20,7 +20,7 @@ Hello, world without explicit compilations!
 Inside a D program:
 <pre>
 % cat myprog.d
-#!/usr/bin/rdmd
+#!/usr/bin/env rdmd
 import std.stdio;
 void main()
 {
@@ -32,7 +32,7 @@ Hello, world with automated script running!
 </pre>
 
 (Under Windows replace $(B cat) with $(B type) and $(B
-#!/usr/bin/rdmd) with $(B #!rdmd), the latter assuming that $(B rdmd)
+#!/usr/bin/env rdmd) with $(B #!rdmd), the latter assuming that $(B rdmd)
 can be found in your path.)
 
 <h2>Description</h2>


### PR DESCRIPTION
Using '#!/usr/bin/env rdmd' makes the resulting programs more portable since no
specific location of the rdmd binary is assumed.

For more info, see http://en.wikipedia.org/wiki/Shebang_(Unix)#Portability
