### PR TITLE
Fix the compilation instructions of phobos and compiler to use posix.mak on unix-like systems

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -1089,7 +1089,7 @@ make -f win32.mak
 $(UNIX
 $(CONSOLE
 cd ~/$(DMDDIR)/src/dmd
-make -f $(OS).mak
+make -f posix.mak
 )
 )
 
@@ -1112,7 +1112,7 @@ $(CONSOLE
 cd ~/$(DMDDIR)/src/druntime
 make -f posix.mak DMD=~/$(DMDDIR)/$(OS)/bin/dmd
 cd ../phobos
-make -f $(OS).mak DMD=~/$(DMDDIR)/$(OS)/bin/dmd
+make -f posix.mak DMD=~/$(DMDDIR)/$(OS)/bin/dmd
 )
 )
 


### PR DESCRIPTION
This fixes the instructions for the compiler and phobos that makes reference to `osx.mak` which was replaced by `posix.mak`.

Which tool can use to compile the docs website locally and check other issues?

Once you guys tell me how to compile the website locally, I can add these instructions to a Readme.md file so others can contribute more quickly.
