### PR TITLE
fix the algorithm in the isprime example

### DIFF
--- a/concepts.dd
+++ b/concepts.dd
@@ -51,13 +51,16 @@ template Foo(int N)
 	)
 
 ---
-bool isPrime(int n) {
+bool isPrime(int n) 
+{
 	if (n == 2)
 		return true;
 	if (n < 1 || (n & 1) == 0)
 		return false;
-	if (n > 3) { 
-		for (auto i = 3; i * i < n; i += 2) { 
+	if (n > 3) 
+	{
+		for (auto i = 3; i * i <= n; i += 2) 
+		{ 
 			if ((n % i) == 0)
 				return false;
 		} 


### PR DESCRIPTION
The old version of isprime would return false for 2 and return true for any n with no factor less than sqrt(n).

These alterations fix that.
