### PR TITLE
Fix 2.061 changelog for deprecated options wording/grammar

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -95,15 +95,15 @@ $(UL
 $(VERSION 061, Jan 1, 2013, =================================================,
 
     $(WHATSNEW
-	$(LI DMD now show deprecated features as warnings (a message is
-	     displayed but compilation is not halted anymore) by default,
-	     and there are 2 new compiler flags, -de (to get the old default
-	     behaviour to make deprecation to be errors) and -dw, to
-	     explicitly enable the new default behaviour (make them warnings).
-	     This makes possible to add -de in the configuration file to
-	     get the old default and still being able override that default
+	$(LI DMD now shows deprecated features as warnings by default (a
+	     message is displayed but compilation is not halted anymore).
+	     There are also 2 new compiler flags: -de, to get the old default
+	     behaviour (using deprecated features is an error) and -dw, to
+	     explicitly enable the new default behaviour (just warn).
+	     This makes it possible to add -de in the configuration file to
+	     get the old default and still be able to override that default
 	     by using -dw when compiling.
-	     The -d flag stay the same (silently ignore deprecated features).
+	     The -d flag stays the same (silently ignore deprecated features).
 	)
 	$(LI Complete list of $(WHATSNEW2 2012-08-02, 2012-12-31))
     )


### PR DESCRIPTION
This fixes some minor grammatical mistakes and fixes the wording to be easier to read.
