### PR TITLE
fix BinaryInteger grammar.

### DIFF
--- a/lex.dd
+++ b/lex.dd
@@ -593,7 +593,7 @@ $(GNAME DecimalInteger):
     $(GLINK NonZeroDigit) $(I DecimalDigitsUS)
 
 $(GNAME BinaryInteger):
-    $(GLINK BinPrefix) $(GLINK BinaryDigits)
+    $(GLINK BinPrefix) $(GLINK BinaryDigitsUS)
 
 $(GNAME BinPrefix):
     $(B 0b)


### PR DESCRIPTION
BinaryDigits does not exist. Instead it should point BinaryDigitsUS.

Spin-off from #431
