### PR TITLE
Use lower-case names for the HTML files generated by DDOX.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -298,12 +298,12 @@ apidocs-serve : docs-prerelease.json
 	  --git-target=master --web-file-dir=. docs-prerelease.json
 
 ${DOC_OUTPUT_DIR}/library-prerelease/sitemap.xml : docs-prerelease.json
-	${DPL_DOCS} generate-html --std-macros=std.ddoc --std-macros=std-ddox.ddoc \
+	${DPL_DOCS} generate-html --lowercase-names --std-macros=std.ddoc --std-macros=std-ddox.ddoc \
 	  --override-macros=std-ddox-override.ddoc --package-order=std \
 	  --git-target=master docs-prerelease.json ${DOC_OUTPUT_DIR}/library-prerelease
 
 ${DOC_OUTPUT_DIR}/library/sitemap.xml : docs.json
-	${DPL_DOCS} generate-html --std-macros=std.ddoc --std-macros=std-ddox.ddoc \
+	${DPL_DOCS} generate-html --lowercase-names --std-macros=std.ddoc --std-macros=std-ddox.ddoc \
 	  --override-macros=std-ddox-override.ddoc --package-order=std \
 	  --git-target=v${LATEST} docs.json ${DOC_OUTPUT_DIR}/library
 

--- a/win32.mak
+++ b/win32.mak
@@ -303,12 +303,12 @@ clean:
 ################# DDOX based API docs #########################
 
 apidocs: docs.json
-	$(DPL_DOCS) generate-html --std-macros=std.ddoc --std-macros=std-ddox.ddoc --override-macros=std-ddox-override.ddoc --package-order=std --git-target=master docs.json library
+	$(DPL_DOCS) generate-html --lowercase-names --std-macros=std.ddoc --std-macros=std-ddox.ddoc --override-macros=std-ddox-override.ddoc --package-order=std --git-target=master docs.json library
 
 apidocs-serve: docs.json
 	$(DPL_DOCS) serve-html --std-macros=std.ddoc --std-macros=std-ddox.ddoc --override-macros=std-ddox-override.ddoc --package-order=std --git-target=master --web-file-dir=. docs.json
 
-docs.json: dpl-docs
+docs.json: $(DPL_DOCS)
 	mkdir .tmp
 	dir /s /b /a-d ..\druntime\src\*.d | findstr /V "unittest.d gcstub" > .tmp/files.txt
 	dir /s /b /a-d ..\phobos\*.d | findstr /V "unittest.d linux osx format.d" >> .tmp/files.txt
@@ -316,5 +316,5 @@ docs.json: dpl-docs
 	$(DPL_DOCS) filter docs.json --min-protection=Protected --only-documented --ex=gc. --ex=rt. --ex=std.internal.
 	rmdir /s /q .tmp
 
-dpl-docs: $(DPL_DOCS)
+$(DPL_DOCS):
 	dub build --root=$(DPL_DOCS_PATH)


### PR DESCRIPTION
This lets all generated files be lower case, so that there are no conflicts on case insensitive file systems. Matching declarations will be aggregated on a single page.

Depends on https://github.com/D-Programming-Language/tools/pull/129
