### PR TITLE
Make Scoped Imports appear only in D2 docs

### DIFF
--- a/module.dd
+++ b/module.dd
@@ -378,6 +378,8 @@ void main()
                              // foo is not a member of io
 --------------
 
+$(V2
+
 $(H3 Scoped Imports)
 
     $(P Import declarations may be used at any scope. For example:)
@@ -413,6 +415,8 @@ void main() {
   std.stdio.writeln("bar");  // error, std is undefined
 }
 --------------
+
+)
 
 $(H3 Module Scope Operator)
 


### PR DESCRIPTION
Scoped Imports are a D2-only feature so they shouldn't appear in D1
documentation.

Since I don't know how branches are managed here, I'm posting both pull requests...
