### PR TITLE
Update LDC download links to 0.12.0.

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -140,35 +140,43 @@ $(TABLEDL LDC - the LLVM-based D compiler,
 	)
 
 	$(TR
-	 $(TDL $(LINK2 http://d32gngvpvl2pi1.cloudfront.net/ldc2-0.11.0-linux-x86_64.tar.gz, ldc2-0.11.0-linux-x86_64.tar.gz))
-	 $(TD 0.11.0 &#40;2.062&#41;)
-	 $(TD x86_64)
-	 $(TD $(LINUX))
-	 $(TD LDC 64-bit Linux binaries)
+	 $(TDL $(LINK2 https://github.com/ldc-developers/ldc/releases/download/v0.12.0/ldc2-0.12.0-mingw-x86.zip, ldc2-0.12.0-mingw-x86.zip (19&thinsp;MB)), $(LINK2 https://github.com/ldc-developers/ldc/releases/download/v0.12.0/ldc2-0.12.0-mingw-x86.7z, .7z (9&thinsp;MB)))
+	 $(TD 0.12.0 &#40;2.063.2&#41;)
+	 $(TD i386)
+	 $(TD $(WIN32))
+	 $(TD LDC Win32 mingw-w64 binaries (see README.txt!))
 	)
 
 	$(TR
-	 $(TDL $(LINK2 http://d32gngvpvl2pi1.cloudfront.net/ldc2-0.11.0-linux-x86.tar.gz, ldc2-0.11.0-linux-x86.tar.gz))
-	 $(TD 0.11.0 &#40;2.062&#41;)
+	 $(TDL $(LINK2 https://github.com/ldc-developers/ldc/releases/download/v0.12.0/ldc2-0.12.0-osx-x86_64.tar.gz, ldc2-0.12.0-osx-x86_64.tar.gz (28&thinsp;MB)), $(LINK2 https://github.com/ldc-developers/ldc/releases/download/v0.12.0/ldc2-0.12.0-osx-x86_64.tar.xz, .tar.xz (12&thinsp;MB)))
+	 $(TD 0.12.0 &#40;2.063.2&#41;)
+	 $(TD x86_64)
+	 $(TD $(OSX))
+	 $(TD LDC Mac OS&nbsp;X 10.7+ binaries)
+	)
+
+	$(TR
+	 $(TDL $(LINK2 https://github.com/ldc-developers/ldc/releases/download/v0.12.0/ldc2-0.12.0-linux-x86.tar.gz, ldc2-0.12.0-linux-x86.tar.gz (18&thinsp;MB)), $(LINK2 https://github.com/ldc-developers/ldc/releases/download/v0.12.0/ldc2-0.12.0-linux-x86.tar.xz, .tar.xz (9&thinsp;MB)))
+	 $(TD 0.12.0 &#40;2.063.2&#41;)
 	 $(TD i386)
 	 $(TD $(LINUX))
 	 $(TD LDC 32-bit Linux binaries)
 	)
 
 	$(TR
-	 $(TDL $(LINK2 http://d32gngvpvl2pi1.cloudfront.net/ldc2-0.11.0-osx-x86_64.tar.gz, ldc2-0.11.0-osx-x86_64.tar.gz))
-	 $(TD 0.11.0 &#40;2.062&#41;)
+	 $(TDL $(LINK2 https://github.com/ldc-developers/ldc/releases/download/v0.12.0/ldc2-0.12.0-linux-x86_64.tar.gz, ldc2-0.12.0-linux-x86_64.tar.gz (29&thinsp;MB)), $(LINK2 https://github.com/ldc-developers/ldc/releases/download/v0.12.0/ldc2-0.12.0-linux-x86_64.tar.xz, .tar.xz (12&thinsp;MB)))
+	 $(TD 0.12.0 &#40;2.063.2&#41;)
 	 $(TD x86_64)
-	 $(TD $(OSX))
-	 $(TD LDC Mac OS X 10.7+ binaries)
+	 $(TD $(LINUX))
+	 $(TD LDC 64-bit Linux binaries)
 	)
 
 	$(TR
-	 $(TDL $(LINK2 http://d32gngvpvl2pi1.cloudfront.net/ldc-0.11.0-src.tar.gz, ldc-0.11.0-src.tar.gz))
-	 $(TD 0.11.0 &#40;2.062&#41;)
+	 $(TDL $(LINK2 https://github.com/ldc-developers/ldc/releases/download/v0.12.0/ldc-0.12.0-src.tar.gz, ldc-0.12.0-src.tar.gz (4&thinsp;MB)))
+	 $(TD 0.12.0 &#40;2.063.2&#41;)
 	 $(TD i386, x86_64)
-	 $(TD $(LINUX) $(OSX))
-	 $(TD LDC source)
+	 $(TDL $(WIN32) $(LINUX) $(OSX) $(FREEBSD))
+	 $(TD LDC source archive)
 	)
 )
 


### PR DESCRIPTION
Also rearranges the links to be in the same order as for DMD.
