### PR TITLE
Add note about enum member names which match keywords.

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -169,8 +169,19 @@ immutable hexDigits = "0123456789ABCDEF";
          lowercase.
 
 -------------------------------
-Enum Direction { bwd, fwd, both }
-Enum OpenRight { no, yes }
+enum Direction { bwd, fwd, both }
+enum OpenRight { no, yes }
+-------------------------------
+    )
+
+    $(DT Keywords)
+    $(DD If a name would conflict with a keyword, and it is desirable to use the
+         keyword rather than pick a different name, a single underscore
+         $(SINGLEQUOTE _) should be appended to it. Names should not be
+         capitalized differently in order to avoid conflicting with keywords.
+
+-------------------------------
+enum Attribute { nothrow_, pure_, safe }
 -------------------------------
     )
 


### PR DESCRIPTION
If an enum member's name would be a keyword, then the way to make it
legal is to append an underscore to it, which we've been doing. But
apparently it didn't make it into the style guide. So, this adds it.
