### PR TITLE
Add "search" link to bug statistics page

### DIFF
--- a/bugstats.php.dd
+++ b/bugstats.php.dd
@@ -2,7 +2,7 @@ Ddoc
 
 $(D_S Bug tracker,
 
-$(BOOKTABLE $(SECTION3 Current bugs <font size=-1>$(LINK2 https://d.puremagic.com/issues/enter_bug.cgi?product=D,[report new bug])</font>),
+$(BOOKTABLE $(SECTION3 Current bugs <font size=-1>$(LINK2 https://d.puremagic.com/issues/enter_bug.cgi?product=D,[report new bug])$(LINK2 http://d.puremagic.com/issues/query.cgi,[search])</font>),
 $(DISPLAY Regression, y_axis_field=bug_severity&query_format=report-table&product=D&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&bug_severity=regression)
 $(DISPLAY Blocker, y_axis_field=bug_severity&query_format=report-table&product=D&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&bug_severity=blocker)
 $(DISPLAY Critical, y_axis_field=bug_severity&query_format=report-table&product=D&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&bug_severity=critical)


### PR DESCRIPTION
Loading the "All open" link takes a whopping ~10 seconds for me, while I almost always just want to get to the search page. Loading the search page only takes a second for me, so this adds a `[search]` link to the right of the `[report new bug]` link.

At least I hope it does - `bugstats.php` is only mentioned in `posix.mak`, not in `win32.mak`, so I can't test it. @andralex?
