### PR TITLE
Remove Scoped Imports

### DIFF
--- a/module.dd
+++ b/module.dd
@@ -363,42 +363,6 @@ void main()
                             // foo is not a member of io
 --------------
 
-<h3>Scoped Imports</h3>
-
-    $(P Import declarations may be used at any scope. For example:)
-
---------------
-void main() {
-  import std.stdio;
-  writeln("bar");
-}
---------------
-
-    $(P The imports are looked up to satisfy any unresolved symbols at that scope.
-    Imported symbols may hide symbols from outer scopes.)
-
-
-        $(P In function scopes, imported symbols only become visible after the
-        import declaration
-        lexically appears in the function body. In other words, imported symbols
-        at function scope cannot be forward referenced.
-        )
-
---------------
-void main() {
-  void writeln(string) {}
-  void foo() {
-    writeln("bar"); // calls main.writeln
-    import std.stdio;
-    writeln("bar"); // calls std.stdio.writeln
-    void writeln(string) {}
-    writeln("bar"); // calls main.foo.writeln
-  }
-  writeln("bar"); // calls main.writeln
-  std.stdio.writeln("bar");  // error, std is undefined
-}
---------------
-
 <h3>Module Scope Operator</h3>
 
         Sometimes, it's necessary to override the usual lexical scoping rules


### PR DESCRIPTION
Scoped Imports are a D2-only feature so they shouldn't appear in D1
documentation.
