### PR TITLE
Issue 9394 - ABI for static arrays is outdated

### DIFF
--- a/abi.dd
+++ b/abi.dd
@@ -203,22 +203,6 @@ $(SECTION3 Reference Types,
 	referred to by reference; this means that class instances can never reside on the stack
 	or be passed as function parameters.
 	)
-
-	$(P When passing a static array to a function, the result, although declared as a static array, will
-	actually be a reference to a static array. For example:
-	)
-
----------
-int[3] abc;
----------
-
-	$(P Passing abc to functions results in these implicit conversions:)
-
----------
-void func(int* p);       // abc is converted to a pointer
-                         // to the first element
-void func(int[] array);	 // abc is converted to a dynamic array
----------
 )
 
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9394

Almost of "Reference Types" section is outdated in D2.
