### PR TITLE
Kill the syntax `alias this = sym;`

### DIFF
--- a/declaration.dd
+++ b/declaration.dd
@@ -21,7 +21,6 @@ $(GNAME AliasInitializer):
 
 $(GNAME AliasThisDeclaration):
     $(D alias) $(I Identifier) $(D this)
-    $(D alias) $(D this) $(D =) $(I Identifier)
 
 $(GNAME Decl):
     $(GLINK StorageClasses) $(I Decl)


### PR DESCRIPTION
This is a supplemental pull of https://github.com/D-Programming-Language/dmd/pull/1413 .
