### PR TITLE
Added section on acronyms to dstyle.dd.

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -174,6 +174,19 @@ Enum OpenRight { no, yes }
 -------------------------------
     )
 
+    $(DT Acronyms)
+    $(DD When acronyms are used in symbol names, all letters in the acronym
+         should have the same case. So, if the first letter in the acronym
+         is lowercase, then all of the letters in the acronym are lowercase, and
+         if the first letter in the acronym is uppercase, then all of the
+         letters in the acronym are uppercase.
+
+-------------------------------
+class UTFException;
+ubyte asciiChar;
+-------------------------------
+    )
+
 $(V1
     $(DT Const names)
     $(DD Are in all caps.)


### PR DESCRIPTION
It now explains what case to use with acronyms as it comes up fairly
often in reviews for new functionality. The rule follows what we've
mostly been doing and been insisting on during the review process.

And it's been insisted on several times that this be added to the style guide, so here's the change with it.
