### PR TITLE
Make Scoped Imports appear only in D2 docs (dmd-1.x branch)

### DIFF
--- a/module.dd
+++ b/module.dd
@@ -363,6 +363,8 @@ void main()
                             // foo is not a member of io
 --------------
 
+$(V2
+
 <h3>Scoped Imports</h3>
 
     $(P Import declarations may be used at any scope. For example:)
@@ -398,6 +400,8 @@ void main() {
   std.stdio.writeln("bar");  // error, std is undefined
 }
 --------------
+
+)
 
 <h3>Module Scope Operator</h3>
 


### PR DESCRIPTION
Scoped Imports are a D2-only feature so they shouldn't appear in D1
documentation.

Since I don't know how branches are managed here, I'm posting both pull requests...
