### PR TITLE
Add implicit symbols section to lex.dd

### DIFF
--- a/lex.dd
+++ b/lex.dd
@@ -903,7 +903,9 @@ $(GNAME LeadingDecimal):
 
 $(H3 Keywords)
 
-	Keywords are reserved identifiers.
+	Keywords are reserved identifiers. 
+
+	See Also: Globally Defined $(GLINK Symbols).
 
 $(GRAMMAR
 $(GNAME Keyword):
@@ -999,7 +1001,6 @@ $(MULTICOLS 4,
     $(D $(XLINK2 attribute.html#shared, shared))
     $(D $(XLINK2 type.html, short))
     $(D $(XLINK2 version.html#staticif, static))
-    $(D $(XLINK2 arrays.html#strings, string)) (alias to immutable(char)[]) <!-- This is important; people want to know these things up front. -->
     $(D $(XLINK2 struct.html, struct))
     $(D $(XLINK2 expression.html#super, super))
     $(D $(XLINK2 statement.html#SwitchStatement, switch))
@@ -1036,6 +1037,21 @@ $(MULTICOLS 4,
     $(D $(XLINK2 traits.html, __traits))
     $(D $(XLINK2 phobos/core_simd.html#.Vector,__vector))
     $(D $(XLINK2 expression.html#IsExpression, __parameters))
+))
+
+$(H3 Globally Defined Symbols)
+
+	These are defined in object_.d, which is automatically imported by the default implementation.
+
+$(GRAMMAR
+$(GNAME Symbols):
+$(MULTICOLS 4,
+    $(D $(XLINK2 arrays.html#strings, string)) (alias to immutable(char)[]) <!-- This is important; people want to know these things up front. -->
+    $(D $(XLINK2 arrays.html#strings, wstring)) (alias to immutable(wchar)[])
+    $(D $(XLINK2 arrays.html#strings, dstring)) (alias to immutable(dchar)[])
+
+    $(D $(XLINK2 lex.html#sizet, size_t))
+    $(D $(XLINK2 lex.html#sizet, ptrdiff_t))
 ))
 
 $(H3 $(LNAME2 specialtokens, Special Tokens))

--- a/type.dd
+++ b/type.dd
@@ -325,7 +325,7 @@ mfp(c, 1);  // and call c.foo(1)
 ---
 )
 
-$(SECTION3 $(D size_t) and $(D ptrdiff_t),
+$(SECTION3 $(LNAME2 sizet, $(D size_t) and $(D ptrdiff_t)))
 
     $(P $(D size_t) is an alias to one of the unsigned integral basic types,
     and represents a type that is large enough to represent an offset into


### PR DESCRIPTION
Having string in the keywords list didn't sit well with me, so I ended
up breaking it out and adding the others as well.  Also added two more
of the double-underscore keywords (that don't appear to otherwise have
documentation).
