### PR TITLE
Issue 9232 - Parsing error on some templated methods calls

### DIFF
--- a/expression.dd
+++ b/expression.dd
@@ -650,6 +650,7 @@ $(GNAME UnaryExpression):
     $(D !) $(I UnaryExpression)
     $(GLINK ComplementExpression)
     $(D $(LPAREN)) $(GLINK2 declaration, Type) $(D $(RPAREN) .) $(IDENTIFIER)
+    $(D $(LPAREN)) $(GLINK2 declaration, Type) $(D $(RPAREN) .) $(GLINK2 template, TemplateInstance)
     $(GLINK NewExpression)
     $(GLINK DeleteExpression)
     $(GLINK CastExpression)


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9232

This is a supplemental document fix with https://github.com/D-Programming-Language/dmd/pull/1422 .
