### PR TITLE
Issue 12783: Added 'Third Party Libraries' links to the sidebars

### DIFF
--- a/doc.ddoc
+++ b/doc.ddoc
@@ -207,6 +207,7 @@ $(NAVBLOCK_HEADER $(TOCHEADER Community),
     $(TOCENTRYT http://github.com/D-Programming-Language, D on github, GitHub)
     $(TOCENTRYT http://wiki.dlang.org, Wiki for the D Programming Language, Wiki)
     $(TOCENTRYT http://wiki.dlang.org/Review_Queue, Queue of current and upcoming standard library additions, Review Queue)
+    $(TOCENTRYT http://code.dlang.org, Third party packages written in D, Third Party Packages)
     $(TOCENTRYT http://twitter.com/#search?q=%23d_lang, #d_lang on twitter.com, Twitter)
     $(TOCENTRYT http://digitalmars.com/d/dlinks.html, External D related links, Links)
     $(TOCENTRYX http://d.puremagic.com/conference2008/, D Programming Language Conference, Conference)

--- a/std.ddoc
+++ b/std.ddoc
@@ -201,6 +201,7 @@ TOP=
 	$(LI <a href="../phobos/index.html" title="D Runtime Library">Phobos $(LATEST)</a>)
 	$(LI <a href="../phobos-prerelease/index.html" title="D Runtime Library (prerelease)">Phobos (prerelease)</a>)
 	$(LI <a href="../comparison.html" title="Language Comparisons">Comparisons</a>)
+	$(LI <a href="http://code.dlang.org" title="Third Party Packages">Third Party Packages</a>)
     )
 </div>
 </div>


### PR DESCRIPTION
Andrei was talking about code.dlang.org not being particularly well known at DConf today. I had actually never heard of it prior to then. I think that this problem is one that is best solved by doing something quite simple: Adding a link in the sidebars to point to this wonderful collection.

https://issues.dlang.org/show_bug.cgi?id=12783
