### PR TITLE
Updated links to the existing documentation approaches

### DIFF
--- a/ddoc.dd
+++ b/ddoc.dd
@@ -21,7 +21,7 @@ $(UL
 $(LI $(LINK2 http://www.stack.nl/~dimitri/doxygen, Doxygen) which already has some support for D)
 $(LI Java's $(LINK2 http://docs.oracle.com/javase/7/docs/technotes/guides/javadoc/index.html, Javadoc),
  probably the most well-known)
-$(LI C$(HASH)'s $(LINK2 http://http://msdn.microsoft.com/en-us/library/b2s063f7.aspx, embedded XML))
+$(LI C$(HASH)'s $(LINK2 http://msdn.microsoft.com/en-us/library/b2s063f7.aspx, embedded XML))
 $(LI Other $(LINK2 http://python.org/sigs/doc-sig/otherlangs.html, documentation tools))
 )
 


### PR DESCRIPTION
The links for Javadoc and embedded XML were broken and lead to void. They have been replaced with working ones.
