### PR TITLE
Display runnable examples only on main page.

### DIFF
--- a/js/run.js
+++ b/js/run.js
@@ -335,6 +335,11 @@ $(document).ready(function()
         $(this).css("display", "none");
     });
 
+    var currentPage = $(location).attr('pathname');
+    
+    if (currentPage != "/" && currentPage != "/index.html")
+        return; // temporary workaround
+
     $('pre[class=d_code]').each(function(index) 
     {
         var stripedText = $(this).text().replace(/\s/gm,'');
@@ -503,7 +508,7 @@ $(document).ready(function()
                 },
                 error: function() 
                 {
-                    output.html("Temporarily unavaible");
+                    output.html("Temporarily unavailable");
                     runBtn.attr("disabled", false);
                 }
             });


### PR DESCRIPTION
Temporary workaround to prevent weird forms being displayed in places like changelog, phobos subpages etc.

At this moment I'm overloaded with the work so I'm unable to work on full solution for Phobos runnable examples.

This pull request introduces changes so examples will be shown only on the main dlang.org webpage (http://dlang.org/index.html).

In the free moment I will finish work on Phobos and make pull request
