### PR TITLE
Update operatoroverloading.dd

### DIFF
--- a/operatoroverloading.dd
+++ b/operatoroverloading.dd
@@ -94,27 +94,27 @@ $(H3 Overloading Index Unary Operators)
 	$(TABLE2 Overloadable Index Unary Operators,
 	$(THEAD $(I op), $(I rewrite))
 	$(TROW
-	$(D -)$(I a)$(D [b1,b2,...,bn]),
-	$(ARGS $(I a)$(D .opIndexUnary!("-")$(LPAREN)b1,b2,...,bn$(RPAREN))))
+	$(D -)$(I a)$(D [)$(ARGUMENTS)$(D ]),
+	$(ARGS $(I a)$(D .opIndexUnary!("-")$(LPAREN))$(ARGUMENTS)$(D $(RPAREN))))
 	$(TROW
-	$(D +)$(I a)$(D [b1,b2,...,bn]),
-	$(I a)$(D .opIndexUnary!("+")$(LPAREN)b1,b2,...,bn$(RPAREN))
+	$(D +)$(I a)$(D [)$(ARGUMENTS)$(D ]),
+	$(I a)$(D .opIndexUnary!("+")$(LPAREN))$(ARGUMENTS)$(D $(RPAREN))
 	)
 	$(TROW
-	$(D ~)$(I a)$(D [b1,b2,...,bn]),
-	$(I a)$(D .opIndexUnary!("~")$(LPAREN)b1,b2,...,bn$(RPAREN))
+	$(D ~)$(I a)$(D [)$(ARGUMENTS)$(D ]),
+	$(I a)$(D .opIndexUnary!("~")$(LPAREN))$(ARGUMENTS)$(D $(RPAREN))
 	)
 	$(TROW
-	$(D *)$(I a)$(D [b1,b2,...,bn]),
-	$(I a)$(D .opIndexUnary!("*")$(LPAREN)b1,b2,...,bn$(RPAREN))
+	$(D *)$(I a)$(D [)$(ARGUMENTS)$(D ]),
+	$(I a)$(D .opIndexUnary!("*")$(LPAREN))$(ARGUMENTS)$(D $(RPAREN))
 	)
 	$(TROW
-	$(D ++)$(I a)$(D [b1,b2,...,bn]),
-	$(I a)$(D .opIndexUnary!("++")$(LPAREN)b1,b2,...,bn$(RPAREN))
+	$(D ++)$(I a)$(D [)$(ARGUMENTS)$(D ]),
+	$(I a)$(D .opIndexUnary!("++")$(LPAREN))$(ARGUMENTS)$(D $(RPAREN))
 	)
 	$(TROW
-	$(D --)$(I a)$(D [b1,b2,...,bn]),
-	$(I a)$(D .opIndexUnary!("--")$(LPAREN)b1,b2,...,bn$(RPAREN))
+	$(D --)$(I a)$(D [)$(ARGUMENTS)$(D ]),
+	$(I a)$(D .opIndexUnary!("--")$(LPAREN))$(ARGUMENTS)$(D $(RPAREN))
 	)
 	)
 
@@ -285,8 +285,8 @@ $(OL
 	$(CODE b.opEquals(a)) are tried. If both resolve to the same opEquals
 	function, then the expression is rewritten to be $(CODE a.opEquals(b)).
 	)
-	$(LI If one is a better match than the other, or one compiles and the other
-	does not, the first is selected.)
+	$(LI If one is a better match then the other, or one compiles and the other
+	does not, the one is selected.)
 	$(LI Otherwise, an error results.)
 )
 
@@ -470,8 +470,8 @@ $(H3 Index Assignment Operator Overloading)
 	$(P If the left hand side of an assignment is an index operation
 	on a struct or class instance,
 	it can be overloaded by providing an opIndexAssign member function.
-	Expressions of the form $(D a[b1,b2,...,bn] = c) are rewritten
-	as $(D a.opIndexAssign$(LPAREN)c,b1,b2,...,bn$(RPAREN)).
+	Expressions of the form $(D a[)$(ARGUMENTS)$(D ] = c) are rewritten
+	as $(D a.opIndexAssign$(LPAREN)c,) $(ARGUMENTS)$(D $(RPAREN)).
 	)
 
 -------
@@ -537,13 +537,13 @@ $(H3 Index Op Assignment Operator Overloading)
 	a struct or class instance and opIndexOpAssign is a member:)
 
 ---
-a[$(METACODE $(ARGUMENTS))] $(METACODE op)= c
+a[$(METACODE b1,b2,...,bn)] $(METACODE op)= c
 ---
 
 	$(P it is rewritten as:)
 
 ---
-a.opIndexOpAssign!("$(METACODE op)")(c, $(METACODE $(ARGUMENTS)))
+a.opIndexOpAssign!("$(METACODE op)")(c, $(METACODE b1,b2,...,bn))
 ---
 
 $(H3 Slice Op Assignment Operator Overloading)
@@ -575,7 +575,7 @@ a.opSliceOpAssign!("$(METACODE op)")(c)
 
 $(H2 $(LNAME2 Array, Index Operator Overloading))
 
-	$(P The array index operator, $(D a[)$(ARGUMENTS)$(D ]), can be overloaded by
+	$(P The array index operator, $(D a[b1,b2,...,bn]), can be overloaded by
 	declaring a function named $(D opIndex) with one
 	or more parameters.
 	)


### PR DESCRIPTION
Once more, replaced weird b⊂, b⊂, ... b⊂ by b1,b2,...,bn in sections 'Index Op Assignment Operator Overloading' and 'Array, Index Operator Overloading'. 

Again, please check if the changes are correct.
