### PR TITLE
module name misinformation

### DIFF
--- a/module.dd
+++ b/module.dd
@@ -39,8 +39,9 @@ $(V2  	$(GLINK2 class, SharedStaticConstructor)
 
 
 	$(P Modules have a one-to-one correspondence with source files.
-	The module name is the file name with the path and extension
-	stripped off.
+	The module name is, by default, the file name with the path and
+	extension stripped off, and can be set explicitly with the module
+	declaration.
 	)
 
 	$(P Modules automatically provide a namespace scope for their contents.
@@ -125,8 +126,8 @@ module c.stdio;    // this is module $(B stdio) in the $(B c) package
 ---------
 
 	$(P By convention, package and module names are all lower case. This is
-	because those names have a one-to-one correspondence with the operating
-	system's directory and file names, and many file systems
+	because those names can have a one-to-one correspondence with the
+	operating system's directory and file names, and many file systems
 	are not case sensitive. All lower case package and module names will
 	minimize problems moving projects between dissimilar file systems.)
     


### PR DESCRIPTION
The module page has conflicting information on module names. This adds just a few words (and reorganizes when needed to keep the line length consistent) to clear it up. The module name matches the file name only by default, as affirmed later in the page, so I add the words "by default" and say it can be changed in the intro paragraph.

Later, it says "those names have a one-to-one correspondence". This is not strictly true, as we see later with "foo-bar.d" being "module foo_bar", the declared module name matching the filename is only a convention. So I added the word "can", meaning follow this convention to get the benefit, but it is not required by the language. Indeed, forcing filenames to match module names is impossible anyway, since files can have multiple names and multiple parent directories, whereas modules only have the one name!

See my exchange in this stack overflow comment thread to see what prompted this: http://stackoverflow.com/questions/20319966/how-do-you-compile-multiple-files-in-different-folders-in-d/20320021?noredirect=1#comment30366156_20320021
