### PR TITLE
Fix template alias parameter of type name example

### DIFF
--- a/template.dd
+++ b/template.dd
@@ -548,7 +548,7 @@ $(GNAME TemplateAliasParameterDefault):
 
         ------
         class Foo {
-          static p = int;
+          static int p;
         }
 
         template Bar(alias T) {


### PR DESCRIPTION
Didn't make any sense before. I assume this is what was meant; it compiles and demonstrates the point.
