### PR TITLE
[trivial] $LI() must wrap entire list item to generate valid HTML

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -65,7 +65,7 @@ $(HR)
 
 $(BUGSTITLE Language Changes,
 
-$(LI $(LNAME2 staticfields, Const and immutable fields with initializers are now warned about:))
+$(LI $(LNAME2 staticfields, Const and immutable fields with initializers are now warned about:)
 
 $(P Eventually, they will be deprecated, and then will trigger an error. Such fields should now
 be changed to enum or static.)
@@ -121,9 +121,9 @@ so you may prefer using $(D static) instead.)
 
 $(H3 Rationale:)
 
-$(P Making a field implicitly static based on whether it is const/immutable and has an initializer leads to confusion. The $(D static) keyword can be used to explicitly make any field static.)
+$(P Making a field implicitly static based on whether it is const/immutable and has an initializer leads to confusion. The $(D static) keyword can be used to explicitly make any field static.))
 
-$(LI $(LNAME2 ctorqualifier, Constructor qualifiers are taken into account when constructing objects:))
+$(LI $(LNAME2 ctorqualifier, Constructor qualifiers are taken into account when constructing objects:)
 
 $(P A qualified constructor is now invoked when a $(D const)/$(D immutable)/$(D shared) aggregate object is
     instantiated, respectively:)
@@ -199,8 +199,8 @@ void main()
     auto c3 = new shared C;  // ok
 }
 ---------
-
-$(LI $(LNAME2 structuralcompare, Struct members which require non-bitwise comparison are now properly compared.))
+)
+$(LI $(LNAME2 structuralcompare, Struct members which require non-bitwise comparison are now properly compared.)
 
 $(P In earlier releases some struct members such as arrays would be bitwise-compared in a comparison operation.
     This has now been changed to be a structural comparison instead:)
@@ -225,9 +225,9 @@ void main ()
 
 $(P If an $(D opEquals) function is not present the compiler rewrites the expression
     $(CODE s1 == s2) to $(CODE s1.tupleof == s2.tupleof). Comparing $(D .tupleof) expressions is
-    also a feature new to D in the 2.063 release.)
+    also a feature new to D in the 2.063 release.))
 
-$(LI $(LNAME2 slicecopy, Array copy operations now always require using the slice syntax:))
+$(LI $(LNAME2 slicecopy, Array copy operations now always require using the slice syntax:)
 
 $(P The right-hand-side of an array copy operation now requires using the slice syntax:)
 
@@ -258,9 +258,9 @@ void main()
 
 $(H3 Rationale:)
 
-$(P The compiler will emit a warning to make the user aware that the copy operation is arbitrarily expensive.)
+$(P The compiler will emit a warning to make the user aware that the copy operation is arbitrarily expensive.))
 
-$(LI $(LNAME2 passtype, Types no longer act as arguments in $(D typeof) expressions:))
+$(LI $(LNAME2 passtype, Types no longer act as arguments in $(D typeof) expressions:)
 
 $(P A type can no longer be passed to a function as a value of that type:)
 
@@ -296,9 +296,9 @@ void main()
 $(H3 Rationale:)
 
 $(P Treating types as expressions in special contexts only leads to confusion.
-Instead, the $(D .init) property can be used for such purposes.)
+Instead, the $(D .init) property can be used for such purposes.))
 
-$(LI $(LNAME2 foreachref, The index variable in a foreach range is no longer implicitly a reference:))
+$(LI $(LNAME2 foreachref, The index variable in a foreach range is no longer implicitly a reference:)
 
 $(P The index variable in a foreach range is now by default a value type:)
 
@@ -333,9 +333,9 @@ void main()
 
 $(H3 Rationale:)
 
-$(P Making the index variable implicitly $(D ref) can introduce bugs that are hard to track down.)
+$(P Making the index variable implicitly $(D ref) can introduce bugs that are hard to track down.))
 
-$(LI $(LNAME2 hashentry, Associative array entries are no longer default-initialized before assignment:))
+$(LI $(LNAME2 hashentry, Associative array entries are no longer default-initialized before assignment:)
 
 $(P An associative array entry used to be default-initialized before assignment took place:)
 
@@ -360,9 +360,9 @@ void main()
 
 $(H3 Rationale:)
 
-$(P Default-initialization during assignment can be a source of bugs.)
+$(P Default-initialization during assignment can be a source of bugs.))
 
-$(LI $(LNAME2 constinherit, The const attribute is no longer inherited in overriden methods.))
+$(LI $(LNAME2 constinherit, The const attribute is no longer inherited in overriden methods.)
 
 $(P Method overrides no longer inherit constness of the base method:)
 
@@ -415,9 +415,9 @@ class B : A
     override void foo() const { }
 }
 ---------
+)
 
-
-$(LI $(LNAME2 typeofnullconv, $(D typeof(null)) no longer implicitly converts to T[]:))
+$(LI $(LNAME2 typeofnullconv, $(D typeof(null)) no longer implicitly converts to T[]:)
 
 $(P The following code used to be allowed:)
 
@@ -454,8 +454,8 @@ void main()
     f(() => (int[]).init);  // ok
 }
 ---------
-
-$(LI $(LNAME2 templatethisattrib, The Template This Parameter now changes the member function qualifier:))
+)
+$(LI $(LNAME2 templatethisattrib, The Template This Parameter now changes the member function qualifier:)
 
 $(P The $(LINK2 template.html#TemplateThisParameter, Template This Parameter) can now be used to infer
 the qualifier of $(D this) to member functions:)
@@ -474,8 +474,8 @@ void main()
      s.foo();  // makes S.foo immutable
 }
 ---------
-
-$(LI $(LNAME2 sliceref, Array slices are now r-values:))
+)
+$(LI $(LNAME2 sliceref, Array slices are now r-values:)
 
 $(P Array slices are no longer l-values. This means an address can no longer be
 taken of a slice, and slices cannot be passed by ref to functions:)
@@ -543,8 +543,8 @@ void main()
     assert(arr.length == 4);
 }
 ---------
-
-$(LI $(LNAME2 thisrefaccess, Accessing a non-static field without a $(D this) reference is only allowed in certain contexts:))
+)
+$(LI $(LNAME2 thisrefaccess, Accessing a non-static field without a $(D this) reference is only allowed in certain contexts:)
 
 $(P Accessing non-static fields used to be allowed in many contexts, but is now limited to only a few:)
 
@@ -599,8 +599,8 @@ void main()
     static assert(Foo.get() == 0);  // ok, equivalent to 'typeof(Foo.bar).get()'
 }
 ---------
-
-$(LI $(LNAME2 implicitarrayptr, Arrays no longer implicitly convert to a pointer:))
+)
+$(LI $(LNAME2 implicitarrayptr, Arrays no longer implicitly convert to a pointer:)
 
 $(P The implicit conversion of an array to a pointer was a deprecated feature:)
 
@@ -628,11 +628,10 @@ void main()
     foo(&arr[0]);  // ok
 }
 ---------
-)
-
+))
 $(BUGSTITLE Language Enhancements,
 
-$(LI $(LNAME2 uniqueinference, Expressions which return unique objects can be implicitly casted to immutable:))
+$(LI $(LNAME2 uniqueinference, Expressions which return unique objects can be implicitly casted to immutable:)
 
 $(P Expressions such as $(D new) for objects and arrays, and $(D dup) for arrays, can now be inferred to be unique.
     This allows the compiler to implicitly convert such an expression to immutable:)
@@ -647,8 +646,8 @@ void main()
     immutable C[] arr3 = [new C, new C].dup;  // ok in 2.063
 }
 ---------
-
-$(LI $(LNAME2 staticarrayvoid, Static array of void can now be user-initialized.))
+)
+$(LI $(LNAME2 staticarrayvoid, Static array of void can now be user-initialized.)
 
 $(P A static array of void could not be initialized in user-code:)
 
@@ -677,9 +676,9 @@ $(P The $(D .init) property effectively zero-initializes the array.)
 $(H3 Rationale:)
 
 $(P The restriction has been lifted to allow generic code to use $(D .init) without
-having to specialize for static void arrays.)
+having to specialize for static void arrays.))
 
-$(LI $(LNAME2 multiinvariant, Aggregates can now contain multiple invariants:))
+$(LI $(LNAME2 multiinvariant, Aggregates can now contain multiple invariants:)
 
 $(P If an aggregate type has multiple invariants, the invariants' bodies will be merged
     into a single invariant function and will be run in sequence. Note that the code in
@@ -711,8 +710,8 @@ void main()
     s.foo();  // invoking public function triggers both invariants in sequence
 }
 ---------
-
-$(LI $(LNAME2 attribinference, Methods of templated aggregates can now infer attributes:))
+)
+$(LI $(LNAME2 attribinference, Methods of templated aggregates can now infer attributes:)
 
 $(P If a function with some attributes instantiates a templated aggregate,
     it's member functions will infer those attributes:)
@@ -732,8 +731,8 @@ void main() pure
     assert(s.square(2) == 4);  // ok
 }
 ---------
-
-$(LI $(LNAME2 isexpident, $(B is expression) no longer requires an identifier:))
+)
+$(LI $(LNAME2 isexpident, $(B is expression) no longer requires an identifier:)
 
 $(P In some cases the $(LINK2 expression.html#IsExpression, is expression) required an
     identifier even when you didn't have a use for it:)
@@ -767,8 +766,8 @@ void main()
     }
 }
 ---------
-
-$(LI $(LNAME2 implicitarraycast, Dynamic arrays of known size can be implicitly cast to static arrays in some contexts:))
+)
+$(LI $(LNAME2 implicitarraycast, Dynamic arrays of known size can be implicitly cast to static arrays in some contexts:)
 
 $(P In some contexts the compiler knows the size of a dynamic array or of a slice of an array.
     In such a case the compiler will allow an implicit conversion to a static array of the same size:)
@@ -816,8 +815,8 @@ void main()
     }
 }
 ---------
-
-$(LI $(LNAME2 tupleinitvoid, Tuples can now be void-initialized:))
+)
+$(LI $(LNAME2 tupleinitvoid, Tuples can now be void-initialized:)
 
 $(P You can now void-initialize a tuple variable:)
 
@@ -833,9 +832,9 @@ void main()
 }
 ---------
 
-$(P Upon such initialization the values in the tuple are undetermined.)
+$(P Upon such initialization the values in the tuple are undetermined.))
 
-$(LI $(LNAME2 templconstraint, Template constraints can now be put after the inheritance list:))
+$(LI $(LNAME2 templconstraint, Template constraints can now be put after the inheritance list:)
 
 $(P Template constraints used to be allowed only before the inheritance list, leading to
     code where the inheritance list could be hard to spot:)
@@ -855,8 +854,8 @@ class Foo(T1, T2) : Base
 {
 }
 ---------
-
-$(LI $(LNAME2 tupleequality, Tuples can now be compared for equality:))
+)
+$(LI $(LNAME2 tupleequality, Tuples can now be compared for equality:)
 
 $(P Example:)
 
@@ -956,8 +955,8 @@ void main()
     assert(s1 == s2);
 }
 ---------
-
-$(LI $(LNAME2 initfield, Fields with initializers can now be re-initialized in a const constructor:))
+)
+$(LI $(LNAME2 initfield, Fields with initializers can now be re-initialized in a const constructor:)
 
 $(P You can now initialize a field in a const constructor even if
     such a field already has an initializer:)
@@ -973,8 +972,8 @@ struct S
     }
 }
 ---------
-
-$(LI $(LNAME2 isnestedtrait, Added the $(B isNested) trait for discovery of aggregates and functions with context pointers:))
+)
+$(LI $(LNAME2 isnestedtrait, Added the $(B isNested) trait for discovery of aggregates and functions with context pointers:)
 
 $(P The new $(XLINK2 traits.html#isNested, isNested) trait allows you to discover whether an aggregate or function
     contains a context pointer:)
@@ -996,7 +995,7 @@ void main()
     static assert(!__traits(isNested, f2));
 }
 ---------
-
+)
 $(LI $(LNAME2 nestedtemplate, Templates can now be nested inside of functions:))
 
 ---------
@@ -1010,7 +1009,7 @@ void test()
 $(P Allowing $(D template)'s inside of functions will enable better encapsulation and avoid the
     pollution of module-scoped symbol names.)
 
-$(LI $(LNAME2 ufcslocalimport, UFCS now works with scoped local imports:))
+$(LI $(LNAME2 ufcslocalimport, UFCS now works with scoped local imports:)
 
 $(P Functions that are made available through a local import are now picked up when using Uniform Function Call Syntax:)
 
@@ -1029,9 +1028,9 @@ void main()
 ---------
 
 $(P This feature also works for imports within aggregates. Note that local imports have a higher precedence than
-    module-scoped imports.)
+    module-scoped imports.))
 
-$(LI $(LNAME2 prettyfunc, Added $(D __FUNCTION__), $(D __PRETTY_FUNCTION__) and $(D __MODULE__):))
+$(LI $(LNAME2 prettyfunc, Added $(D __FUNCTION__), $(D __PRETTY_FUNCTION__) and $(D __MODULE__):)
 
 $(P A new set of $(LINK2 traits.html#specialkeywords, special keywords) were added. Together with $(D __FILE__) and $(D __LINE__) they form a complete feature set that is useful in debugging code:)
 
@@ -1058,9 +1057,9 @@ $(P The above will output:)
 $(CONSOLE
 file: 'test.d', line: '13', module: 'test',
 function: 'test.main', pretty function: 'int test.main(string[] args)'
-)
+))
 
-$(LI $(LNAME2 deprecatedmacro, DDoc: Deprecated declarations are now wrapped in a $(B DEPRECATED) macro:))
+$(LI $(LNAME2 deprecatedmacro, DDoc: Deprecated declarations are now wrapped in a $(B DEPRECATED) macro:)
 
 ---------
 module test;
@@ -1081,9 +1080,9 @@ $(P The above ddoc file can then be used when the documentation is being generat
 
 $(CONSOLE
 $ dmd -D -o- test.d macros.ddoc
-)
+))
 
-$(LI $(LNAME2 documentedunittest, Added documented unittest feature for verifiable code example generation:))
+$(LI $(LNAME2 documentedunittest, Added documented unittest feature for verifiable code example generation:)
 
 $(P Documented unittests which follow any symbol declarations are now used to generate example sections for the symbol
     when generating DDOC documentation. Example:)
@@ -1104,11 +1103,11 @@ $(P The body of the unittest will be part of the documentation of the sum functi
 
 $(P For more information, see the $(LINK2 unittest.html#documented-unittests, documentation page) of documented unittests.)
 
-)
+))
 
 
 $(BUGSTITLE Compiler Enhancements,
-$(LI $(LNAME2 mainswitch, Added -main switch which adds an empty main function:))
+$(LI $(LNAME2 mainswitch, Added -main switch which adds an empty main function:)
 
 $(P The $(B -main) switch is primarily useful when unittesting libraries:)
 
@@ -1127,9 +1126,9 @@ $(P The above library would need a $(B main()) function for the unittests to run
 
 $(CONSOLE
 $ dmd -unittest -main -run test.d
-)
+))
 
-$(LI $(LNAME2 minimalcov, Added -cov=percentage switch for minimal coverage tests.))
+$(LI $(LNAME2 minimalcov, Added -cov=percentage switch for minimal coverage tests.)
 
 $(P The $(B -cov) switch now has an optional percentage setting which makes the
     executable emit an error when the coverage doesn't meet the specified requirement:)
@@ -1154,9 +1153,9 @@ $(CONSOLE
 $ dmd -cov=90 test.d
 $ test
 Error: test.d is 80% covered, less than required 90%
-)
+))
 
-$(LI $(LNAME2 symbolmangle, Added ability to override the mangling of a symbol with a compiler pragma:))
+$(LI $(LNAME2 symbolmangle, Added ability to override the mangling of a symbol with a compiler pragma:)
 
 $(P The new $(CODE pragma(mangle, ...)) directive allows you to set a custom mangling for any symbol:)
 
@@ -1167,11 +1166,11 @@ pragma(mangle, "module") extern(C) void module_();
 $(P The above allows linking to a C function named "module", which ordinarily we wouldn't be
     able to link to directly since "module" is a reserved D keyword.)
 
-)
+))
 
 $(BUGSTITLE Phobos Changes,
 
-$(LI $(LNAME2 scopedtypeof, std.typecons.scoped implementation changed, potentially breaking some user-code:))
+$(LI $(LNAME2 scopedtypeof, std.typecons.scoped implementation changed, potentially breaking some user-code:)
 
 $(P User-code which used the $(D std.traits.ReturnType) trait to retrieve the type of a $(D scoped) call will have to be
     changed to use the $(D typeof) operator instead:)
@@ -1213,17 +1212,17 @@ void main()
 }
 ---------
 
-)
+))
 
 $(BUGSTITLE Phobos Enhancements,
 
-$(LI $(LNAME2 newstdprocess, $(STDMODREF process, std.process) has been redesigned from the ground up and introduces a new API and functionality:))
+$(LI $(LNAME2 newstdprocess, $(STDMODREF process, std.process) has been redesigned from the ground up and introduces a new API and functionality:)
 
 $(P The new $(STDMODREF process, std.process) module introduces functionality for invoking processes with custom pipe redirection,
 the ability to wait for processes to finish, and the ability to kill processes. The full list of features
-can be found in the $(STDMODREF process, std.process) documentation.)
+can be found in the $(STDMODREF process, std.process) documentation.))
 
-$(LI $(LNAME2 getoptbool, $(STDMODREF getopt, std.getopt) can now set booleans to false:))
+$(LI $(LNAME2 getoptbool, $(STDMODREF getopt, std.getopt) can now set booleans to false:)
 
 $(P Example code:)
 
@@ -1235,9 +1234,9 @@ void main(string[] args)
 }
 ---------
 
-$(P When invoked via $(CODE --flag=false), it will set $(B flag) to $(D false).)
+$(P When invoked via $(CODE --flag=false), it will set $(B flag) to $(D false).))
 
-$(LI $(LNAME2 ownertid, Added ownerTid property in $(STDMODREF concurrency, std.concurrency):))
+$(LI $(LNAME2 ownertid, Added ownerTid property in $(STDMODREF concurrency, std.concurrency):)
 
 $(P It is now easier to send a message from a child thread to its
 owner thread. Simply use the $(B ownerTid) property to get the owner
@@ -1265,7 +1264,7 @@ void main()
 $(P If the owner thread has exited, accessing ownerTid from any
     of its child threads will throw a $(B TidMissingException).)
 
-)
+))
 
 $(BR)$(BIG $(LNAME2 list2063, List of all bug fixes and enhancements in D 2.063:))
 


### PR DESCRIPTION
It was outputting something like:

```
<ol>
  <li>...</li>
  <p>...</p> <!-- p can not be a child of ol -->
  <li>...</li>
  <p>...</p> <!-- p can not be a child of ol -->
</ol>
```

Which is invalid (though browsers managed to cope with the error visually).
