### PR TITLE
Issue 693 - 'this' can't be used as an alias parameter for a mixin

### DIFF
--- a/template.dd
+++ b/template.dd
@@ -99,6 +99,7 @@ $(GNAME TemplateSingleArgument):
     $(B true)
     $(B false)
     $(B null)
+    $(B this)
     $(B __FILE__)
     $(B __LINE__)
 )


### PR DESCRIPTION
It is fixed in 2.054.
