### PR TITLE
Only use hyphenator.js on Chrome and Opera

### DIFF
--- a/chmgen.d
+++ b/chmgen.d
@@ -345,10 +345,6 @@ void main()
 					if (line.contains(`<script src="http://digg.com/tools/diggthis.js"`))
 						skip = true;
 
-					// skip hyphenation (bad performance in IE with large pages)
-					if (line.contains(`<script src="/js/hyphenate.js"`))
-						skip = true;
-
 					while (!skip && line.test(re_extern_js))
 					{
 						auto url = match.captures[1].replace(`\`, `/`);

--- a/css/style.css
+++ b/css/style.css
@@ -13,6 +13,23 @@ body
     margin: 0px auto;
 }
 
+.hyphenate
+{
+	-webkit-hyphens: auto;
+	-moz-hyphens: auto;
+	-ms-hyphens: auto;
+	hyphens: auto;
+}
+
+.donthyphenate
+{
+	-webkit-hyphens: manual;
+	-moz-hyphens: manual;
+	-ms-hyphens: manual;
+	hyphens: manual;
+}
+
+
 h1, h2, h3, h4, h5, h6
 {
 	font-family: Georgia, "Times New Roman", Times, serif;

--- a/doc.ddoc
+++ b/doc.ddoc
@@ -26,7 +26,7 @@ DDOC=
 <script src="/js/run-main-website.js" type="text/javascript"></script>
 <script src="/js/d.js"></script>
 <script src="/js/run.js" type="text/javascript"></script>
-<script src="/js/hyphenate.js" type="text/javascript"></script>
+<script src="/js/hyphenate-selectively.js" type="text/javascript"></script>
 
 <script type="text/javascript">
 function bodyLoad()

--- a/js/hyphenate-selectively.js
+++ b/js/hyphenate-selectively.js
@@ -1,0 +1,7 @@
+// CSS hyphens is supported by IE10+, Firefox 6+, and Safari 5.1+ so only
+// use hyphenator.js for Chrome where support is still missing completely (as
+// of Chrome 29) and Opera (which now uses Chrome's rendering engine Blink).
+var re = /(Chrome|Opera)/;
+if (re.test(navigator.userAgent)) {
+    document.write('<script src="/js/hyphenate.js" type="text/javascript"></script>');
+}

--- a/posix.mak
+++ b/posix.mak
@@ -42,7 +42,7 @@ search-left.gif search-bg.gif search-button.gif tdpl.jpg				\
 ubuntu_logo.png win32_logo.png)
 
 JAVASCRIPT=$(addprefix js/, codemirror.js d.js hyphenate.js	\
-run.js run-main-website.js)
+hyphenate-selectively.js run.js run-main-website.js)
 
 STYLES=css/style.css css/print.css css/codemirror.css
 

--- a/std.ddoc
+++ b/std.ddoc
@@ -56,7 +56,7 @@ DDOC = <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 <script src="/js/codemirror.js"></script>
 <script src="/js/d.js"></script>
 <script src="/js/run.js" type="text/javascript"></script>
-<script src="/js/hyphenate.js" type="text/javascript"></script>
+<script src="/js/hyphenate-selectively.js" type="text/javascript"></script>
 
 <script type="text/javascript">
 function listanchors()

--- a/std_consolidated_header.dd
+++ b/std_consolidated_header.dd
@@ -9,7 +9,7 @@ Ddoc
 <title>D Programming Language Standard Library</title>
 <link rel="stylesheet" type="text/css" href="http://dlang.org/css/style.css">
 
-<script src="/js/hyphenate.js" type="text/javascript"></script>
+<script src="/js/hyphenate-selectively.js" type="text/javascript"></script>
 
 </head>
 


### PR DESCRIPTION
All the other major browsers support CSS3 hyphens which is significantly faster.  hyphenator.js is supposed to fallback to CSS3 on browsers that support it but testing has shown it's still incredibly slow.
