### PR TITLE
SUB macro collides with SUB=&sub;

### DIFF
--- a/doc.ddoc
+++ b/doc.ddoc
@@ -372,7 +372,6 @@ TH=<th scope="col">$0</th>
 BLOCKQUOTE = <blockquote><p>$+</p><cite>$1</cite></blockquote>
 BLOCKQUOTE_PLAIN = <blockquote><p>$0</p></blockquote>
 TT=<tt>$0</tt>
-SUB=<sub>$0</sub>
 LNAME2=<a name="$1">$+</a>
 SECTION1=<h1>$1</h1>$+
 SECTION2=$(H2 $1)$+
@@ -498,8 +497,8 @@ TABLE_2COLS=$(TABLE2 $1, $+)
 TABLE_3COLS=$(TABLE2 $1, $+)
 TROW_EXPLANATORY=<td colspan=10>$0</td>
 FOOTNOTE=$(I &nbsp;($0))
-SUPERSCRIPT=$(SUP $0)
-SUBSCRIPT=$(SUB $0)
+SUPERSCRIPT=<sup>$0</sup>
+SUBSCRIPT=<sub>$0</sub>
 CPPLISTING=$(CPPCODE $0)
 NBSP=&nbsp;
 TAIL=$+

--- a/operatoroverloading.dd
+++ b/operatoroverloading.dd
@@ -94,27 +94,27 @@ $(H3 Overloading Index Unary Operators)
 	$(TABLE2 Overloadable Index Unary Operators,
 	$(THEAD $(I op), $(I rewrite))
 	$(TROW
-	$(D -)$(I a)$(D [b1,b2,...,bn]),
-	$(ARGS $(I a)$(D .opIndexUnary!("-")$(LPAREN)b1,b2,...,bn$(RPAREN))))
+	$(D -)$(I a)$(D [$(ARGUMENTS)]),
+	$(ARGS $(I a)$(D .opIndexUnary!("-")$(LPAREN)$(ARGUMENTS)$(RPAREN))))
 	$(TROW
-	$(D +)$(I a)$(D [b1,b2,...,bn]),
-	$(I a)$(D .opIndexUnary!("+")$(LPAREN)b1,b2,...,bn$(RPAREN))
+	$(D +)$(I a)$(D [$(ARGUMENTS)]),
+	$(I a)$(D .opIndexUnary!("+")$(LPAREN)$(ARGUMENTS)$(RPAREN))
 	)
 	$(TROW
-	$(D ~)$(I a)$(D [b1,b2,...,bn]),
-	$(I a)$(D .opIndexUnary!("~")$(LPAREN)b1,b2,...,bn$(RPAREN))
+	$(D ~)$(I a)$(D [$(ARGUMENTS)]),
+	$(I a)$(D .opIndexUnary!("~")$(LPAREN)$(ARGUMENTS)$(RPAREN))
 	)
 	$(TROW
-	$(D *)$(I a)$(D [b1,b2,...,bn]),
-	$(I a)$(D .opIndexUnary!("*")$(LPAREN)b1,b2,...,bn$(RPAREN))
+	$(D *)$(I a)$(D [$(ARGUMENTS)]),
+	$(I a)$(D .opIndexUnary!("*")$(LPAREN)$(ARGUMENTS)$(RPAREN))
 	)
 	$(TROW
-	$(D ++)$(I a)$(D [b1,b2,...,bn]),
-	$(I a)$(D .opIndexUnary!("++")$(LPAREN)b1,b2,...,bn$(RPAREN))
+	$(D ++)$(I a)$(D [$(ARGUMENTS)]),
+	$(I a)$(D .opIndexUnary!("++")$(LPAREN)$(ARGUMENTS)$(RPAREN))
 	)
 	$(TROW
-	$(D --)$(I a)$(D [b1,b2,...,bn]),
-	$(I a)$(D .opIndexUnary!("--")$(LPAREN)b1,b2,...,bn$(RPAREN))
+	$(D --)$(I a)$(D [$(ARGUMENTS)]),
+	$(I a)$(D .opIndexUnary!("--")$(LPAREN)$(ARGUMENTS)$(RPAREN))
 	)
 	)
 
@@ -470,8 +470,8 @@ $(H3 Index Assignment Operator Overloading)
 	$(P If the left hand side of an assignment is an index operation
 	on a struct or class instance,
 	it can be overloaded by providing an opIndexAssign member function.
-	Expressions of the form $(D a[b1,b2,...,bn] = c) are rewritten
-	as $(D a.opIndexAssign$(LPAREN)c,b1,b2,...,bn$(RPAREN)).
+	Expressions of the form $(D a[$(ARGUMENTS)] = c) are rewritten
+	as $(D a.opIndexAssign$(LPAREN)c,$(ARGUMENTS)$(RPAREN)).
 	)
 
 -------
@@ -730,7 +730,7 @@ Macros:
 	TITLE=Operator Overloading
 	WIKI=OperatorOverloading
 	CATEGORY_SPEC=$0
-	ARGUMENTS=$(I b)$(SUB 1), $(I b)$(SUB 2), ... $(I b)$(SUB n)
+	ARGUMENTS=$(I b)$(SUBSCRIPT 1), $(I b)$(SUBSCRIPT 2), ... $(I b)$(SUBSCRIPT n)
 	SLICE=$(I i)..$(I j)
 	SLICE2=$(I i), $(I j)
 	FOO=

--- a/std.ddoc
+++ b/std.ddoc
@@ -344,7 +344,10 @@ LEADINGROW = <tr class=leadingrow><td colspan=2><b><em>&nbsp;&nbsp;&nbsp;&nbsp;$
 TABLE = <table cellspacing=0 cellpadding=5><caption>$1</caption>$2</table>
 TD = <td valign=top>$0</td>
 TDNW = <td valign=top class="donthyphenate">$0</td>
+# kept for compatibility, but collides with SUB=&sub; use SUBSCRIPT instead
 SUB = <sub>$0</sub>
+SUPERSCRIPT = <sup>$0</sup>
+SUBSCRIPT = <sub>$0</sub>
 
 COPYRIGHT= Copyright &copy; 1999-$(YEAR) by Digital Mars, All Rights Reserved
 


### PR DESCRIPTION
- add SUBSCRIPT, SUPERSCRIPT like in latex.ddoc
- use SUBSCRIPT for ARGUMENTS in operatoroverloading.dd
- use ARGUMENTS instead of b1,b2..bn
