### PR TITLE
fix TemplateMixin grammar

### DIFF
--- a/template-mixin.dd
+++ b/template-mixin.dd
@@ -12,7 +12,17 @@ $(GNAME TemplateMixinDeclaration):
             $(B {) $(GLINK2 module, DeclDefs) $(B })
 
 $(GNAME TemplateMixin):
-    $(B mixin) $(TEMPLATEIDENTIFIER) $(TEMPLATEARGUMENTS)$(OPT) $(GLINK MixinIdentifier)$(OPT) $(B ;)
+    $(B mixin) $(GLINK MixinTemplateName) $(TEMPLATEARGUMENTS)$(OPT) $(GLINK MixinIdentifier)$(OPT) $(B ;)
+
+$(GNAME MixinTemplateName):
+    $(D .)$(GLINK QualifiedIdentifierList)
+    $(GLINK QualifiedIdentifierList)
+    $(GLINK2 declaration, Typeof) $(D .) $(GLINK QualifiedIdentifierList)
+
+$(GNAME QualifiedIdentifierList):
+    $(I Identifier)
+    $(I Identifier) $(D .) $(I QualifiedIdentifierList)
+    $(GLINK2 template, TemplateInstance) $(D .) $(I QualifiedIdentifierList)
 
 $(GNAME MixinIdentifier):
     $(I Identifier)


### PR DESCRIPTION
Currently, following syntax are allowed for mixin declaration.
But the grammar does not explain it.

(From comment for `Parser::parseMixin` in `dmd/src/parse.c`)

``` cpp
 *      mixin Foo;
 *      mixin Foo!(args);
 *      mixin a.b.c!(args).Foo!(args);
 *      mixin Foo!(args) identifier;
 *      mixin typeof(expr).identifier!(args);
```

This is just a reflection of current implementation behavior to the documentation.
