### PR TITLE
Fix isOverrideFunction description

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -529,7 +529,7 @@ void main()
 }
 ---------
 
-$(LI $(LNAME2 isoverridefunction_trait, Introduced the $(D isOverrideFunction) trait which indicates if a function is overridden or not:))
+$(LI $(LNAME2 isoverridefunction_trait, Introduced the $(D isOverrideFunction) trait which indicates whether or not a function is overriding:))
 
 ---
 class Base
@@ -544,8 +544,8 @@ class Foo : Base
 }
 
 static assert (__traits(isOverrideFunction, Base.foo) == false);
-static assert (__traits(isOverrideFunction, Foo.foo));
-static assert (__traits(isOverrideFunction, Foo.bar) == false);
+static assert (__traits(isOverrideFunction, Foo.foo)  == true);
+static assert (__traits(isOverrideFunction, Foo.bar)  == false);
 ---
 )
 


### PR DESCRIPTION
As it was worded, it did not match the example (or its name).  Plus imagine trying to figure out whether a function is _overridden_, anyway!

Plus minor explicitness change in the asserts of the example.
