### PR TITLE
Add 'Runtime Initialization of Immutable AAs' section

### DIFF
--- a/hash-map.dd
+++ b/hash-map.dd
@@ -167,6 +167,39 @@ struct MyString {
         $(D opEquals) and $(D opCmp) are consistent with each other when
         the struct/union objects are the same or not.)
 
+$(V2
+<h3>Runtime Initialization of Immutable AAs</h3>
+
+    $(P Immutable associative arrays are often desirable, but sometimes
+        initialization must be done at runtime. This can be achieved with
+        a constructor (static constructor depending on scope), 
+        a buffer associative array and $(D assumeUnique):)
+---------
+immutable long[string] aa;
+
+static this()
+{
+    import std.exception : assumeUnique;
+    import std.conv : to;
+
+    long[string] temp; // mutable buffer
+    foreach(i; 0 .. 10)
+    {
+        temp[to!string(i)] = i;
+    }
+
+    aa = assumeUnique(temp);
+}
+
+unittest
+{
+    assert(aa["1"] == 1);
+    assert(aa["5"] == 5);
+    assert(aa["9"] == 9);
+}
+---------
+)
+
 <h3>Properties</h3>
 
 Properties for associative arrays are:


### PR DESCRIPTION
This was requested on IRC, and I agree it's a good idea. Immutable AAs are often wanted in real code and it's not obvious how to do them. Currently, all AAs must be runtime initialized, which makes the section even more relevant.
