### PR TITLE
Fix missing '#' in some anchor links

### DIFF
--- a/arrays.dd
+++ b/arrays.dd
@@ -302,7 +302,7 @@ a = b;           // a refers to b
 a = b ~ c[0..0]; // a refers to a copy of b
 ---------
 
-        $(P Appending does not always create a copy, see $(LINK2 resize,
+        $(P Appending does not always create a copy, see $(LINK2 #resize,
         setting dynamic array length) for details.
         )
 

--- a/property.dd
+++ b/property.dd
@@ -21,11 +21,11 @@ $(BR)
 
 $(TABLE2 Properties for All Types,
 $(THEAD  Property, Description)
-$(TROW $(LINK2 init, $(D .init)),	initializer)
-$(TROW $(LINK2 sizeof, $(D .sizeof)), size in bytes (equivalent to C's sizeof(type)))
-$(TROW $(LINK2 alignof, $(D .alignof)), alignment size)
+$(TROW $(LINK2 #init, $(D .init)),	initializer)
+$(TROW $(LINK2 #sizeof, $(D .sizeof)), size in bytes (equivalent to C's sizeof(type)))
+$(TROW $(LINK2 #alignof, $(D .alignof)), alignment size)
 $(TROW $(D .mangleof), string representing the $(SINGLEQUOTE mangled) representation of the type)
-$(TROW $(LINK2 stringof, $(D .stringof)), string representing the source representation of the type)
+$(TROW $(LINK2 #stringof, $(D .stringof)), string representing the source representation of the type)
 )
 
 $(BR)
@@ -62,7 +62,7 @@ $(BR)
 
 $(TABLE2 Properties for Class Types,
 $(THEAD Property, Description)
-$(TROW $(LINK2 classinfo, $(D .classinfo)), Information about the dynamic type of the class)
+$(TROW $(LINK2 #classinfo, $(D .classinfo)), Information about the dynamic type of the class)
 )
 
 $(SECTION3 $(LNAME2 init, .init) Property,

--- a/struct.dd
+++ b/struct.dd
@@ -4,7 +4,7 @@ $(SPEC_S Structs and Unions,
 
          $(P Whereas classes are reference types, structs are value types.
              Any C struct can be exactly represented as a D struct, except non-static
-             $(LINK2 nested, function-nested D structs) which access the context of
+             $(LINK2 #nested, function-nested D structs) which access the context of
              their enclosing scope.
              Structs and unions are meant as simple aggregations of data, or as a way
              to paint a data structure over hardware or an external type. External
@@ -76,7 +76,7 @@ $(SPEC_S Structs and Unions,
         $(UNCHECK), $(UNCHECK))
         $(TROW const/immutable/shared, $(CHECK), $(CHECK), $(UNCHECK),
         $(UNCHECK), $(UNCHECK))
-        $(TROW inner nesting, $(LINK2 nested, $(CHECK)), $(DDSUBLINK class,
+        $(TROW inner nesting, $(LINK2 #nested, $(CHECK)), $(DDSUBLINK class,
         nested, $(CHECK)), $(UNCHECK), $(UNCHECK), $(UNCHECK))
         )
 


### PR DESCRIPTION
Add missing `#` to target for some uses of `LINK2`.
