### PR TITLE
Added note about deprecated class allocators and deallocators

### DIFF
--- a/memory.dd
+++ b/memory.dd
@@ -227,6 +227,7 @@ $(H2 <a name="referencecounting">Reference Counting</a>)
 	)
 
 $(H2 <a name="newdelete">Explicit Class Instance Allocation</a>)
+$(B Note): Class <a href="class.html#allocators">allocators</a> and <a href="class.html#deallocators">deallocators</a> are deprecated in D2.
 
 	$(P D provides a means of creating custom allocators and deallocators
 	for class instances. Normally, these would be allocated on the


### PR DESCRIPTION
This article has the potential to lead learners astry as it advocates the usage of deprecated class allocators and deallocators.  This note warns readers until an updated example can be made.
