### PR TITLE
Fixes for deprecate.dd

### DIFF
--- a/d-array-article.dd
+++ b/d-array-article.dd
@@ -229,7 +229,7 @@ slice.assumeSafeAppend();
 assert(slice.capacity == 7); // force the used data to 2 elements
 ------
 
-$(P If D slices' append performance just isn't up to snuff for your performance requirements, there is another alternative.  The $(FULL_STDREF array, Appender) type will append data to an array as fast as possible, without any need to look up metadata from the runtime.  $(STDREF array, Appender) also supports the output range idiom via an append operation (normal slices only support the output range by overwriting their own data).)
+$(P If D slices' append performance just isn't up to snuff for your performance requirements, there is another alternative.  The $(FULL_XREF array, Appender) type will append data to an array as fast as possible, without any need to look up metadata from the runtime.  $(STDREF array, Appender) also supports the output range idiom via an append operation (normal slices only support the output range by overwriting their own data).)
 
 $(H2 Conclusion)
 
@@ -245,6 +245,5 @@ $(P $(I Thanks to David Gileadi, Andrej Mitrovic, Jesse Phillips, Alex Dovhal, J
 Macros:
 	TITLE=D Slices
 	CATEGORY_ARTICLES=$0
-    FULL_STDREF = <a href="phobos/std_$1.html#$2">$(D std.$1.$2)</a>
     STDREF = <a href="phobos/std_$1.html#$2">$(D $2)</a>
     OBJREF = <a href="phobos/object.html#$1">$(D $2)</a>

--- a/deprecate.dd
+++ b/deprecate.dd
@@ -111,7 +111,7 @@ typedef int myint;
 static assert(!is(myint == int));
 ---
 $(H4 Corrective Action)
-	$(P Replace use of typedef with alias or use $(FULL_STDREF typecons, Typedef).
+	$(P Replace use of typedef with alias or use $(FULL_XREF typecons, Typedef).
 	)
 $(H4 Rationale)
 	$(P typedef is not flexible enough to cover all use cases.  This is better done with a library solution.
@@ -297,7 +297,7 @@ $(H3 $(DEPNAME Octal literals))
 // auto x = 0123;
 ---
 $(H4 Corrective Action)
-	$(P Use the $(FULL_STDREF conv, octal) template.
+	$(P Use the $(FULL_XREF conv, octal) template.
 ---
 auto x = octal!123;
 ---
@@ -554,7 +554,7 @@ $(H4 Rationale)
 $(H3 $(DEPNAME floating point NCEG operators))
 	D currently supports the NCEG floating point operators (!<>=, <>, <>=, !>, !>=, !<, !<=, !<>) for comparisons involving NaNs.
 $(H4 Corrective Action)
-	$(P Use the normal operators and $(FULL_STDREF math, isNaN).
+	$(P Use the normal operators and $(FULL_XREF math, isNaN).
 	)
 $(H4 Rationale)
 	$(P These operators are too specialized to be a part of the core language.
@@ -652,7 +652,7 @@ void main()
 }
 ---
 $(H4 Corrective Action)
-	$(P Use $(FULL_STDREF typecons, scoped) instead.
+	$(P Use $(FULL_XREF typecons, scoped) instead.
 ---
 class A
 {
@@ -688,7 +688,6 @@ Macros:
 	DEPNAME=$(LNAME2 $0, $0)
 	TITLE=Deprecated Features
 	WIKI=DeprecatedFeatures
-	FULL_STDREF = <a href="phobos/std_$1.html#$2">$(D std.$1.$2)</a>
 	STDFILEREF = <a href="phobos/std_$1.html">$(D std.$1)</a>
 
 


### PR DESCRIPTION
- Fix a dangerous example of using `scoped`.
- Add and improve ddoc links.
