### PR TITLE
Add note to avoid the opCall limitation

### DIFF
--- a/operatoroverloading.dd
+++ b/operatoroverloading.dd
@@ -364,27 +364,60 @@ struct S {
 $(H2 $(LNAME2 FunctionCall, Function Call Operator Overloading $(D f())))
 
 	$(P The function call operator, (), can be overloaded by
-	declaring a function named $(B opCall):
+	declaring a function named $(CODE opCall):
 	)
 
--------
-struct F {
-  int $(CODE_HIGHLIGHT opCall)();
-  int $(CODE_HIGHLIGHT opCall)(int x, int y, int z);
-}
+	-------
+	struct F {
+	  int $(CODE_HIGHLIGHT opCall)();
+	  int $(CODE_HIGHLIGHT opCall)(int x, int y, int z);
+	}
 
-void test() {
-  F f;
-  int i;
+	void test() {
+	  F f;
+	  int i;
 
-  i = f();      // same as i = f.opCall();
-  i = f(3,4,5); // same as i = f.opCall(3,4,5);
-}
--------
+	  i = f();      // same as i = f.opCall();
+	  i = f(3,4,5); // same as i = f.opCall(3,4,5);
+	}
+	-------
 
 	$(P In this way a struct or class object can behave as if it
 	were a function.
 	)
+
+	$(P $(CODE static opCall) also works as expected for function call operator with
+	type names.
+	)
+
+	-------
+	struct Double {
+	  $(CODE_HIGHLIGHT static) int $(CODE_HIGHLIGHT opCall)(int x) { return x * 2; }
+	}
+	void test() {
+	  int i = Double(2);
+	  assert(i == 4);
+	}
+	-------
+
+	$(P Note that merely declaring $(D opCall) automatically disables
+	$(XLINK2 struct.html#StructLiteral, struct literal) syntax.
+	To avoid the limitation, you need to also declare $(XLINK2 Struct-Constructor,
+	constructor) so that it takes priority over $(D opCall) in $(D Type(...)) syntax.
+	)
+
+	-------
+	struct Multiplier {
+	  int factor;
+	  this(int num) { factor = num; }
+	  int opCall(int value) { return value * factor; }
+	}
+	void test() {
+	  Multiplier m = Multiplier(10);  // invoke constructor
+	  int result = m(5);              // invoke opCall
+	  assert(result == 50);
+	}
+	-------
 
 $(H2 $(LNAME2 Assignment, Assignment Operator Overloading))
 
@@ -570,7 +603,7 @@ $(H2 $(LNAME2 Slice, Slice Operator Overloading))
 
 	$(P Overloading the slicing operator means overloading expressions
 	like $(CODE a[]) and $(D a[)$(SLICE)$(D ]).
-	This can be done by declaring a member function named $(B opSlice).
+	This can be done by declaring a member function named $(CODE opSlice).
 	)
 
 -------

--- a/struct.dd
+++ b/struct.dd
@@ -255,17 +255,19 @@ $(H3 $(LNAME2 StructLiteral, Struct Literals))
         $(P Struct literals consist of the name of the struct followed
         by a parenthesized argument list:)
 
----
-struct S { int x; float y; }
+        ---
+        struct S { int x; float y; }
 
-int foo(S s) { return s.x; }
+        int foo(S s) { return s.x; }
 
-foo( S(1, 2) ); // set field x to 1, field y to 2
----
+        foo( S(1, 2) ); // set field x to 1, field y to 2
+        ---
 
         $(P Struct literals are syntactically like function calls.
         If a struct has a member function named $(CODE opCall), then
-        struct literals for that struct are not possible.
+        struct literals for that struct are not possible. See also
+        $(XLINK2 operatoroverloading.html#FunctionCall, opCall operator overloading)
+        for the issue workaround.
         It is an error if there are more arguments than fields of
         the struct.
         If there are fewer arguments than fields, the remaining


### PR DESCRIPTION
Explain both method `opCall` and `static opCall`, then describe how to resolve `opCall` vs struct literal syntax conflict.
