### PR TITLE
Workaround: chm generation raises error because hhc.exe returns 1 upon s...

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -329,7 +329,7 @@ d.hhp d.hhc d.hhk : chmgen.exe $(TARGETS)
 	chmgen
 
 d.chm : d.hhp d.hhc d.hhk
-	cmd /C ""$(HHC)" d.hhp || echo."
+	-cmd /C ""$(HHC)" d.hhp"
 
 ################# Other #########################
 


### PR DESCRIPTION
...uccess.
