### PR TITLE
add Visual D to download page

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -7,7 +7,7 @@ src="/images/github-ribbon.png" alt="Fork D on GitHub"></a>
 
 $(D_S Downloads,
 
-$(TABLE2 DMD - Digital Mars D Programming Language version 2,
+$(TABLEDL DMD - Digital Mars D Programming Language version 2,
 
 	$(TR
 	$(TH Download)
@@ -97,10 +97,107 @@ $(TABLE2 DMD - Digital Mars D Programming Language version 2,
 	$(TD other dmd 2.0 versions)
 	)
 )
+
 $(BR)
 $(BR)
 
-$(TABLE2 DMD - Digital Mars D Programming Language version 1 (please note: official support for D1 has been discontinued effective December 31, 2012),
+$(TABLEDL GDC - D Programming Language for GCC,
+	$(TR
+	$(TH Download)
+	$(TH Version)
+	$(TH CPU)
+	$(TH Operating System(s))
+	$(TH Product)
+	)
+
+	$(TR
+	 $(TDL $(LINK2 https://bitbucket.org/goshawk/gdc/downloads, GDC))
+	 $(TD Latest stable)
+	 $(TD i386, x86_64)
+	 $(TD $(WIN32))
+	 $(TD GNU D Compiler)
+	)
+
+	$(TR
+	 $(TDL $(LINK2 https://github.com/D-Programming-GDC/GDC, GDC))
+	 $(TD HEAD)
+	 $(TD i386, x86_64, armel, armhf, mips, mipsel, powerpc, ia64, s390, sparc)
+	 $(TD $(WIN32) $(LINUX) $(OSX) $(FREEBSD))
+	 $(TD GNU D Compiler)
+	)
+)
+
+$(BR)
+$(BR)
+
+$(TABLEDL LDC - the LLVM-based D compiler,
+	$(TR
+	$(TH Download)
+	$(TH Version)
+	$(TH CPU)
+	$(TH Operating System(s))
+	$(TH Product)
+	)
+
+	$(TR
+	 $(TDL $(LINK2 http://d32gngvpvl2pi1.cloudfront.net/ldc2-0.11.0-linux-x86_64.tar.gz, ldc2-0.11.0-linux-x86_64.tar.gz))
+	 $(TD 0.11.0 &#40;2.062&#41;)
+	 $(TD x86_64)
+	 $(TD $(LINUX))
+	 $(TD LDC 64-bit Linux binaries)
+	)
+
+	$(TR
+	 $(TDL $(LINK2 http://d32gngvpvl2pi1.cloudfront.net/ldc2-0.11.0-linux-x86.tar.gz, ldc2-0.11.0-linux-x86.tar.gz))
+	 $(TD 0.11.0 &#40;2.062&#41;)
+	 $(TD i386)
+	 $(TD $(LINUX))
+	 $(TD LDC 32-bit Linux binaries)
+	)
+
+	$(TR
+	 $(TDL $(LINK2 http://d32gngvpvl2pi1.cloudfront.net/ldc2-0.11.0-osx-x86_64.tar.gz, ldc2-0.11.0-osx-x86_64.tar.gz))
+	 $(TD 0.11.0 &#40;2.062&#41;)
+	 $(TD x86_64)
+	 $(TD $(OSX))
+	 $(TD LDC Mac OS X 10.7+ binaries)
+	)
+
+	$(TR
+	 $(TDL $(LINK2 http://d32gngvpvl2pi1.cloudfront.net/ldc-0.11.0-src.tar.gz, ldc-0.11.0-src.tar.gz))
+	 $(TD 0.11.0 &#40;2.062&#41;)
+	 $(TD i386, x86_64)
+	 $(TD $(LINUX) $(OSX))
+	 $(TD LDC source)
+	)
+)
+
+$(BR)
+$(BR)
+
+$(TABLEDL IDE Support,
+	$(TR
+	$(TH Download)
+	$(TH Version)
+	$(TH CPU)
+	$(TH Operating System(s))
+	$(TH Product)
+	)
+
+	$(TR
+	 $(TDL $(LINK2 http://www.dsource.org/projects/visuald/browser/downloads/VisualD-v0.3.36.exe?format=raw&FixForIE=.exe, VisualD-v0.3.36.exe))
+	 $(TD 0.3.36)
+	 $(TD i386)
+	 $(TD $(WIN32))
+	 $(TD Visual D, plugin for VS 2005-12)
+	)
+)
+
+$(BR)
+$(BR)
+
+$(TABLEDL DMD - Digital Mars D Programming Language version 1 $(BR)
+ (please note: official support for D1 has been discontinued effective December 31, 2012),
 	$(TR
 	$(TH Download)
 	$(TH Version)
@@ -209,7 +306,7 @@ $(TABLE2 DMD - Digital Mars D Programming Language version 1 (please note: offic
 $(BR)
 $(BR)
 
-$(TABLE2 DMC - Digital Mars C and C++ Compiler,
+$(TABLEDL DMC - Digital Mars C and C++ Compiler,
 	$(TR
 	$(TH Download)
 	$(TH Version)
@@ -227,80 +324,6 @@ $(TABLE2 DMC - Digital Mars C and C++ Compiler,
 	)
 
 )
-
-$(BR)
-$(BR)
-
-	$(TABLE2 GDC - D Programming Language for GCC,
-	$(TR
-	$(TH Download)
-	$(TH Version)
-	$(TH CPU)
-	$(TH Operating System(s))
-	$(TH Product)
-	)
-
-	$(TR
-	 $(TDL $(LINK2 https://bitbucket.org/goshawk/gdc/downloads, GDC))
-	 $(TD Latest stable)
-	 $(TD i386, x86_64)
-	 $(TD $(WIN32))
-	 $(TD GNU D Compiler)
-	)
-
-	$(TR
-	 $(TDL $(LINK2 https://github.com/D-Programming-GDC/GDC, GDC))
-	 $(TD HEAD)
-	 $(TD i386, x86_64, armel, armhf, mips, mipsel, powerpc, ia64, s390, sparc)
-	 $(TD $(WIN32) $(LINUX) $(OSX) $(FREEBSD))
-	 $(TD GNU D Compiler)
-	)
-	)
-
-$(BR)
-$(BR)
-
-	$(TABLE2 LDC - the LLVM-based D compiler,
-	$(TR
-	$(TH Download)
-	$(TH Version)
-	$(TH CPU)
-	$(TH Operating System(s))
-	$(TH Product)
-	)
-
-	$(TR
-	 $(TDL $(LINK2 http://d32gngvpvl2pi1.cloudfront.net/ldc2-0.11.0-linux-x86_64.tar.gz, ldc2-0.11.0-linux-x86_64.tar.gz))
-	 $(TD 0.11.0 &#40;2.062&#41;)
-	 $(TD x86_64)
-	 $(TD $(LINUX))
-	 $(TD LDC 64-bit Linux binaries)
-	)
-
-	$(TR
-	 $(TDL $(LINK2 http://d32gngvpvl2pi1.cloudfront.net/ldc2-0.11.0-linux-x86.tar.gz, ldc2-0.11.0-linux-x86.tar.gz))
-	 $(TD 0.11.0 &#40;2.062&#41;)
-	 $(TD i386)
-	 $(TD $(LINUX))
-	 $(TD LDC 32-bit Linux binaries)
-	)
-
-	$(TR
-	 $(TDL $(LINK2 http://d32gngvpvl2pi1.cloudfront.net/ldc2-0.11.0-osx-x86_64.tar.gz, ldc2-0.11.0-osx-x86_64.tar.gz))
-	 $(TD 0.11.0 &#40;2.062&#41;)
-	 $(TD x86_64)
-	 $(TD $(OSX))
-	 $(TD LDC Mac OS X 10.7+ binaries)
-	)
-
-	$(TR
-	 $(TDL $(LINK2 http://d32gngvpvl2pi1.cloudfront.net/ldc-0.11.0-src.tar.gz, ldc-0.11.0-src.tar.gz))
-	 $(TD 0.11.0 &#40;2.062&#41;)
-	 $(TD i386, x86_64)
-	 $(TD $(LINUX) $(OSX))
-	 $(TD LDC source)
-	)
-    )
 
 $(SECTION2 Documentation Downloads,
 
@@ -380,3 +403,4 @@ Macros:
 	TDL=<td style="text-align: left;">$0</td>
     TH=<th class='donthyphenate'>$0</th>
 	CATEGORY_DOWNLOAD=$0
+	TABLEDL = <center><table width="100%" border=1 cellpadding=4 cellspacing=0><caption>$(H2 $1)</caption>$+</table></center>


### PR DESCRIPTION
current link is still to dsource
in addition moves GDC/LDC up
change table header size and fit table to width

see the result here: http://rainers.github.io/visuald/download.html
