### PR TITLE
Link to 2013 schedule directly in announcement

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -6,7 +6,7 @@ $(SECTION3 The D programming language. Modern
 convenience. Modeling power. Native efficiency.,
 
 $(P $(RED $(B Join us for $(LINK2 http://dconf.org/2014/schedule/index.html, DConf 2014) on May 21-23 in Menlo Park, California.)))
-$(P Videos and slides for DConf 2013 are available on $(LINK2 http://dconf.org/schedule/index.html, dconf.org).)
+$(P Videos and slides for DConf 2013 are available on $(LINK2 http://dconf.org/2013/schedule/index.html, dconf.org).)
 $(BR)
 
 <div style="text-align: right; font-size: 11px; margin-bottom: -35px; margin-right: 5px; position: relative; z-index: 10000">


### PR DESCRIPTION
Just in case the old URL stops going to DConf 2013.

@MartinNowak recommended this [here](https://github.com/D-Programming-Language/dlang.org/pull/512/files#r10357535).
