### PR TITLE
Add note for lower case suffix 'l' and allow it in lexing level.

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -21,7 +21,7 @@ $(SPEC_S Deprecated Features,
 	$(TROW $(DEPLINK .offset property),                                       ?,     N/A,    0.107,  2.061,  &nbsp;)
 	$(TROW $(DEPLINK .size property),                                         ?,     N/A,    0.107,  0.107,  2.061 )
 	$(TROW $(DEPLINK Escape string literals),                                 ?,     N/A,    2.026,  2.061,  &nbsp;)
-	$(TROW $(DEPLINK Lower case 'l' suffix for integer literals),             ?,     N/A,    1.054,  0.174,  2.061 )
+	$(TROW $(DEPLINK Lower case 'l' suffix for integer literals),             ?,     N/A,    1.054,  0.174,  (never) )
 	$(TROW $(DEPLINK Octal literals),                                         2.054, N/A,    2.053,  &nbsp;, &nbsp;)
 	$(TROW $(DEPLINK Upper case 'I' suffix for imaginary literals),           ?,     N/A,    0.154,  2.061,  &nbsp;)
 	$(TROW $(DEPLINK HTML source files),                                      ?,     N/A,    2.013,  N/A,    2.061 )
@@ -280,6 +280,11 @@ auto x = 123L;
 	)
 $(H4 Rationale)
 	$(P The lower case suffix is easily confused with the digit '1'.
+    )
+$(H4 Note)
+    $(P In lexical analysis phase, compiler can recognize lower case suffix 'l'
+        to report better error message - for the use case such as C-to-D code
+        translation. Thus DMD would continue to parse 'l' suffix.
     )
 
 


### PR DESCRIPTION
Related: [Issue 11759](https://d.puremagic.com/issues/show_bug.cgi?id=11759) - Poor error message trying to use lowercase L in literal
suffix.

I think it would have enough benefit to continue parsing lower case suffix 'l'.
