### PR TITLE
Don't describe D variadic functions as "typesafe variadic"

### DIFF
--- a/function.dd
+++ b/function.dd
@@ -937,7 +937,7 @@ int foo(int x, int y, ...) {
         with the name $(D _arguments) and type $(D TypeInfo[])
         is passed to the function.
         $(D _arguments) gives the number of arguments and the type
-        of each, enabling the creation of typesafe variadic functions.
+        of each, enabling type safety to be checked at run time.
 
 ------
 import std.stdio;


### PR DESCRIPTION
Currently the "D variadic functions" section says that _argptr "enables the creation of typesafe variadic functions". This wording creates confusion, since the  next section is titled "Typesafe variadic functions" but means something different!
