### PR TITLE
length does not exist between [ ] and tail description is wrong

### DIFF
--- a/tuple.dd
+++ b/tuple.dd
@@ -67,10 +67,9 @@ TP[1] f = TP[2];	// f is declared as a float and initialized to 3
 	$(P and even sliced:)
 
 ---
-alias TP[0..length-1] TQ; // TQ is now the same as Tuple!(float, float)
+alias TP[0..$-1] TQ; // TQ is now the same as Tuple!(float, float)
 ---
 
-	$(P Yes, $(B length) is defined within the [ ]s.
 	There is one restriction: the indices for indexing and slicing
 	must be evaluatable at compile time.)
 
@@ -83,7 +82,7 @@ void foo(int i)
 
 	$(P These make it simple to produce the $(SINGLEQUOTE head) and $(SINGLEQUOTE tail)
 	of a tuple. The head is just TP[0], the tail
-	is TP[1 .. length].
+	is TP[$-1 .. $].
 	Given the head and tail, mix with a little conditional
 	compilation, and we can implement some classic recursive
 	algorithms with templates.
@@ -99,10 +98,10 @@ template Erase(T, TL...)
         alias TL Erase;
     else static if (is(T == TL[0]))
 	// match with first in tuple, return tail
-        alias TL[1 .. length] Erase;
+        alias TL[1 .. $] Erase;
     else
 	// no match, return head concatenated with recursive tail operation
-        alias Tuple!(TL[0], Erase!(T, TL[1 .. length])) Erase;
+        alias Tuple!(TL[0], Erase!(T, TL[1 .. $])) Erase;
 }
 ---
 
@@ -201,7 +200,7 @@ alias Tuple!(3, 7L, 6.8) ET;
 ...
 writeln(ET);            // prints 376.8
 writeln(ET[1]);         // prints 7
-writeln(ET[1..length]); // prints 76.8
+writeln(ET[1..$]); // prints 76.8
 ---
 
 	$(P It can be used to create an array literal:)


### PR DESCRIPTION
Many uses of length between [ and ] which is not valid(And its ugly).
Correct definition of a Tuple's tail to be TP[$-1..$]
