### PR TITLE
[enh] Issue 8959 - IsExpression should support syntax which has no Identifier in all cases

### DIFF
--- a/expression.dd
+++ b/expression.dd
@@ -1589,6 +1589,8 @@ $(GNAME IsExpression):
     $(D is $(LPAREN)) $(GLINK2 declaration, Type) $(D $(RPAREN))
     $(D is $(LPAREN)) $(GLINK2 declaration, Type) $(D :) $(GLINK TypeSpecialization) $(D $(RPAREN))
     $(D is $(LPAREN)) $(GLINK2 declaration, Type) $(D ==) $(GLINK TypeSpecialization) $(D $(RPAREN))
+    $(D is $(LPAREN)) $(GLINK2 declaration, Type) $(D :) $(GLINK TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))
+    $(D is $(LPAREN)) $(GLINK2 declaration, Type) $(D ==) $(GLINK TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))
     $(D is $(LPAREN)) $(GLINK2 declaration, Type) $(IDENTIFIER) $(D $(RPAREN))
     $(D is $(LPAREN)) $(GLINK2 declaration, Type) $(IDENTIFIER) $(D :) $(GLINK TypeSpecialization) $(D $(RPAREN))
     $(D is $(LPAREN)) $(GLINK2 declaration, Type) $(IDENTIFIER) $(D ==) $(GLINK TypeSpecialization) $(D $(RPAREN))
@@ -1834,8 +1836,10 @@ void foo(bar x) {
 
         )
 
-        $(LI $(D is $(LPAREN)) $(I Type) $(I Identifier) $(D :) $(I TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))$(BR)
-        $(D is $(LPAREN)) $(I Type) $(I Identifier) $(D ==) $(I TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))
+        $(LI $(D is $(LPAREN)) $(I Type) $(D :) $(I TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))$(BR)
+             $(D is $(LPAREN)) $(I Type) $(D ==) $(I TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))$(BR)
+             $(D is $(LPAREN)) $(I Type) $(I Identifier) $(D :) $(I TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))$(BR)
+             $(D is $(LPAREN)) $(I Type) $(I Identifier) $(D ==) $(I TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))
 
         $(P More complex types can be pattern matched; the
         $(GLINK2 template, TemplateParameterList) declares symbols based on the
@@ -1844,10 +1848,18 @@ void foo(bar x) {
         )
 
 ---
-import std.stdio;
+import std.stdio, std.typecons;
 
 void main() {
+  alias Tuple!(int, string) Tup;
   alias long[char[]] AA;
+
+  static if (is(Tup : TX!TL, alias TX, TL...))
+  {
+    writeln(is(TX!(int, long) == Tuple!(int, long)));  // true
+    writeln(typeid(TL[0]));  // int
+    writeln(typeid(TL[1]));  // immutable(char)[]
+  }
 
   static if (is(AA T : T[U], U : const char[]))
   {


### PR DESCRIPTION
This is a documentation fix for [dmd/pull/1255](https://github.com/D-Programming-Language/dmd/pull/1255).
