### PR TITLE
Fix TDNW macro broken by added comment

### DIFF
--- a/std.ddoc
+++ b/std.ddoc
@@ -344,7 +344,7 @@ LEADINGROW = <tr class=leadingrow><td colspan=2><b><em>&nbsp;&nbsp;&nbsp;&nbsp;$
 TABLE = <table cellspacing=0 cellpadding=5><caption>$1</caption>$2</table>
 TD = <td valign=top>$0</td>
 TDNW = <td valign=top class="donthyphenate">$0</td>
-# kept for compatibility, but collides with SUB=&sub; use SUBSCRIPT instead
+SUB_IS_DEPRECATED=kept for compatibility, but collides with SUB=&sub; use SUBSCRIPT instead (this is a comment and can be changed into one if ddoc files ever start supporting comments)
 SUB = <sub>$0</sub>
 SUPERSCRIPT = <sup>$0</sup>
 SUBSCRIPT = <sub>$0</sub>


### PR DESCRIPTION
ddoc files don't support comments currently.

I was not in a position to test this when I created this pull request.  Merging this sooner than later would be good because dlang.org's documentation is kind of [screwed up currently](http://dlang.org/phobos/std_container.html).
