### PR TITLE
Issue 10514 - Constructor declaration grammar is incorrect

### DIFF
--- a/class.dd
+++ b/class.dd
@@ -243,6 +243,7 @@ $(H3 $(LNAME2 constructors, Constructors))
 
 $(GRAMMAR
 $(GNAME Constructor):
+    $(D this) $(GLINK2 declaration, Parameters) $(GLINK2 declaration, MemberFunctionAttributes)$(OPT) $(D ;)
     $(D this) $(GLINK2 declaration, Parameters) $(GLINK2 declaration, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
     $(GLINK2 template, ConstructorTemplate)
 )
@@ -534,6 +535,7 @@ $(H3 $(LNAME2 destructors, Destructors))
 
 $(GRAMMAR
 $(GNAME Destructor):
+    $(D ~ this ( )) $(GLINK2 declaration, MemberFunctionAttributes)$(OPT) $(D ;)
     $(D ~ this ( )) $(GLINK2 declaration, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
 )
 
@@ -593,6 +595,7 @@ $(H3 Static Constructors)
 
 $(GRAMMAR
 $(GNAME StaticConstructor):
+    $(D static this ( )) $(D ;)
     $(D static this ( )) $(GLINK2 function, FunctionBody)
 )
 
@@ -692,6 +695,7 @@ $(H3 Static Destructors)
 
 $(GRAMMAR
 $(GNAME StaticDestructor):
+    $(D static ~ this ( )) $(GLINK2 declaration, MemberFunctionAttributes)$(OPT) $(D ;)
     $(D static ~ this ( )) $(GLINK2 declaration, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
 )
 
@@ -737,6 +741,7 @@ $(H3 Shared Static Constructors)
 
 $(GRAMMAR
 $(GNAME SharedStaticConstructor):
+    $(D shared static this ( )) $(D ;)
     $(D shared static this ( )) $(GLINK2 function, FunctionBody)
 )
 
@@ -748,6 +753,7 @@ $(H3 Shared Static Destructors)
 
 $(GRAMMAR
 $(GNAME SharedStaticDestructor):
+    $(D shared static ~ this ( )) $(GLINK2 declaration, MemberFunctionAttributes)$(OPT) $(D ;)
     $(D shared static ~ this ( )) $(GLINK2 declaration, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
 )
 
@@ -772,6 +778,7 @@ $(H3 $(LNAME2 allocators, Class Allocators))
 $(B Note): Class allocators are deprecated in D2.
 $(GRAMMAR
 $(GNAME Allocator):
+    $(D new) $(GLINK2 declaration, Parameters) $(D ;)
     $(D new) $(GLINK2 declaration, Parameters) $(GLINK2 function, FunctionBody)
 )
 
@@ -847,6 +854,7 @@ assert(foo.x == int.init);  // object is still accessible
 
 $(GRAMMAR
 $(GNAME Deallocator):
+    $(D delete) $(GLINK2 declaration, Parameters) $(D ;)
     $(D delete) $(GLINK2 declaration, Parameters) $(GLINK2 function, FunctionBody)
 )
 

--- a/grammar.dd
+++ b/grammar.dd
@@ -1191,22 +1191,28 @@ $(GNAME BodyStatement):
 
 $(GRAMMAR
 $(GNAME Constructor):
+    $(D this) $(GLINK Parameters) $(GLINK MemberFunctionAttributes)$(OPT) $(D ;)
     $(D this) $(GLINK Parameters) $(GLINK MemberFunctionAttributes)$(OPT) $(GLINK FunctionBody)
     $(GLINK ConstructorTemplate)
 
 $(GNAME ConstructorTemplate):
+    $(D this) $(GLINK TemplateParameters) $(GLINK Parameters) $(GLINK MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(D ;)
     $(D this) $(GLINK TemplateParameters) $(GLINK Parameters) $(GLINK MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(GLINK FunctionBody)
 
 $(GNAME Destructor):
+    $(D ~ this ( )) $(GLINK MemberFunctionAttributes)$(OPT) $(D ;)
     $(D ~ this ( )) $(GLINK MemberFunctionAttributes)$(OPT) $(GLINK FunctionBody)
 
 $(GNAME Postblit):
+    $(D this $(LPAREN) this $(RPAREN)) $(GLINK MemberFunctionAttributes)$(OPT) $(D ;)
     $(D this $(LPAREN) this $(RPAREN)) $(GLINK MemberFunctionAttributes)$(OPT) $(GLINK FunctionBody)
 
 $(GNAME Allocator):
+    $(D new) $(GLINK Parameters) $(D ;)
     $(D new) $(GLINK Parameters) $(GLINK FunctionBody)
 
 $(GNAME Deallocator):
+    $(D delete) $(GLINK Parameters) $(D ;)
     $(D delete) $(GLINK Parameters) $(GLINK FunctionBody)
 
 $(GNAME Invariant):
@@ -1218,15 +1224,19 @@ $(GNAME UnitTest):
 
 $(GRAMMAR
 $(GNAME StaticConstructor):
+    $(D static this ( )) $(D ;)
     $(D static this ( )) $(GLINK FunctionBody)
 
 $(GNAME StaticDestructor):
+    $(D static ~ this ( )) $(GLINK MemberFunctionAttributes)$(OPT) $(D ;)
     $(D static ~ this ( )) $(GLINK MemberFunctionAttributes)$(OPT) $(GLINK FunctionBody)
 
 $(GNAME SharedStaticConstructor):
+    $(D shared static this ( )) $(D ;)
     $(D shared static this ( )) $(GLINK FunctionBody)
 
 $(GNAME SharedStaticDestructor):
+    $(D shared static ~ this ( )) $(GLINK MemberFunctionAttributes)$(OPT) $(D ;)
     $(D shared static ~ this ( )) $(GLINK MemberFunctionAttributes)$(OPT) $(GLINK FunctionBody)
 )
 

--- a/struct.dd
+++ b/struct.dd
@@ -409,6 +409,7 @@ $(SECTION3 $(LNAME2 StructPostblit, Struct Postblits),
 
 $(GRAMMAR
 $(GNAME Postblit):
+    $(D this $(LPAREN) this $(RPAREN)) $(GLINK2 declaration, MemberFunctionAttributes)$(OPT) $(D ;)
     $(D this $(LPAREN) this $(RPAREN)) $(GLINK2 declaration, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
 )
 

--- a/template.dd
+++ b/template.dd
@@ -797,6 +797,7 @@ $(H2 Template Constructors)
 
 $(GRAMMAR
 $(GNAME ConstructorTemplate):
+    $(D this) $(GLINK2 template, TemplateParameters) $(GLINK2 declaration, Parameters) $(GLINK2 declaration, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(D :)
     $(D this) $(GLINK2 template, TemplateParameters) $(GLINK2 declaration, Parameters) $(GLINK2 declaration, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(GLINK2 function, FunctionBody)
 )
 


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=10514

Same issue is in `ConstructorTemplate`, `Destructor`, `Postblit`, `Allocator`, `Deallocator`,
`StaticConstructor`, `StaticDestructor`, `SharedStaticConstructor`, and `SharedStaticDestructor`.
