### PR TITLE
Bug 9033 Remove __thread from list of keywords

### DIFF
--- a/js/d.js
+++ b/js/d.js
@@ -164,7 +164,7 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
                     " module new nothrow out override package pragma private protected public pure real ref" + 
                     " return scope string shared short static struct success super switch synchronized template this throw true" + 
                     " try typeid typeof ubyte ucent uint ulong union unittest ushort version void volatile" + 
-                    " wchar with wstring __FILE__ __LINE__ __gshared __thread __traits"),
+                    " wchar with wstring __FILE__ __LINE__ __gshared __traits"),
     atoms: words("asm catch class debug do else exit failure finally for foreach foreach_reverse if struct switch synchronized unittest version try while with "),
 
     hooks: {

--- a/lex.dd
+++ b/lex.dd
@@ -1087,7 +1087,6 @@ $(V2
     $(B __FILE__)
     $(B __LINE__)
     $(B __gshared)
-    $(B __thread)
     $(B __traits)
     $(B __vector)
     $(B __parameters))


### PR DESCRIPTION
It was used only for internal testing, never documented, and has been obsolete for three years.
(Doesn't close the bug report, we also need to change DMD).
