### PR TITLE
Update function.dd

### DIFF
--- a/function.dd
+++ b/function.dd
@@ -697,7 +697,7 @@ void test() {
 
 
         $(P Functions defined with non-D linkage cannot be overloaded.
-        because the name mangling does not take the parameter types
+        This is because the name mangling might not take the parameter types
         into account.
         )
 


### PR DESCRIPTION
Sentence now starts with capital letter. Also corrected reason for disallowed overloading for non-D linkage. 

It is true that C name mangling does NOT take parameter types into account with the consequence that there is no function overloading in C. However, C++ name mangling DOES mentions parameter types and enables function overloading in this way. Therefore, the statement "name mangling does not take the parameter types into account" is not correct for all linkage types.
