### PR TITLE
Remove redundant commas

### DIFF
--- a/hash-map.dd
+++ b/hash-map.dd
@@ -196,14 +196,14 @@ Properties for associative arrays are:
         )
 
         $(TR
-        $(TD $(B .dup)),
+        $(TD $(B .dup))
         $(TD Create a new associative array of the same size
         and copy the contents of the associative array into it.
         )
         )
 
         $(TR
-        $(TD $(B .keys)),
+        $(TD $(B .keys))
         $(TD Returns dynamic array, the elements of which are the keys in
         the associative array.
         )


### PR DESCRIPTION
It appears above the table title.

```
Properties

Properties for associative arrays are:
,,   <--- here
Associative Array Properties
(table)
```
