### PR TITLE
FIX Issue 11449 - Jump lists of phobos are in wrong order

### DIFF
--- a/std.ddoc
+++ b/std.ddoc
@@ -84,7 +84,11 @@ function listanchors()
         var li = a.lastIndexOf('.');
         return a.slice(li + 1);
     }
-    values.sort(function(a,b){return lastName(a) > lastName(b)});
+    values.sort(function(a,b){
+        return function(aa, bb){
+            return aa == bb ? 0 : (aa < bb ? -1 : 1);
+        }(lastName(a), lastName(b));
+    });
 
     for(var i = 0; i < values.length; i++) {
         var a = values[i];


### PR DESCRIPTION
Fixed the compare function for sort in std.ddoc template.
