### PR TITLE
Fix padded link target "class.html#        nested" in struct.html

### DIFF
--- a/struct.dd
+++ b/struct.dd
@@ -76,8 +76,8 @@ $(SPEC_S Structs and Unions,
         $(UNCHECK), $(UNCHECK))
         $(TROW const/immutable/shared, $(CHECK), $(CHECK), $(UNCHECK),
         $(UNCHECK), $(UNCHECK))
-        $(TROW inner nesting, $(RELATIVE_LINK2 nested, $(CHECK)), $(DDSUBLINK class,
-        nested, $(CHECK)), $(UNCHECK), $(UNCHECK), $(UNCHECK))
+        $(TROW inner nesting, $(RELATIVE_LINK2 nested, $(CHECK)),
+        $(DDSUBLINK class, nested, $(CHECK)), $(UNCHECK), $(UNCHECK), $(UNCHECK))
         )
 
 $(GRAMMAR


### PR DESCRIPTION
The last row in the comparison table [here](http://dlang.org/struct) has a wrong link to `class.html#        nested`.  This is because `DDSUBLINK`'s 2nd argument was on an indented new line. Reformatted to avoid indentation being included in the link target.
