### PR TITLE
Issue 11396 & 12802 - Allow optional 'StorageClasses' for old/new alias syntax

### DIFF
--- a/declaration.dd
+++ b/declaration.dd
@@ -347,8 +347,8 @@ $(GNAME AliasDeclaration):
     $(D alias) $(I AliasDeclarationX) $(D ;)
 
 $(GNAME AliasDeclarationX):
-    $(I Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK Type)
-    $(I AliasDeclarationX) $(D ,) $(I Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK Type)
+    $(I Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK Type)
+    $(I AliasDeclarationX) $(D ,) $(I Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK Type)
 )
 
     $(P $(I AliasDeclaration)s create a symbol that is an alias for another type,

--- a/grammar.dd
+++ b/grammar.dd
@@ -984,8 +984,8 @@ $(GNAME AliasDeclaration):
     $(D alias) $(I AliasDeclarationX) $(D ;)
 
 $(GNAME AliasDeclarationX):
-    $(I Identifier) $(GLINK TemplateParameters)$(OPT) $(D =) $(GLINK Type)
-    $(I AliasDeclarationX) $(D ,) $(I Identifier) $(GLINK TemplateParameters)$(OPT) $(D =) $(GLINK Type)
+    $(I Identifier) $(GLINK TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK Type)
+    $(I AliasDeclarationX) $(D ,) $(I Identifier) $(GLINK TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK Type)
 )
 
 $(GRAMMAR


### PR DESCRIPTION
[Issue 11396](https://issues.dlang.org/show_bug.cgi?id=11396) - Function alias declaration not valid according to spec
[Issue 12802](https://issues.dlang.org/show_bug.cgi?id=12802) - Allow optional 'StorageClasses' for new alias syntax
