### PR TITLE
Remove section in style guide about comments.

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -27,68 +27,6 @@ $(UL
     $(LI Each indentation level will be four columns.)
 )
 
-$(H3 Comments)
-
-$(UL
-    $(LI Use // comments to document a single line:
--------------------------------
-statement;  // comment
-statement;  // comment
--------------------------------
-    )
-
-    $(LI Use block comments to document a multiple line block of
-    statements:
--------------------------------
-/* comment
- * comment
- */
- statement;
- statement;
--------------------------------
-    )
-
-    $(LI Use $(CODE version (none)) to $(SINGLEQUOTE comment out) a piece of trial code
-    that is syntactically valid:
--------------------------------
-  version (none)
-  {
-    /* comment
-     * comment
-     */
-     statement;
-     statement;
-  }
--------------------------------
-
-    It can be turned on with $(CODE version(all)):
-
--------------------------------
-  version (all)
-  {
-    /* comment
-     * comment
-     */
-     statement;
-     statement;
-  }
--------------------------------
-
-    )
-
-    $(LI Use nesting comments to $(SINGLEQUOTE comment out) a piece of syntactically invalid code:
--------------------------------
-/+++++
-    /* comment
-     * comment
-     */
-     { statement;
-       statement;
- +++++/
--------------------------------
-    )
-)
-
 $(H3 Naming Conventions)
 
 $(DL


### PR DESCRIPTION
This has been bugging me for a while, so I'm just creating this pull request to get rid of the comments section in the style guide. It has no business being there IMHO.

We don't really follow the guidelines on comments, and some of them are
arguably outright bad (e.g. using version(none) does not play nicely
with syntax highlighting, since the code appears to be active unlike
when it's commented out). There was some agreement on this when I
brought it up in the past, but for the most part, no one even responded
to attempted discussions on it. But since we don't really follow the
comment guideliness, and they _are_ bad in at least one case, I think
that it's far better to just remove them. The only case where we even
get any dispute about comments at this point is whether ddoc comments
should use /++ +/ or /*\* */ and the comment guidelines don't discuss
that.
