### PR TITLE
Remove DIGG

### DIFF
--- a/doc.ddoc
+++ b/doc.ddoc
@@ -449,7 +449,6 @@ COMMA=,
 VER=2.0
 V1=
 V2=$0
-DIGG=<script src="http://digg.com/tools/diggthis.js" type="text/javascript"></script>
 SLASHDOT=<script src="http://slashdot.org/slashdot-it.js" type="text/javascript"></script>
 HOMEIMG=<img src="home.png" border=0 alt="digitalmars.com">
 SEARCHIMG=<img src="search.png" border=0 alt="Search">

--- a/hijack.dd
+++ b/hijack.dd
@@ -2,8 +2,6 @@ Ddoc
 
 $(D_S Function Hijacking Mitigation,
 
-<div align="right">$(DIGG)</div>
-
 $(P
 As software becomes more complex, we become more reliant on module
 interfaces. An application may import and combine modules from multiple

--- a/safed.dd
+++ b/safed.dd
@@ -6,8 +6,6 @@ $(D_S SafeD&mdash;The Safe Subset of D,
 	$(SMALL by Bartosz Milewski, a member of the D design team)
 	)
 
-<div align="right">$(DIGG)</div>
-
 	$(P
 	I've seen some very good programmers move away from C++ in favor of languages like Java or C#. Being a hard-core C++ programmer myself, I wondered why anyone would want to switch to a less powerful and less efficient language. Mind you, I could understand why a newcomer would opt for a simpler, flatter-learning-curve language but, once somebody invested the time and effort to become proficient in C++, why in the world would they want to abandon it? 
 	)


### PR DESCRIPTION
This remove digg toolkit which is not supported anymore and returns 404.

There's also tons of links to hyphenate.js and (less) to hyphenate_selectively.js, which IIRC had been removed because they slowed the site down, however they're still in the DDOC. I didn't fix it because I have basically 0 knowledge in DDOC / web, but should be pretty straightforward.
