### PR TITLE
A bunch of version identifier changes.

### DIFF
--- a/version.dd
+++ b/version.dd
@@ -239,6 +239,8 @@ version($(I identifier)) // add in version code if version
 	$(TR $(TD $(B OSX)) $(TD Mac OS X))
 	$(TR $(TD $(B FreeBSD)) $(TD FreeBSD))
 	$(TR $(TD $(B OpenBSD)) $(TD OpenBSD))
+	$(TR $(TD $(B NetBSD)) $(TD NetBSD))
+	$(TR $(TD $(B DragonFlyBSD)) $(TD DragonFlyBSD))
 	$(TR $(TD $(B BSD)) $(TD All other BSDs))
 	$(TR $(TD $(B Solaris)) $(TD Solaris))
 	$(TR $(TD $(B Posix)) $(TD All POSIX systems (includes Linux, FreeBSD, OS X, Solaris, etc.)))
@@ -252,16 +254,32 @@ version($(I identifier)) // add in version code if version
 	$(TR $(TD $(B Cygwin)) $(TD The Cygwin environment))
 	$(TR $(TD $(B MinGW)) $(TD The MinGW environment))
 	$(TR $(TD $(B X86)) $(TD Intel and AMD 32-bit processors))
-	$(TR $(TD $(B X86_64)) $(TD AMD and Intel 64-bit processors))
-	$(TR $(TD $(B ARM)) $(TD The Advanced RISC Machine architecture (32-bit) (AArch32:A32)))
+	$(TR $(TD $(B X86_64)) $(TD Intel and AMD 64-bit processors))
+	$(TR $(TD $(B ARM)) $(TD The ARM architecture (32-bit) (AArch32:A32)))
+	$(TR $(TD $(B ARM_Thumb)) $(TD ARM in Thumb mode (AArch32:T32)))
+	$(TR $(TD $(B ARM_Soft)) $(TD The ARM $(B soft) floating point ABI))
+	$(TR $(TD $(B ARM_SoftFP)) $(TD The ARM $(B softfp) floating point ABI))
+	$(TR $(TD $(B ARM_HardFP)) $(TD The ARM $(B hardfp) floating point ABI))
 	$(TR $(TD $(B ARM64)) $(TD The Advanced RISC Machine architecture (64-bit) (AArch64:A64)))
-	$(TR $(TD $(B Thumb)) $(TD The Advanced RISC Machine architecture (32-bit) in Thumb mode (AArch32:T32)))
 	$(TR $(TD $(B PPC)) $(TD The PowerPC architecture, 32-bit))
+	$(TR $(TD $(B PPC_SoftFP)) $(TD The PowerPC soft float ABI))
+	$(TR $(TD $(B PPC_HardFP)) $(TD The PowerPC hard float ABI))
 	$(TR $(TD $(B PPC64)) $(TD The PowerPC architecture, 64-bit))
 	$(TR $(TD $(B IA64)) $(TD The Itanium architecture (64-bit)))
 	$(TR $(TD $(B MIPS)) $(TD The MIPS architecture, 32-bit))
+	$(TR $(TD $(B MIPS_O32)) $(TD The MIPS O32 ABI))
+	$(TR $(TD $(B MIPS_O32_SoftFP)) $(TD The MIPS O32 soft float ABI))
+	$(TR $(TD $(B MIPS_O32_SoftFP)) $(TD The MIPS O32 hard float ABI))
+	$(TR $(TD $(B MIPS_N32)) $(TD The MIPS N32 ABI))
+	$(TR $(TD $(B MIPS_N32_SoftFP)) $(TD The MIPS N32 soft float ABI))
+	$(TR $(TD $(B MIPS_N32_HardFP)) $(TD The MIPS N32 hard float ABI))
 	$(TR $(TD $(B MIPS64)) $(TD The MIPS architecture, 64-bit))
+	$(TR $(TD $(B MIPS64_SoftFP)) $(TD The MIPS N64 soft float ABI))
+	$(TR $(TD $(B MIPS64_HardFP)) $(TD The MIPS N64 hard float ABI))
 	$(TR $(TD $(B SPARC)) $(TD The SPARC architecture, 32-bit))
+	$(TR $(TD $(B SPARC_V8Plus)) $(TD The SPARC v8+ ABI))
+	$(TR $(TD $(B SPARC_SoftFP)) $(TD The SPARC soft float ABI))
+	$(TR $(TD $(B SPARC_HardFP)) $(TD The SPARC hard float ABI))
 	$(TR $(TD $(B SPARC64)) $(TD The SPARC architecture, 64-bit))
 	$(TR $(TD $(B S390)) $(TD The System/390 architecture, 32-bit))
 	$(TR $(TD $(B S390X)) $(TD The System/390X architecture, 64-bit))
@@ -270,6 +288,8 @@ version($(I identifier)) // add in version code if version
 	$(TR $(TD $(B SH)) $(TD The SuperH architecture, 32-bit))
 	$(TR $(TD $(B SH64)) $(TD The SuperH architecture, 64-bit))
 	$(TR $(TD $(B Alpha)) $(TD The Alpha architecture))
+	$(TR $(TD $(B Alpha_SoftFP)) $(TD The Alpha soft float ABI))
+	$(TR $(TD $(B Alpha_HardFP)) $(TD The Alpha hard float ABI))
 	$(TR $(TD $(B LittleEndian)) $(TD Byte order, least significant first))
 	$(TR $(TD $(B BigEndian)) $(TD Byte order, most significant first))
 	$(TR $(TD $(B D_Coverage)) $(TD $(DPLLINK code_coverage.html, Code coverage analysis) instrumentation (command line $(DPLLINK dmd-windows.html#switches, switch) $(B -cov)) is being generated))
@@ -278,8 +298,10 @@ version($(I identifier)) // add in version code if version
 	$(TR $(TD $(B D_InlineAsm_X86_64)) $(TD $(DDLINK iasm, Inline Assembler, Inline assembler) for X86-64 is implemented))
 	$(TR $(TD $(B D_LP64)) $(TD Pointers are 64 bits (command line $(DPLLINK dmd-windows.html#switches, switch) $(B -m64))))
 	$(TR $(TD $(B D_X32)) $(TD Pointers are 32 bits, but words are still 64 bits (x32 ABI)))
+	$(TR $(TD $(B D_HardFloat)) $(TD The target hardware has a floating point unit))
+	$(TR $(TD $(B D_SoftFloat)) $(TD The target hardware does not have a floating point unit))
 	$(TR $(TD $(B D_PIC)) $(TD Position Independent Code (command line $(DPLLINK dmd-windows.html#switches, switch) $(B -fPIC)) is being generated))
-	$(V2 $(TR $(TD $(B D_SIMD)) $(TD $(DDLINK simd, simd, Vector extensions) (__vector and __simd) are supported)))
+	$(V2 $(TR $(TD $(B D_SIMD)) $(TD $(DDLINK simd, simd, Vector extensions) (via $(B __simd)) are supported)))
 	$(V2 $(TR $(TD $(B D_Version2)) $(TD This is a D version 2 compiler)))
 	$(V2 $(TR $(TD $(B D_NoBoundsChecks)) $(TD Array bounds checks are disabled (command line $(DPLLINK dmd-windows.html#switches, switch) $(B -noboundscheck)))))
 	$(V2 $(TR $(TD $(B unittest)) $(TD $(DDLINK unittest, Unit Tests, Unit tests) are enabled (command line $(DPLLINK dmd-windows.html#switches, switch) $(B -unittest)))))
@@ -294,6 +316,7 @@ version($(I identifier)) // add in version code if version
 	$(TABLE2 Predefined Version Identifiers,
 	$(TR $(TH Version Identifier) $(TH Description))
 	$(TR $(TD $(B darwin)) $(TD The Darwin operating system; use $(B OSX) instead))
+	$(TR $(TD $(B Thumb)) $(TD ARM in Thumb mode; use $(B ARM_Thumb) instead))
 	)
 
 	$(P Others will be added as they make sense and new implementations appear.
@@ -302,7 +325,10 @@ version($(I identifier)) // add in version code if version
 	$(P It is inevitable that the D language will evolve over time.
 	Therefore, the version identifier namespace beginning with "D_"
 	is reserved for identifiers indicating D language specification
-	or new feature conformance.
+	or new feature conformance. Further, all identifiers derived from
+	the ones listed above by appending any character(s) are reserved. This
+	means that e.g. $(B ARM_foo) and $(B Windows_bar) are reserved while
+	$(B foo_ARM) and $(B bar_Windows) are not.
 	)
 
 	$(P Furthermore, predefined version identifiers from this list cannot
@@ -312,8 +338,7 @@ version($(I identifier)) // add in version code if version
 	)
 
 	$(P Compiler vendor specific versions can be predefined if the
-	trademarked vendor
-	identifier prefixes it, as in:
+	trademarked vendor identifier prefixes it, as in:
 	)
 
 ------


### PR DESCRIPTION
- Adds some new OSs.
- Adds a bunch of identifiers for various ABIs of various architectures.
- Adds `D_HardFloat`/`D_SoftFloat` which are just meant to give a general idea of whether the target has an FPU.
- Deprecates `Thumb` in favor of `ARM_Thumb`.
- Adjusts `D_SIMD`'s description a bit: Only `__simd` is compiler-specific; all compilers should still implement `__vector`.
- Changes the rules for version identifier reservations to be more future proof.
