### PR TITLE
fix implicit conversion table for references

### DIFF
--- a/const3.dd
+++ b/const3.dd
@@ -392,16 +392,18 @@ $(SECTION2 Implicit Conversions,
 	$(P References can be converted according to the following rules:
 	)
 
-	$(TABLE_SPECIAL $(ARGS Implicit Conversion of Reference Types)
-	$(TROW from/to, $(I mutable), $(D const), $(D immutable), $(D shared), $(D shared const), $(D inout), $(D inout shared))
-	$(TROW $(I mutable)      $(YES) $(YES) $(NO)  $(NO)  $(NO)  $(YES) $(NO))
-	$(TROW $(D const)        $(NO)  $(YES) $(NO)  $(NO)  $(NO)  $(YES) $(NO))
-	$(TROW $(D immutable)    $(NO)  $(YES) $(YES) $(NO)  $(NO)  $(YES) $(YES))
-	$(TROW $(D shared)       $(NO)  $(NO)  $(NO)  $(YES) $(YES) $(NO)  $(YES))
-	$(TROW $(D shared const) $(NO)  $(NO)  $(NO)  $(NO)  $(YES) $(NO)  $(YES))
-	$(TROW $(D inout)        $(NO)  $(YES) $(NO)  $(NO)  $(NO)  $(YES) $(NO))
-	$(TROW $(D inout shared) $(NO)  $(YES) $(NO)  $(NO)  $(NO)  $(NO)  $(YES))
-	)
+    $(TABLE_SPECIAL $(ARGS Implicit Conversion of Reference Types)
+    $(TROW from/to, $(I mutable), $(D const), $(D shared), $(D shared const), $(D inout), $(D inout const), $(D inout shared), $(D inout shared const), $(D immutable))
+    $(TROW $(I mutable)            $(YES) $(YES) $(NO)  $(NO)  $(NO)  $(NO)  $(NO)  $(NO)  $(NO) )
+    $(TROW $(D const)              $(NO)  $(YES) $(NO)  $(NO)  $(NO)  $(NO)  $(NO)  $(NO)  $(NO) )
+    $(TROW $(D shared)             $(NO)  $(NO)  $(YES) $(YES) $(NO)  $(NO)  $(NO)  $(NO)  $(NO) )
+    $(TROW $(D shared const)       $(NO)  $(NO)  $(NO)  $(YES) $(NO)  $(NO)  $(NO)  $(NO)  $(NO) )
+    $(TROW $(D inout)              $(NO)  $(YES) $(NO)  $(NO)  $(YES) $(YES) $(NO)  $(NO)  $(NO) )
+    $(TROW $(D inout const)        $(NO)  $(YES) $(NO)  $(NO)  $(NO)  $(YES) $(NO)  $(NO)  $(NO) )
+    $(TROW $(D inout shared)       $(NO)  $(NO)  $(NO)  $(YES) $(NO)  $(NO)  $(YES) $(YES) $(NO) )
+    $(TROW $(D inout shared const) $(NO)  $(NO)  $(NO)  $(YES) $(NO)  $(NO)  $(NO)  $(YES) $(NO) )
+    $(TROW $(D immutable)          $(NO)  $(YES) $(NO)  $(YES) $(NO)  $(YES) $(NO)  $(YES) $(YES))
+    )
 
 	$(P If an implicit conversion is disallowed by the table, an $(GLINK2 expression, Expression)
 	may be converted if:


### PR DESCRIPTION
It should follow compiler's behavior.

Test code:

``` d
alias /*MutableOf         */ M  (T) = T;
alias /*ConstOf           */ C  (T) = const(T);
alias /*SharedOf          */ S  (T) = shared(T);
alias /*SharedConstOf     */ SC (T) = shared(const(T));
alias /*InoutOf           */ W  (T) = inout(T);
alias /*InoutConstOf      */ WC (T) = inout(const(T));
alias /*InoutSharedOf     */ WS (T) = inout(shared(T));
alias /*InoutSharedConstOf*/ WSC(T) = inout(shared(const(T)));
alias /*ImutableOf        */ I  (T) = immutable(T);

alias Seq(T...) = T;
alias Quals = Seq!( M   ,  C   ,  S   ,  SC  ,  W   ,  WC  ,  WS  ,  WSC ,  I   );
alias Names = Seq!("M  ", "C  ", "S  ", "SC ", "W  ", "WC ", "WS ", "WSC", "I  ");

void main()
{
    import std.range, std.array;
    pragma(msg, "    ", Names.chain.array);
    foreach (i, F; Quals)
    {
        pragma(msg, Names[i], {
            string r;
            foreach (T; Quals)
            {
                // Test conversion, eg. from const(int)* to immutable(int)*
                r ~= is(F!(int)* : T!(int)*) ? " Y " : " N ";
            }
            return r;
        }());
    }
}
```
