### PR TITLE
Clarify that destroy does not free the allocated memory

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -35,11 +35,11 @@ $(SPEC_S Deprecated Features,
 	$(TROW $(DEPLINK Windows 3.x and Windows 9x support),                     2.058, N/A,    N/A,    N/A,    2.058 )
 
     $(TROW $(DEPLINK .min property for floating point types),                 N/A,    2.061,  &nbsp;, &nbsp;, &nbsp;)
-    $(TROW $(DEPLINK imaginary and complex types),                            future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
-    $(TROW $(DEPLINK floating point NCEG operators),                          future, &nbsp;,  2.066, &nbsp;, &nbsp;)
+    $(TROW $(DEPLINK Imaginary and complex types),                            future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
+    $(TROW $(DEPLINK Floating point NCEG operators),                          future, &nbsp;,  2.066, &nbsp;, &nbsp;)
     $(TROW $(DEPLINK .sort and .reverse properties for arrays),               future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
     $(TROW $(DEPLINK delete),                                                 future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
-    $(TROW $(DEPLINK overriding without override),                            future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
+    $(TROW $(DEPLINK Overriding without override),                            future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
     $(TROW $(DEPLINK scope for allocating classes on the stack),              future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
 	)
 
@@ -532,7 +532,7 @@ $(H4 Rationale)
     )
 
 
-$(H3 $(DEPNAME imaginary and complex types))
+$(H3 $(DEPNAME Imaginary and complex types))
 	D currently supports imaginary and complex versions of all floating point types.
 ---
 float a = 2;
@@ -551,7 +551,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME floating point NCEG operators))
+$(H3 $(DEPNAME Floating point NCEG operators))
 	D currently supports the NCEG floating point operators (!<>=, <>, <>=, !>, !>=, !<, !<=, !<>) for comparisons involving NaNs.
 $(H4 Corrective Action)
 	$(P Use the normal operators and $(FULL_XREF math, isNaN).
@@ -606,7 +606,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME overriding without override))
+$(H3 $(DEPNAME Overriding without override))
 	Virtual functions can currently override a function in a base class without the 'override' attribute.
 ---
 class A


### PR DESCRIPTION
This also fixes some heading capitalization in `deprecate.dd`.
