### PR TITLE
Add note for built-in init property

### DIFF
--- a/property.dd
+++ b/property.dd
@@ -101,7 +101,7 @@ Foo.init.b  // is 7
 	default constructed. That means using $(B .init) is sometimes incorrect.)
 
     $(OL
-	$(LI If $(B T) is a nested struct, the frame pointer in $(B T.init)
+	$(LI If $(B T) is a nested struct, the context pointer in $(B T.init)
 	is $(B null).)
 
 ----------------
@@ -118,7 +118,7 @@ void main() {
 ----------------
 
 	$(LI If $(B T) is a struct which has $(CODE @disable this();), $(B T.init)
-	might return logically incorrect object.)
+	might return a logically incorrect object.)
 
 ----------------
 struct S {


### PR DESCRIPTION
Built-in `.init` property sometimes unsafe. 
