### PR TITLE
Clarify that __ctfe never causes code generation

### DIFF
--- a/function.dd
+++ b/function.dd
@@ -1604,7 +1604,9 @@ $(V2
     $(P The $(D_KEYWORD __ctfe) boolean pseudo-variable, which evaluates to $(D_KEYWORD true)
         at compile time, but $(D_KEYWORD false) at run time, can be used to provide
         an alternative execution path to avoid operations which are forbidden
-        at compile time.
+        at compile time. Every usage of $(D_KEYWORD __ctfe) is evaluated before
+        code generation and therefore has no run-time cost, even if no optimizer
+        is used.
     )
 )
 


### PR DESCRIPTION
Many people have been confused about this. The existing docs say
it evaluates to 'true' but don't spell out what that means.
