### PR TITLE
bar.obj should be abc.obj

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -1020,7 +1020,7 @@ $(H2 $(LNAME2 library, Building Libraries))
 
 	$(P There are three ways to build a library. For example,
 	given $(D foo.d) and $(D bar.d) which are to be compiled, and existing
-	object file $(D bar.$(OBJEXT)) and existing library
+	object file $(D abc.$(OBJEXT)) and existing library
 	$(D def.$(LIBEXT)) which are
 	all to be combined into a library $(D foo.$(LIBEXT)):)
 


### PR DESCRIPTION
From http://dlang.org/dmd-windows.html , we see "Building Libraries" section, "and existing object file bar.obj and existing library", bar.obj should be abc.obj
