### PR TITLE
Fix images for pages not in root (/phobos)

### DIFF
--- a/doc.ddoc
+++ b/doc.ddoc
@@ -52,7 +52,7 @@ function bodyLoad()
 <div id="top">
 	<div id="search-box">
 		<form method="get" action="http://google.com/search">
-			<img src="images/search-left.gif" width="11" height="22" /><input id="q" name="q" /><input type="image" id="search-submit" name="submit" src="images/search-button.gif" />
+			<img src="/images/search-left.gif" width="11" height="22" /><input id="q" name="q" /><input type="image" id="search-submit" name="submit" src="/images/search-button.gif" />
 			<input type="hidden" id="domains" name="domains" value="dlang.org" />
 			<input type="hidden" id="sourceid" name="sourceid" value="google-search" />
 			<div id="search-dropdown">
@@ -66,7 +66,7 @@ function bodyLoad()
 	</div>
 	<div id="header">
 		<a id="d-language" href="/">
-		<img id="logo" width="125" height="95" border="0" alt="D Logo" src="images/dlogo.png">
+		<img id="logo" width="125" height="95" border="0" alt="D Logo" src="/images/dlogo.png">
 		D Programming Language</a>
 	</div>
 </div>
@@ -448,7 +448,7 @@ DIGG=<script src="http://digg.com/tools/diggthis.js" type="text/javascript"></sc
 SLASHDOT=<script src="http://slashdot.org/slashdot-it.js" type="text/javascript"></script>
 HOMEIMG=<img src="home.png" border=0 alt="digitalmars.com">
 SEARCHIMG=<img src="search.png" border=0 alt="Search">
-DOWNLOADIMG=<img src="images/download.png" border=0 alt="Download">
+DOWNLOADIMG=<img src="/images/download.png" border=0 alt="Download">
 WIKIIMG=<img src="wiki.png" border=0 alt="D Wiki">
 DIMG=<img src="d.png" border=0 alt="D Programming Language">
 NEWSIMG=<img src="http://digitalmars.com/news.png" border=0 alt="User Forums">

--- a/std.ddoc
+++ b/std.ddoc
@@ -106,7 +106,7 @@ function listanchors()
 <div id="top">
 	<div id="search-box">
 		<form method="get" action="http://google.com/search">
-			<img src="images/search-left.gif" width="11" height="22" alt=""><input id="q" name="q"><input type="image" id="search-submit" name="submit" src="images/search-button.gif">
+			<img src="/images/search-left.gif" width="11" height="22" alt=""><input id="q" name="q"><input type="image" id="search-submit" name="submit" src="/images/search-button.gif">
 			<input type="hidden" id="domains" name="domains" value="dlang.org">
 			<input type="hidden" id="sourceid" name="sourceid" value="google-search">
 			<div id="search-dropdown">
@@ -119,7 +119,7 @@ function listanchors()
 		</form>
 	</div>
 	<div id="header">
-		<a href="/"><img id="logo" width="125" height="95" border="0" alt="D Logo" src="images/dlogo.png"></a>
+		<a href="/"><img id="logo" width="125" height="95" border="0" alt="D Logo" src="/images/dlogo.png"></a>
 		<a id="d-language" href="/">D Programming Language $(VER)</a>
 	</div>
 </div>


### PR DESCRIPTION
Fixes issue 9544.

76e0de544f9d0aa67bbcad9127cd320dbdb7cc80 broke images for pages not in the root of the website (most notably /phobos pages).

Not having local images work has always bugged me too but it's more important that the actual website have working images.

@WalterBright and anyone else: A quick way to test locally with working images is to just run `python -m SimpleHTTPServer` from the root directory of this repository. Just navigate to http://127.0.0.1:8000.
