### PR TITLE
Optimize ordering of CSS links and scripts

### DIFF
--- a/doc.ddoc
+++ b/doc.ddoc
@@ -19,14 +19,13 @@ DDOC=
 <link rel="stylesheet" href="css/codemirror.css" />
 <link rel="stylesheet" type="text/css" href="css/style.css" />
 <link rel="stylesheet" type="text/css" href="css/print.css" media="print" />
+<link rel="shortcut icon" href="favicon.ico" />
+
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
 <script src="/js/codemirror.js"></script>
 <script src="/js/run-main-website.js" type="text/javascript"></script>
 <script src="/js/d.js"></script>
 <script src="/js/run.js" type="text/javascript"></script>
-
-<link rel="shortcut icon" href="favicon.ico" />
-
 <script src="/js/hyphenate.js" type="text/javascript"></script>
 
 <script type="text/javascript">

--- a/std.ddoc
+++ b/std.ddoc
@@ -49,12 +49,14 @@ DDOC = <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 <head>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" >
 <title>$(TITLE) - D Programming Language - Digital Mars</title>
+<link rel="stylesheet" type="text/css" href="../css/codemirror.css" />
+<link rel="stylesheet" type="text/css" href="../css/style.css">
+
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
 <script src="/js/codemirror.js"></script>
 <script src="/js/d.js"></script>
 <script src="/js/run.js" type="text/javascript"></script>
-<link rel="stylesheet" href="../css/codemirror.css" />
-<link rel="stylesheet" type="text/css" href="../css/style.css">
+<script src="/js/hyphenate.js" type="text/javascript"></script>
 
 <script type="text/javascript">
 function listanchors()
@@ -96,8 +98,6 @@ function listanchors()
     a.innerHTML = newText;
 }
 </script>
-
-<script src="/js/hyphenate.js" type="text/javascript"></script>
 
 </head>
 


### PR DESCRIPTION
Placing CSS links before all script tags allows the CSS to be loaded in parallel.
