### PR TITLE
Fix getOverloads documentation

### DIFF
--- a/traits.dd
+++ b/traits.dd
@@ -396,10 +396,9 @@ void main() {
 
 $(H2 $(GNAME getOverloads))
 
-	$(P The first argument is a class type or an expression of
-	class type.
+	$(P The first argument is an aggregate (e.g. struct/class/module).
 	The second argument is a string that matches the name of
-	one of the functions of that class.
+	one of the functions in that aggregate.
 	The result is a tuple of all the overloads of that function.
 	)
 


### PR DESCRIPTION
Previously it said it only worked on classes. It actually works on structs and modules too.
