### PR TITLE
Revert changelog.dd encoding to UTF-8

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -437,8 +437,7 @@ $(LI $(LNAME2 uni_bygrapheme, Add std.uni.byGrapheme and std.uni.byCodePoint.)
 
         void main()
         {
-            string s = "noe\u0308l"; // noÎl
-
+            string s = "noe\u0308l"; // no√´l
             // reverse it and convert the result back to UTF-8
             string reverse = s.byGrapheme()
                 .array() // Note: byGrapheme will support bidirectionality in the future
@@ -446,7 +445,7 @@ $(LI $(LNAME2 uni_bygrapheme, Add std.uni.byGrapheme and std.uni.byCodePoint.)
                 .byCodePoint()
                 .text();
 
-            assert(reverse == "le\u0308on"); // lÎon
+            assert(reverse == "le\u0308on"); // l√´on
         }
         ---------
         Note that $(D byGrapheme) will support bidirectionality in the future,
@@ -775,7 +774,7 @@ $(LI $(BUGZILLA 11738): partialShuffle actually shuffles the entire input)
 $(LI $(BUGZILLA 11771): Unicode set intersection with char is broken)
 $(LI $(BUGZILLA 11775): std.regex should check for valid repetition range in assert mode)
 $(LI $(BUGZILLA 11780): RangeError in format for incomplete format specifier)
-$(LI $(BUGZILLA 11808): std.uni.CodepointSet$(LPAREN)'°¶', '–Ø'+1, '–∞', '°¶'+1$(RPAREN) asserts)
+$(LI $(BUGZILLA 11808): std.uni.CodepointSet$(LPAREN)'–ê', '–Ø'+1, '–∞', '—è'+1$(RPAREN) asserts)
 $(LI $(BUGZILLA 11839): std.regex capture group names should allow numbers to be in them)
 )
 )
@@ -2036,7 +2035,7 @@ $(LI $(BUGZILLA 10813): ICE$(LPAREN)DMD2.063$(RPAREN) template.c:6040: Identifie
 $(LI $(BUGZILLA 10834): cannot use cast$(LPAREN)void$(RPAREN)expr if the type of expr is a struct)
 $(LI $(BUGZILLA 10840): [CTFE] *this._data.arr is not yet implemented at compile time)
 $(LI $(BUGZILLA 10842): Some integer casts wrongly remove side-effect of the operand.)
-$(LI $(BUGZILLA 10857): ICE$(LPAREN)glue.c,°¶Äbugzilla 2962?$(RPAREN) or compiles, depending on the files order)
+$(LI $(BUGZILLA 10857): ICE$(LPAREN)glue.c,„ÄÄbugzilla 2962?$(RPAREN) or compiles, depending on the files order)
 $(LI $(BUGZILLA 10858): CTFE wrong code for comparison of array of pointers)
 $(LI $(BUGZILLA 10862): Assignment inside if condition still sometimes accepted)
 $(LI $(BUGZILLA 10869): Ddoc mark methods with "const" twice)
@@ -4031,7 +4030,7 @@ $(LI $(BUGZILLA 9420): [2.062alpha] Weird "$(LPAREN)null$(RPAREN)" output in err
 $(LI $(BUGZILLA 9435): regression$(LPAREN)head$(RPAREN): forward reference error)
 $(LI $(BUGZILLA 9436): enum cannot be forward referenced with cyclic imports and mixin)
 $(LI $(BUGZILLA 9496): [REG 2.061 -> 2.062 alpha] "this[1 .. $]" passes wrong "this" to "opDollar")
-$(LI $(BUGZILLA 9514): "template instance ·ﬂ°¶is not an alias")
+$(LI $(BUGZILLA 9514): "template instance ‚Ä¶ is not an alias")
 $(LI $(BUGZILLA 9525): [CTFE] Cannot convert &S to const$(LPAREN)S*$(RPAREN) at compile time)
 )
 


### PR DESCRIPTION
#476 had unintendedly broke Unicode characters...
