### PR TITLE
Update dcompiler.dd

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -574,13 +574,6 @@ $(V2
 		turns off all array bounds checking, even for safe functions
 	  )
 )
-    $(WINDOWS
-	  $(SWITCH $(B -nofloat),
-		Prevents emission of $(B __fltused) reference in
-		object files, even if floating point code is present.
-		Useful for library code.
-	  )
-    )
 
 	  $(SWITCH $(B -O),
 		Optimize generated code. For fastest executables, compile


### PR DESCRIPTION
Followup of D-Programming-Language/dmd#1258.
(Remove -nofloat from usage text.)
