### PR TITLE
Change named headers into subtle links to themselves

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -156,6 +156,30 @@ a:visited
 	color: #606;
 }
 
+/*
+Styling for page anchor self-links.
+
+These links look like regular headers unless hovered, in which case
+they are underlined and display a pilcrow after them.
+*/
+a.anchor
+{
+	color: #633; /* Use the regular header text color */
+	text-decoration: none; /* Don't underline unless hovered */
+}
+
+a.anchor:hover
+{
+	text-decoration: underline; /* See above */
+}
+
+a.anchor:hover:after
+{
+	content: " \00B6"; /* Unicode pilcrow symbol */
+	color: black; /* Pilcrow should not use the regular header text color */
+	font-style: normal; /* ... and should not be italic */
+}
+
 /* These are different kinds of <pre> sections */
 .bnf /* grammar */
 {

--- a/doc.ddoc
+++ b/doc.ddoc
@@ -375,7 +375,7 @@ TH=<th scope="col">$0</th>
 BLOCKQUOTE = <blockquote><p>$+</p><cite>$1</cite></blockquote>
 BLOCKQUOTE_PLAIN = <blockquote><p>$0</p></blockquote>
 TT=<tt>$0</tt>
-LNAME2=<a name="$1">$+</a>
+LNAME2=<a class="anchor" title="Permalink to this section" name="$1" href="#$1">$+</a>
 SECTION1=<h1>$1</h1>$+
 SECTION2=$(H2 $1)$+
 SECTION3=<h3>$1</h3>$+
@@ -436,7 +436,7 @@ GLINK=$(RELATIVE_LINK2 $0, $(I $0))
 GLINK2=$(LINK2 $1.html#$2, $(I $2))
 GLINK2=$(DDSUBLINK $1,$2,$(I $2))
 DPLLINK=$(LINK2 $1,$+)
-GNAME=$(LNAME2 $0, $(I $0))
+GNAME=<a name="$0">$(I $0)</a>
 NOT_EBOOK=$0
 PHOBOS=<a href="phobos/std_$1.html#$2">$3</a>
 


### PR DESCRIPTION
Many sections in the language reference have page anchors, but to know the anchor name one has to look in the source code, effectively rendering them useless.

This change makes these headers links to themselves, so people can easily share links to _specific_ parts of a page.

The links have subtle styling. When not hovering over one, it looks like any other header. Hover over it, and it gets an underline and a pilcrow/paragraph symbol after it.
