### PR TITLE
Update/consistency-ify download.dd.

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -20,7 +20,7 @@ $(TABLE2 DMD - Digital Mars D Programming Language version 2,
 	$(TR
 	$(TD <a HREF="$(DLGITHUB dmd.$(DMDV2).zip)" title="download D compiler">$(DOWNLOADIMG) dmd.$(DMDV2).zip</a>)
 	$(TD $(DMDV2))
-	$(TD --)
+	$(TD i386, x86_64)
 	$(TDL $(WIN32) $(LINUX) $(OSX) $(FREEBSD))
 	$(TD dmd D 2.0 compiler, all platforms)
 	)
@@ -234,32 +234,26 @@ $(BR)
 	$(TABLE2 GDC - D Programming Language for GCC,
 	$(TR
 	$(TH Download)
-	$(TH Operating System)
+	$(TH Version)
+	$(TH CPU)
+	$(TH Operating System(s))
 	$(TH Product)
 	)
 
 	$(TR
-	 $(TD $(LINK2 https://github.com/D-Programming-GDC/GDC, GDC))
-	 $(TD all)
-	 $(TD GDC)
-	)
-
-	$(TR
 	 $(TD $(LINK2 https://bitbucket.org/goshawk/gdc/downloads, GDC))
+	 $(TD 2.058)
+	 $(TD i386, x86_64)
 	 $(TD $(WIN32))
-	 $(TD GDC)
+	 $(TD GNU D Compiler)
 	)
 
 	$(TR
-	 $(TD $(LINK2 http://sourceforge.net/projects/gdcmac, gdcmac))
-	 $(TD $(OSX))
-	 $(TD GDC)
-	)
-
-	$(TR
-	 $(TD $(D sudo apt-get install gdc))
-	 $(TD $(DEBIAN) $(UBUNTU))
-	 $(TD GDC)
+	 $(TD $(LINK2 https://github.com/D-Programming-GDC/GDC, GDC))
+	 $(TD HEAD)
+	 $(TD i386, x86_64, armel, armhf, mips, mipsel, powerpc, ia64, s390, sparc)
+	 $(TD $(WIN32) $(LINUX) $(DEBIAN) $(UBUNTU) $(GENTOO) $(OPENSUSE) $(FEDORA) $(OSX) $(FREEBSD))
+	 $(TD GNU D Compiler)
 	)
 	)
 
@@ -269,26 +263,34 @@ $(BR)
 	$(TABLE2 LDC - D Programming Language for LLVM,
 	$(TR
 	$(TH Download)
-	$(TH Operating System)
+	$(TH Version)
+	$(TH CPU)
+	$(TH Operating System(s))
 	$(TH Product)
 	)
 
 	$(TR
 	 $(TD $(LINK2 https://github.com/ldc-developers/ldc/wiki/Building-and-hacking-LDC-on-Windows-using-MSVC, LDC))
+	 $(TD HEAD)
+	 $(TD i386, x86_64)
 	 $(TD $(WIN32))
 	 $(TD LDC installation instructions for Windows)
 	)
 
 	$(TR
-	 $(TD $(LINK2 http://www.dsource.org/projects/ldc/wiki/BuildInstructionsFedora, $(D yum install ldc ldc-phobos-devel ldc-druntime-devel)))
+	 $(TD $(LINK2 http://www.dsource.org/projects/ldc/wiki/BuildInstructionsFedora, LDC))
+	 $(TD 2.060)
+	 $(TD i386, x86_64)
 	 $(TD $(FEDORA))
 	 $(TD LDC installation instructions for Fedora)
 	)
 
 	$(TR
 	 $(TD $(LINK2 https://github.com/ldc-developers/ldc/wiki/Installation, LDC))
-	 $(TD $(LINUX) $(UBUNTU) $(GENTOO) $(FREEBSD))
-	 $(TD Installing on various Linuxen)
+	 $(TD HEAD)
+	 $(TD i386, x86_64, armel)
+	 $(TD $(LINUX) $(DEBIAN) $(UBUNTU) $(GENTOO) $(OPENSUSE) $(FEDORA) $(OSX) $(FREEBSD))
+	 $(TD LDC installation instructions for various Unixen)
 	)
     )
 


### PR DESCRIPTION
- Lists architectures for all downloads.
- Lists OSs for all downloads.
- Removes some ancient, outdated links.
- Fixes some version listings.

I had to remove the Fedora `yum` commands from the LDC table because it made it look fairly silly (read: very large) for little reason. It still links to the page with instructions, though.

(Note: I didn't bother with the D1 table. My care factor is too low. ;)
