### PR TITLE
Allow postfix const/immutable/shared/inout for delegate type

### DIFF
--- a/declaration.dd
+++ b/declaration.dd
@@ -96,7 +96,7 @@ $(GNAME BasicType2):
     $(B [) $(VEXPRESSION) $(B ])
     $(B [) $(VEXPRESSION) .. $(VEXPRESSION) $(B ])
     $(B [) $(GLINK Type) $(B ])
-    $(B delegate) $(GLINK Parameters) $(V2 $(GLINK FunctionAttributes)$(OPT))
+    $(B delegate) $(GLINK Parameters) $(V2 $(GLINK MemberFunctionAttributes)$(OPT))
     $(B function) $(GLINK Parameters) $(V2 $(GLINK FunctionAttributes)$(OPT))
 
 $(GNAME Declarator):


### PR DESCRIPTION
The syntax change is necessary, because it has been allowed from 2.061.
