### PR TITLE
Clarify: char is UTF8 code unit

### DIFF
--- a/type.dd
+++ b/type.dd
@@ -28,9 +28,9 @@ $(SECTION3 Basic Data Types,
     $(TROW $(D cfloat), $(D float.nan+float.nan*1.0i), a complex number of two float values)
     $(TROW $(D cdouble), $(D double.nan+double.nan*1.0i), complex double)
     $(TROW $(D creal), $(D real.nan+real.nan*1.0i), complex real)
-    $(TROW $(D char), $(D 0xFF), unsigned 8 bit UTF-8)
-    $(TROW $(D wchar), $(D 0xFFFF), unsigned 16 bit UTF-16)
-    $(TROW $(D dchar), $(D 0x0000FFFF), unsigned 32 bit UTF-32)
+    $(TROW $(D char), $(D 0xFF), unsigned 8 bit, UTF-8 code unit)
+    $(TROW $(D wchar), $(D 0xFFFF), unsigned 16 bit, UTF-16 code unit)
+    $(TROW $(D dchar), $(D 0x0000FFFF), unsigned 32 bit, UTF-32 code unit)
     )
 )
 


### PR DESCRIPTION
Clarify that 'char' is supposed to be a UTF-8 **code unit**.

Personally, I was confused what the "UTF-8" should mean there. The contrast to 'ubyte' is still not that clear, though.
