### PR TITLE
Add a section on Strings and Unicode

### DIFF
--- a/arrays.dd
+++ b/arrays.dd
@@ -840,24 +840,24 @@ d = 'd';     // d is assigned the character 'd'
 ---------
 
 $(H5 $(LNAME2 strings_unicode, Strings and Unicode))
-        $(P Note that built-in comparison operators operate on 
+        $(P Note that built-in comparison operators operate on a
         $(WEB www.unicode.org/glossary/#code_unit, code unit) basis. 
         The end result for valid strings is the same as that of 
         $(WEB www.unicode.org/glossary/#code_point, code point) 
         for $(WEB www.unicode.org/glossary/#code_point, code point)
-        comparision as long as both strings are in the same
+        comparison as long as both strings are in the same
         $(WEB www.unicode.org/glossary/#normalization_form, normalization form).
         Since normalization is a costly operation not suitable for language 
         primitives it's assumed to be enforced by the user.
         )
-        $(P Standard library lends a hand for comparing strings with mixed encodings
+        $(P The standard library lends a hand for comparing strings with mixed encodings
         (by transparently decoding, see $(PHOBOS algorithm, cmp, std.algorithm.cmp)), 
-        $(PHOBOS uni, icmp, case-insensitive comparision) and $(PHOBOS uni, normalize, normalization).
+        $(PHOBOS uni, icmp, case-insensitive comparison) and $(PHOBOS uni, normalize, normalization).
         )
         $(P The last but not least - a desired string sorting order differs 
         by culture and language and is usually nothing like code point 
         for code point comparison. The natural order of strings is obtained by applying
-        $(WEB www.unicode.org/reports/tr10/, unicode collation algorithm)
+        $(WEB www.unicode.org/reports/tr10/, the Unicode collation algorithm)
         that should be implemented in the standard library.
         )
 
@@ -952,5 +952,3 @@ Macros:
         WIKI=Arrays
         CATEGORY_SPEC=$0
         FOO=
-        WEB=$(LINK2 http://$1, $2)
-        PHOBOS=<a href="phobos/std_$1.html#$2">$3</a>

--- a/doc.ddoc
+++ b/doc.ddoc
@@ -436,6 +436,8 @@ GLINK2=$(DDSUBLINK $1,$2,$(I $2))
 DPLLINK=$(LINK2 $1,$+)
 GNAME=$(LNAME2 $0, $(I $0))
 NOT_EBOOK=$0
+WEB=$(LINK2 http://$1, $2)
+PHOBOS=<a href="phobos/std_$1.html#$2">$3</a>
 
 ASSIGNEXPRESSION=$(GLINK2 expression, AssignExpression)
 ISEXPRESSION=$(GLINK2 expression, IsExpression)


### PR DESCRIPTION
I'm not proud of wording but we need clarifications on how exactly builtins correlate to Unicode standard (if at all).
The "obvious meaning" present there previously is not good enough definition.

Along the way I fixed a bug in docs - H5 macro was used but not defined, effectively throwing away level-5 titles.

Why wouldn't DDoc complain about undefined macros instead of sliently eating them, that's a topic in its own right.

Preview of that page:
http://blackwhale.github.io/arrays.html#strings_unicode
