### PR TITLE
Kill introduced again deprecated `WEB` macro.

### DIFF
--- a/arrays.dd
+++ b/arrays.dd
@@ -841,12 +841,12 @@ d = 'd';     // d is assigned the character 'd'
 
 $(H5 $(LNAME2 strings_unicode, Strings and Unicode))
         $(P Note that built-in comparison operators operate on a
-        $(WEB goo.gl/zRY1K, code unit) basis. 
+        $(HTTP goo.gl/zRY1K, code unit) basis. 
         The end result for valid strings is the same as that of 
-        $(WEB goo.gl/WR424, code point) 
-        for $(WEB goo.gl/WR424, code point)
+        $(HTTP goo.gl/WR424, code point) 
+        for $(HTTP goo.gl/WR424, code point)
         comparison as long as both strings are in the same
-        $(WEB goo.gl/3DKfI, normalization form).
+        $(HTTP goo.gl/3DKfI, normalization form).
         Since normalization is a costly operation not suitable for language 
         primitives it's assumed to be enforced by the user.
         )
@@ -857,7 +857,7 @@ $(H5 $(LNAME2 strings_unicode, Strings and Unicode))
         $(P Last but not least, a desired string sorting order differs 
         by culture and language and is usually nothing like code point 
         for code point comparison. The natural order of strings is obtained by applying
-        $(WEB www.unicode.org/reports/tr10/, the Unicode collation algorithm)
+        $(HTTP www.unicode.org/reports/tr10/, the Unicode collation algorithm)
         that should be implemented in the standard library.
         )
 

--- a/doc.ddoc
+++ b/doc.ddoc
@@ -435,7 +435,6 @@ GLINK2=$(DDSUBLINK $1,$2,$(I $2))
 DPLLINK=$(LINK2 $1,$+)
 GNAME=$(LNAME2 $0, $(I $0))
 NOT_EBOOK=$0
-WEB=$(LINK2 http://$1, $2)
 PHOBOS=<a href="phobos/std_$1.html#$2">$3</a>
 
 ASSIGNEXPRESSION=$(GLINK2 expression, AssignExpression)


### PR DESCRIPTION
This is a fixup for pull request #349.
#### P.S.

Sorry for being this late.
