### PR TITLE
fix Issue 8130 - Memory corruption because without *.def file DMD compil...

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -648,9 +648,14 @@ $(COMMENT
 	  )
 )
     $(UNIX
-	  $(SWITCH $(B -shared),
+          $(SWITCH2 -shared,
 		generate shared library
 	  )
+    )
+    $(WINDOWS
+          $(SWITCH2 -shared,
+                generate DLL library
+          )
     )
 	  $(SWITCH $(B -unittest),
 		compile in $(LINK2 unittest.html, unittest) code, turns on asserts, and sets the
@@ -1078,4 +1083,5 @@ Macros:
 	LIB=$(WINDOWS phobos.lib)$(UNIX libphobos2.a)
 	DMD_CONF=$(RELATIVE_LINK2 dmd_conf, dmd.conf)
 	SWITCH=$(DT $1)$(DD $+)
+        SWITCH2=$(DT $(LNAME2 switch$1,$(B $1)))$(DD $+)
 	CATEGORY_DOWNLOAD=$0

--- a/dll.dd
+++ b/dll.dd
@@ -17,10 +17,20 @@ $(D_S Writing Win32 DLLs in D,
 	$(P This guide will show how to create DLLs of various types with D.)
 
 	$(UL
+        $(LI <a href="#compiling">Compiling a DLL</a>)
 	$(LI <a href="#Cinterface">DLLs with a C interface</a>)
 	$(LI <a href="#com">DLLs that are COM servers</a>)
 	$(LI <a href="#Dcode">D code calling D code in DLLs</a>)
 	)
+
+$(H2 <a name="compiling">Compiling a DLL</a>)
+
+        $(P Use the $(DDSUBLINK dmd-windows,switch-shared, $(B -shared)) switch to tell the compiler
+        that the generated code is to be
+        put into a DLL. Code compiled for an EXE file will use the optimization assumption
+        that $(D _tls_index==0). Such code in a DLL will crash.
+        )
+
 
 $(H2 <a name="Cinterface">DLLs with a C Interface</a>)
 


### PR DESCRIPTION
...es DLL with assumption

http://d.puremagic.com/issues/show_bug.cgi?id=8130
