### PR TITLE
Fix ABI documentation

### DIFF
--- a/abi.dd
+++ b/abi.dd
@@ -426,6 +426,7 @@ $(I Type):
     $(I TypeChar)
     $(I TypeWchar)
     $(I TypeDchar)
+    $(I TypeNull)
     $(I TypeTuple)
 
 $(I Shared):
@@ -597,6 +598,9 @@ $(I TypeWchar):
 
 $(I TypeDchar):
     $(B w)
+
+$(I TypeNull):
+    $(B n)
 
 $(I TypeTuple):
     $(B B) $(I Number) $(I Arguments)


### PR DESCRIPTION
- Remove `TypeNone` …
  It is not used at all.
- Remove `TypeNewArray` …
  It had been prepared for `T[new]`, but in current it is not used at all.
- Add `TypeNull`
  Now `typeof(null)` has its own type.
