### PR TITLE
Update operatoroverloading.dd

### DIFF
--- a/operatoroverloading.dd
+++ b/operatoroverloading.dd
@@ -94,27 +94,27 @@ $(H3 Overloading Index Unary Operators)
 	$(TABLE2 Overloadable Index Unary Operators,
 	$(THEAD $(I op), $(I rewrite))
 	$(TROW
-	$(D -)$(I a)$(D [)$(ARGUMENTS)$(D ]),
-	$(ARGS $(I a)$(D .opIndexUnary!("-")$(LPAREN))$(ARGUMENTS)$(D $(RPAREN))))
+	$(D -)$(I a)$(D [b1,b2,...,bn]),
+	$(ARGS $(I a)$(D .opIndexUnary!("-")$(LPAREN)b1,b2,...,bn$(RPAREN))))
 	$(TROW
-	$(D +)$(I a)$(D [)$(ARGUMENTS)$(D ]),
-	$(I a)$(D .opIndexUnary!("+")$(LPAREN))$(ARGUMENTS)$(D $(RPAREN))
+	$(D +)$(I a)$(D [b1,b2,...,bn]),
+	$(I a)$(D .opIndexUnary!("+")$(LPAREN)b1,b2,...,bn$(RPAREN))
 	)
 	$(TROW
-	$(D ~)$(I a)$(D [)$(ARGUMENTS)$(D ]),
-	$(I a)$(D .opIndexUnary!("~")$(LPAREN))$(ARGUMENTS)$(D $(RPAREN))
+	$(D ~)$(I a)$(D [b1,b2,...,bn]),
+	$(I a)$(D .opIndexUnary!("~")$(LPAREN)b1,b2,...,bn$(RPAREN))
 	)
 	$(TROW
-	$(D *)$(I a)$(D [)$(ARGUMENTS)$(D ]),
-	$(I a)$(D .opIndexUnary!("*")$(LPAREN))$(ARGUMENTS)$(D $(RPAREN))
+	$(D *)$(I a)$(D [b1,b2,...,bn]),
+	$(I a)$(D .opIndexUnary!("*")$(LPAREN)b1,b2,...,bn$(RPAREN))
 	)
 	$(TROW
-	$(D ++)$(I a)$(D [)$(ARGUMENTS)$(D ]),
-	$(I a)$(D .opIndexUnary!("++")$(LPAREN))$(ARGUMENTS)$(D $(RPAREN))
+	$(D ++)$(I a)$(D [b1,b2,...,bn]),
+	$(I a)$(D .opIndexUnary!("++")$(LPAREN)b1,b2,...,bn$(RPAREN))
 	)
 	$(TROW
-	$(D --)$(I a)$(D [)$(ARGUMENTS)$(D ]),
-	$(I a)$(D .opIndexUnary!("--")$(LPAREN))$(ARGUMENTS)$(D $(RPAREN))
+	$(D --)$(I a)$(D [b1,b2,...,bn]),
+	$(I a)$(D .opIndexUnary!("--")$(LPAREN)b1,b2,...,bn$(RPAREN))
 	)
 	)
 


### PR DESCRIPTION
In my browser the arguments are not properly displayed. Therefore, I changed them so they will be. For me it looks like this: 
    -a[b⊂, b⊂, ... b⊂]    a.opIndexUnary!("-" )(b⊂, b⊂, ... b⊂)
    +a[b⊂, b⊂, ... b⊂]    a.opIndexUnary!("+" )(b⊂, b⊂, ... b⊂)
    ~a[b⊂, b⊂, ... b⊂]    a.opIndexUnary!("~" )(b⊂, b⊂, ... b⊂)
    _a[b⊂, b⊂, ... b⊂]    a.opIndexUnary!("_" )(b⊂, b⊂, ... b⊂)
   ++a[b⊂, b⊂, ... b⊂]    a.opIndexUnary!("++")(b⊂, b⊂, ... b⊂)
   --a[b⊂, b⊂, ... b⊂]    a.opIndexUnary!("--")(b⊂, b⊂, ... b⊂)
Which does not seem to be right.
