### PR TITLE
Doc links for keywords

### DIFF
--- a/lex.dd
+++ b/lex.dd
@@ -1024,7 +1024,7 @@ $(MULTICOLS 4,
 
     $(D $(XLINK2 version.html#version, version))
     $(D $(XLINK2 declaration.html#VoidInitializer, void))
-    $(D $(XLINK ctod.html#volatile, volatile)) ($(XLINK2 deprecate.html#volatile, deprecated))
+    $(D $(XLINK2 ctod.html#volatile, volatile)) ($(XLINK2 deprecate.html#volatile, deprecated))
 
     $(D $(XLINK2 type.html, wchar))
     $(D $(XLINK2 statement.html#WhileStatement, while))


### PR DESCRIPTION
Addresses the first part of [bug #9469](http://d.puremagic.com/issues/show_bug.cgi?id=9469).  This could probably be improved a bit, but I consider it an adequate start.
