### PR TITLE
Update dbc.dd

### DIFF
--- a/dbc.dd
+++ b/dbc.dd
@@ -89,7 +89,7 @@ long square_root(long x)
   }
   out (result)
   {
-    assert((result * result) <= x && (result+1) * (result+1) >= x);
+    assert((result * result) <= x && (result+1) * (result+1) > x);
   }
   body
   {


### PR DESCRIPTION
square_root(9) shall not return 2 (previous contract allows that)
