### PR TITLE
Move -Articles/Memory Management- to wiki

### DIFF
--- a/memory.dd
+++ b/memory.dd
@@ -1,6 +1,6 @@
 Ddoc
 
-$(D_S D for Win32,
+$(D_S Memory Management,
 
 This page has been moved to 
 $(LINK2 http://wiki.dlang.org/Memory_Management, http://wiki.dlang.org/Memory_Management)


### PR DESCRIPTION
Following up on [#511](https://github.com/D-Programming-Language/dlang.org/pull/511).  See also [this discussion](http://forum.dlang.org/thread/mailman.249.1393157192.6445.digitalmars-d@puremagic.com).  Wiki article is [here](http://wiki.dlang.org/Memory_Management).  Updates have already been made to the article on the wiki to replace some of the deprecated examples.  See the history of the wiki article.
