### PR TITLE
Updated the changelog for isOverrideFunction and thisExePath

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -760,13 +760,16 @@ $(P With the $(D thisExePath) function you can retrieve the current executable p
 
 ---------
 import std.file;
+import std.stdio;
 
 void main(string[] args)
 {
-    // note: typically args[0] already contains the executable path,
-    // but you may not always parse the command-line arguments,
-    // or you may want to access the exe path from another function.
-    assert(args[0] == thisExePath());
+    // Prints the full path of the current running executable.
+    // Note: this may, or may not be the same as args[0]. The content
+    // of args[0] is dependent of how the application was invoked, thisExePath()
+    // is not. It's also possible to access thisExePath() from other parts of the
+    // code than main.
+    writeln(thisExePath());
 }
 ---------
 $(LI $(LNAME2 regex_api, New API for std.regex $(D match)/$(D replace) functions:)) 


### PR DESCRIPTION
The changelog entry for `__trait(isOverrideFunction)` was missing and the example for `thisExePath()` was not correct.
