### PR TITLE
Add `clear` method to the list of deprecated features

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -38,7 +38,7 @@ $(SPEC_S Deprecated Features,
     $(TROW $(DEPLINK imaginary and complex types),                            future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
     $(TROW $(DEPLINK floating point NCEG operators),                          future, &nbsp;,  2.066, &nbsp;, &nbsp;)
     $(TROW $(DEPLINK .sort and .reverse properties for arrays),               future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
-    $(TROW $(DEPLINK clear),                                                   2.060,  2.066,  2.066, &nbsp;, &nbsp;)
+    $(TROW $(DEPLINK clear),                                                   2.060, &nbsp;,  2.066, &nbsp;, &nbsp;)
     $(TROW $(DEPLINK delete),                                                 future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
     $(TROW $(DEPLINK overriding without override),                            future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
     $(TROW $(DEPLINK scope for allocating classes on the stack),              future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
@@ -595,7 +595,7 @@ destroy(a);
 ---
 	)
 $(H4 Rationale)
-	$(P Due to Uniform Function Call Syntax (UFCS), clear can cause confusion with other methods of the same name, such as a clear method used to remove the contents of a container.
+	$(P Due to Uniform Function Call Syntax (UFCS), $(D clear) can cause confusion with other methods of the same name, such as a $(D clear) method used to remove the contents of a container.
     )
 
 


### PR DESCRIPTION
This is a documentation pull request to accompany https://github.com/D-Programming-Language/druntime/pull/757
