### PR TITLE
Documentation for `__traits(documentation, ...)`

### DIFF
--- a/traits.dd
+++ b/traits.dd
@@ -38,6 +38,7 @@ $(GNAME TraitsKeyword):
     $(GBLINK isLazy)
     $(GBLINK hasMember)
     $(GBLINK identifier)
+    $(GBLINK documentation)
     $(GBLINK getAliasThis)
     $(GBLINK getAttributes)
     $(GBLINK getFunctionAttributes)
@@ -361,9 +362,16 @@ void main() {
 
 $(H2 $(GNAME identifier))
 
-	$(P Takes one argument, a symbol. Returns the identifier
-	for that symbol as a string literal.
-	)
+    $(P Takes one argument, a symbol. Returns the identifier
+    for that symbol as a string literal.
+    )
+
+$(H2 $(GNAME documentation))
+
+    $(P Takes one argument, a symbol. Returns the $(DDSUBLINK ddoc, ddoc, Ddoc) comment for
+        that symbol as a string literal. Returns an empty string literal if no
+        documentation comment is present.
+    )
 
 $(H2 $(GNAME getAliasThis))
 


### PR DESCRIPTION
This is the dlang.org documentation associated with dmd pull request #3531:
https://github.com/D-Programming-Language/dmd/pull/3531.
