### PR TITLE
Remove point about D being easy to implement

### DIFF
--- a/overview.dd
+++ b/overview.dd
@@ -113,8 +113,6 @@ $(SECTION3 Major Design Goals of D,
 	$(LI Provide low level bare metal access as required. Provide a means
 	for the advanced programmer to escape checking as necessary.)
 
-	$(LI Make D reasonably easy to implement a compiler for.)
-
 	$(LI Be compatible with the local C application binary interface.)
 
 	$(LI Where D code looks the same as C code, have it either behave the


### PR DESCRIPTION
@donc [removed a similar statement](https://github.com/D-Programming-Language/d-programming-language.org/pull/70/files#L0L212) from the FAQ awhile back. Might as well change this to match.
