### PR TITLE
Added missing dup property

### DIFF
--- a/hash-map.dd
+++ b/hash-map.dd
@@ -221,6 +221,13 @@ Properties for associative arrays are:
         Unlike for dynamic arrays, it is read-only.
         )
         )
+        
+        $(TR
+        $(TD $(B .dup)),
+        $(TD Create a new associative array of the same size
+        and copy the contents of the associative array into it.
+        )
+        )
 
         $(TR
         $(TD $(B .keys))


### PR DESCRIPTION
For some reason dup wasn't documented for AAs. 

I'm not that familiar with ddoc, hopefully i've done this right.
