### PR TITLE
Capitalize and add anchors to headers in grammar.dd

### DIFF
--- a/grammar.dd
+++ b/grammar.dd
@@ -2,11 +2,11 @@ Ddoc
 
 $(SPEC_S Grammar,
 
-$(H3 lex)
+$(H3 Lexical Syntax)
 
-    $(P Refer the page for $(XLINK2 lex.html, Lexical).)
+    $(P Refer to the page for $(XLINK2 lex.html, lexical syntax).)
 
-$(H3 type)
+$(H3 $(LNAME2 type, Type))
 
 $(GRAMMAR
 $(GNAME Type):
@@ -75,7 +75,7 @@ $(GNAME Typeof):
     $(D typeof $(LPAREN)) $(D return) $(D $(RPAREN))
 )
 
-$(H3 expression)
+$(H3 $(LNAME2 expression, Expression))
 
 $(GRAMMAR
 $(GNAME Expression):
@@ -501,7 +501,7 @@ $(GNAME SpecialKeyword):
     $(D $(XLINK2 traits.html#specialkeywords, __PRETTY_FUNCTION__))
 )
 
-$(H3 statement)
+$(H3 $(LNAME2 statement, Statement))
 
 $(GRAMMAR
 $(GNAME Statement):
@@ -798,7 +798,7 @@ $(GNAME MixinStatement):
     $(D mixin) $(D $(LPAREN)) $(ASSIGNEXPRESSION) $(D $(RPAREN)) $(D ;)
 )
 
-$(H3 iasm)
+$(H3 $(LNAME2 iasm, Iasm))
 
 $(GRAMMAR
 $(GNAME AsmInstruction):
@@ -967,7 +967,7 @@ $(GNAME AsmTypePrefix):
     $(D real ptr)
 )
 
-$(H3 declaration)
+$(H3 $(LNAME2 declaration, Declaration))
 
 $(GRAMMAR
 $(GNAME Declaration):
@@ -1110,7 +1110,7 @@ $(GNAME StructMemberInitializer):
     $(I Identifier) $(D :) $(GLINK NonVoidInitializer)
 )
 
-$(H3 function)
+$(H3 $(LNAME2 function, Function))
 
 $(GRAMMAR
 $(GNAME Parameters):
@@ -1230,7 +1230,7 @@ $(GNAME SharedStaticDestructor):
     $(D shared static ~ this ( )) $(GLINK MemberFunctionAttributes)$(OPT) $(GLINK FunctionBody)
 )
 
-$(H3 aggregate)
+$(H3 $(LNAME2 aggregate, Aggregate))
 
 $(GRAMMAR
 $(GNAME AggregateDeclaration):
@@ -1310,7 +1310,7 @@ $(GNAME AliasThis):
     $(D alias) $(I Identifier) $(D this ;)
 )
 
-$(H3 enum)
+$(H3 $(LNAME2 enum, Enum))
 
 $(GRAMMAR
 $(GNAME EnumDeclaration):
@@ -1346,7 +1346,7 @@ $(GNAME EnumMember):
     $(GLINK Type) $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
 )
 
-$(H3 template)
+$(H3 $(LNAME2 template, Template))
 
 $(GRAMMAR
 $(GNAME TemplateDeclaration):
@@ -1484,7 +1484,7 @@ $(GNAME QualifiedIdentifierList):
     $(GLINK TemplateInstance) $(D .) $(I QualifiedIdentifierList)
 )
 
-$(H3 attribute)
+$(H3 $(LNAME2 attribute, Attribute))
 
 $(GRAMMAR
 $(GNAME AttributeSpecifier):
@@ -1578,7 +1578,7 @@ $(GNAME Pragma):
     $(D pragma) $(D $(LPAREN)) $(I Identifier) $(D ,) $(GLINK ArgumentList) $(D $(RPAREN))
 )
 
-$(H3 conditional)
+$(H3 $(LNAME2 conditional, Conditional))
 
 $(GRAMMAR
 $(GNAME ConditionalDeclaration):
@@ -1628,7 +1628,7 @@ $(GNAME StaticAssert):
     $(D static assert $(LPAREN)) $(ASSIGNEXPRESSION) $(D ,) $(ASSIGNEXPRESSION) $(D $(RPAREN);)
 )
 
-$(H3 module)
+$(H3 $(LNAME2 module, Module))
 
 $(GRAMMAR
 $(GNAME Module):


### PR DESCRIPTION
Combined with #497, this makes grammar sections easily referable.

I also took the liberty of capitalizing the section headers.
