### PR TITLE
use typeof in conditional compilation docs

### DIFF
--- a/simd.dd
+++ b/simd.dd
@@ -121,7 +121,7 @@ $(H3 Conditional Compilation)
 	)
 
 ---
-static if (is(typeNN))
+static if (is(typeof(typeNN)))
     ... yes, it is supported ...
 else
     ... nope, use workaround ...


### PR DESCRIPTION
Otherwise you don't suppress errors. See https://issues.dlang.org/show_bug.cgi?id=12429 for example
