### PR TITLE
Updated FAQ links to the new wiki

### DIFF
--- a/faq.dd
+++ b/faq.dd
@@ -215,13 +215,14 @@ $(ITEM gui, Where can I get a GUI library for D?)
 
 	$(P Since D can call C functions, any GUI library with a C interface is
 	accessible from D. Various D GUI libraries and ports can be found at
-	$(LINK2 http://www.prowiki.org/wiki4d/wiki.cgi?GuiLibraries, the D wiki).
+	$(LINK2 http://wiki.dlang.org/GUI_Libraries, the D wiki).
 	)
 
 $(ITEM ide, Where can I get an IDE for D?)
 
-	$(P A list of IDEs and editors that support D can be found on
-    $(LINK2 http://prowiki.org/wiki4d/wiki.cgi?EditorSupport, the D wiki).
+	$(P Lists of $(LINK2 http://wiki.dlang.org/Editors, editors) and
+	$(LINK2 http://wiki.dlang.org/IDEs, IDEs) that support D can be found on
+	the D wiki.
 	)
 
 $(ITEM q4, Why is printf in D?)


### PR DESCRIPTION
Just updated some links in the FAQ to point to our new wiki, instead of the old one.
