### PR TITLE
Issue 3011 - alias should have assignment syntax

### DIFF
--- a/declaration.dd
+++ b/declaration.dd
@@ -20,9 +20,18 @@ $(GNAME AliasDeclaration):
 
 $(GNAME AliasDeclaration):
     $(B alias) $(GLINK BasicType) $(GLINK Declarator)
+    $(B alias) $(GLINK AliasInitializerList)
+
+$(GNAME AliasInitializerList):
+    $(GLINK AliasInitializer)
+    $(GLINK AliasInitializer) $(B ,) $(I AliasInitializerList)
+
+$(GNAME AliasInitializer):
+    $(I Identifier) $(B =) $(GLINK Type)
 
 $(GNAME AliasThisDeclaration):
     $(B alias) $(I Identifier) $(B this)
+    $(B alias) $(B this) $(B =) $(I Identifier)
 )
 $(GNAME Decl):
     $(GLINK StorageClasses) $(I Decl)


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=3011

Documentation fix for the syntax: `alias ident = Type;` and `alias this = ident;`
