### PR TITLE
fix Issue 6024 - Windows 2000 SP4 is not supported any more? And what is...

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -38,7 +38,7 @@ $(H2 $(LNAME2 requirements, Requirements and Downloads))
 	$(LI $(LINK2 http://www.digitalmars.com/d/download.html, Download D Compiler))
 
     $(WINDOWS
-	$(LI 32 bit Windows (Win32) operating system, such as Windows XP)
+	$(LI Windows operating system, Windows XP or later, 32 or 64 bit)
 
 	$(LI Download
 	 <a href="http://ftp.digitalmars.com/dmc.zip" title="download dmc.zip">


### PR DESCRIPTION
... still supported?

Specify D supports Win XP or later.
