### PR TITLE
prowiki -> wiki.dlang.org

### DIFF
--- a/doc.ddoc
+++ b/doc.ddoc
@@ -85,7 +85,7 @@ PAGE_TOOLS=
 			local clone.
 		</span>
 	</a>
-	<a href="http://www.prowiki.org/wiki4d/wiki.cgi?DocComments/$(WIKI)" class="tip button">
+	<a href="http://wiki.dlang.org/DocComments/$(WIKI)" class="tip button">
 		Page wiki
 		<span>
 	        View or edit the community-maintained wiki page associated with this page.
@@ -144,7 +144,7 @@ Copyright &copy; 1999-$(YEAR) by Digital Mars &reg;, All Rights Reserved
 FOOTER=
 <div id="footernav">
 <a href="http://forum.dlang.org/" title="User Forums">Forums</a> |
-<a href="http://www.prowiki.org/wiki4d/wiki.cgi?DocComments/$(WIKI)" title="Read/write comments and feedback">Comments</a> |
+	<a href="href="http://wiki.dlang.org/DocComments/$(WIKI)" title="Read/write comments and feedback">Comments</a> |
 <a href="http://digitalmars.com/advancedsearch.html" title="Search Digital Mars web site">Search</a> |
 <a href="download.html" title="Download D">Downloads</a> |
 <a href="/">Home</a>
@@ -198,8 +198,8 @@ $(NAVBLOCK_HEADER $(TOCHEADER Documentation),
 $(NAVBLOCK_HEADER $(TOCHEADER Community),
 	$(TOCENTRYT http://forum.dlang.org/, User forums, Forums)
 	$(TOCENTRYT http://github.com/D-Programming-Language, D on github, GitHub)
-	$(TOCENTRYT http://prowiki.org/wiki4d/wiki.cgi?FrontPage, Wiki for the D Programming Language, Wiki)
-	$(TOCENTRYT http://prowiki.org/wiki4d/wiki.cgi?ReviewQueue, Queue of current and upcoming standard library additions, Review Queue)
+	$(TOCENTRYT http://wiki.dlang.org, Wiki for the D Programming Language, Wiki)
+	$(TOCENTRYT http://wiki.dlang.org/Review_Queue, Queue of current and upcoming standard library additions, Review Queue)
 	$(TOCENTRYT http://twitter.com/#search?q=%23d_lang, #d_lang on twitter.com, Twitter)
 	$(TOCENTRYT http://digitalmars.com/d/dlinks.html, External D related links, Links)
 	$(TOCENTRYX http://d.puremagic.com/conference2008/, D Programming Language Conference, Conference)
@@ -237,8 +237,8 @@ $(NAVBLOCK
 	$(TOCENTRYT rdmd.html, rdmd - run D programs as if they were scripts, DMD Script Shell)
 	$(TOCENTRYT windbg.html, windbg - debugging Windows programs, Windows Debugger)
 	$(TOCENTRYT htod.html, htod - mechanically convert C .h header files to D, C .h to D .d)
-	$(TOCENTRYT http://www.prowiki.org/wiki4d/wiki.cgi?EditorSupport, Editors with support for D, Editors)
-	$(TOCENTRYT http://www.prowiki.org/wiki4d/wiki.cgi?ReferenceForTools, Even more tools for D, More Tools)
+	$(TOCENTRYT http://wiki.dlang.org/Editors, Editors with support for D, Editors)
+	$(TOCENTRYT http://wiki.dlang.org/IDEs, IDEs with support for D, IDEs)
 )
 
 SUBNAV_FAQ=


### PR DESCRIPTION
All DIPs were moved to new wiki so switching links on main page
