### PR TITLE
Have rsync delete files on server if they are not present in source

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -176,10 +176,10 @@ clean:
 	@echo You should issue manually: rm -rf ${DMD_DIR}-${LATEST} ${DRUNTIME_DIR}-${LATEST} ${PHOBOS_DIR}-${LATEST}
 
 rsync : all
-	rsync -avz $(DOC_OUTPUT_DIR)/ d-programming@digitalmars.com:data/
+	rsync -avz --delete $(DOC_OUTPUT_DIR)/ d-programming@digitalmars.com:data/
 
 rsync-only :
-	rsync -avz $(DOC_OUTPUT_DIR)/ d-programming@digitalmars.com:data/
+	rsync -avz --delete $(DOC_OUTPUT_DIR)/ d-programming@digitalmars.com:data/
 
 pdf : $(PDFTARGETS)
 


### PR DESCRIPTION
To keep things tidy and clear the cruft.

@andralex You'll have to make sure everything is present in the source directory on your machine before you use this.
