### PR TITLE
[trivial] Use CSS classes instead of ids in changelog

### DIFF
--- a/changelog.d
+++ b/changelog.d
@@ -81,7 +81,7 @@ $(VERSION 075, Aug 2, 2012, =================================================,
     )
 )
 
-<div id=version>
+<div class="version">
 $(UL 
 	$(NEW1 075)
 	$(NEW1 074)
@@ -2332,7 +2332,7 @@ Macros:
 	NEW1 = $(LI What's new for <a href="#new1_$0">D 1.$0</a>)
 
 	VERSION=
-	<div id=version>
+	<div class="version">
 	$(B $(LARGE <a name="new1_$1">
 	  Version
 	  <a HREF="http://ftp.digitalmars.com/dmd.1.$1.zip" title="D 1.$1">D 1.$1</a>

--- a/changelog.dd
+++ b/changelog.dd
@@ -1985,7 +1985,7 @@ $(LI $(BUGZILLA 9302): Document extern properly)
 
 )
 
-<div id=version>
+<div class="version">
 $(UL
 	$(NEW 062)
 	$(NEW 061)
@@ -6290,7 +6290,7 @@ Macros:
 	NEW = $(LI Version <a href="#new2_$0">D 2.$0</a>)
 
 	VERSION=
-	<div id=version>
+	<div class="version">
 	$(B $(LARGE <a name="new2_$1">
 	  Version
 	  <a HREF="http://ftp.digitalmars.com/dmd.2.$1.zip" title="D 2.$1">D 2.$1</a>
@@ -6302,11 +6302,11 @@ Macros:
 	BUGZILLA = <a href="http://d.puremagic.com/issues/show_bug.cgi?id=$0">Bugzilla $0</a>
 	CPPBUGZILLA = <a href="http://bugzilla.digitalmars.com/issues/show_bug.cgi?id=$0">Bugzilla $0</a>
 	DSTRESS = dstress $0
-	BUGSFIXED = <div id="bugsfixed">$(H4 Bugs Fixed) $(UL $0 )</div>
-	DMDBUGSFIXED = <div id="bugsfixed">$(H4 DMD Bugs Fixed) $(UL $0 )</div>
-	LIBBUGSFIXED = <div id="bugsfixed">$(H4 Library Bugs Fixed) $(UL $0 )</div>
-	RUNTIMEBUGSFIXED = <div id="bugsfixed">$(H4 Druntime Bugs Fixed) $(UL $0 )</div>
-    BUGSTITLE = <div id="bugsfixed">$(H4 $1) $(OL $2 )</div>
+	BUGSFIXED = <div class="bugsfixed">$(H4 Bugs Fixed) $(UL $0 )</div>
+	DMDBUGSFIXED = <div class="bugsfixed">$(H4 DMD Bugs Fixed) $(UL $0 )</div>
+	LIBBUGSFIXED = <div class="bugsfixed">$(H4 Library Bugs Fixed) $(UL $0 )</div>
+	RUNTIMEBUGSFIXED = <div class="bugsfixed">$(H4 Druntime Bugs Fixed) $(UL $0 )</div>
+    BUGSTITLE = <div class="bugsfixed">$(H4 $1) $(OL $2 )</div>
 
 	UPCOMING = <div id="upcoming">$(H4 Under Construction) $(OL $0 )</div>
 	WHATSNEW = <div id="whatsnew">$(H4 New/Changed Features) $(UL $0 )</div>

--- a/css/style.css
+++ b/css/style.css
@@ -617,25 +617,25 @@ div#PostingTOC a
 }
 
 /* These are for the changelogs */
-div#version
+div.version
 {
 	border-top: 1px solid black;
 	font-size: 0.9em;
 	padding-top: 2ex;
 }
-div#version font
+div.version font
 {
 	font-family: Georgia, "Times New Roman", Times, serif;
 	color: #633;
 }
-div#version li
+div.version li
 {
 	padding-bottom: 0.3ex;
 }
-div#bugsfixed
+div.bugsfixed
 {
 }
-div#whatsnew
+div.whatsnew
 {
 }
 

--- a/ebook.css
+++ b/ebook.css
@@ -400,20 +400,20 @@ div#copyright
 
 
 /* These are for the changelogs */
-div#version
+div.version
 {
 	border-top: 1px solid black;
 	font-size: 0.9em;
 	padding-top: 2ex;
 }
-div#version li
+div.version li
 {
 	padding-bottom: 0.3ex;
 }
-div#bugsfixed
+div.bugsfixed
 {
 }
-div#whatsnew
+div.whatsnew
 {
 }
 


### PR DESCRIPTION
More than one element needs the styling so classes must be used instead
