### PR TITLE
Update struct.dd

### DIFF
--- a/struct.dd
+++ b/struct.dd
@@ -439,9 +439,6 @@ $(GNAME StructPostblit):
           this(this) {
             a = a.dup;
           }
-          ~this() {
-            delete a;
-          }
         }
         ---
 
@@ -533,10 +530,6 @@ $(SECTION3 $(LNAME2 AssignOverload, Assignment Overload),
 
           this(this) {
             buf = buf.dup;
-          }
-
-          ~this() {
-            delete buf;
           }
         }
         ---


### PR DESCRIPTION
Removed example code which used the delete keyword. The delete keyword is considered harmful.
