### PR TITLE
Relax inout rule

### DIFF
--- a/function.dd
+++ b/function.dd
@@ -210,10 +210,6 @@ inout(int)[] foo(inout(int)[] a, int x, int y) { return a[x .. y]; }
         Casting to or from inout is not allowed in @safe functions.
         )
 
-        $(P If an inout appears in a function parameter list, it must also appear
-        in the return type.
-        )
-
         $(P A set of arguments to a function with inout parameters is considered
         a match if any inout argument types match exactly, or:)
 


### PR DESCRIPTION
It has been introduced by [issue 7105](http://d.puremagic.com/issues/show_bug.cgi?id=7105) from 2.059. In current, an inout is not necessary to appear in the return type.
