### PR TITLE
Create a team page for dlang, listing some frequent contributors to the project

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -121,8 +121,8 @@ PAGES_ROOT=$(SPEC_ROOT) 32-64-portability acknowledgements ascii-table		\
 	gsoc2012-template hijack howto-promote htod htomodule index intro	\
 	intro-to-datetime lazy-evaluation memory migrate-to-shared mixin	\
 	overview pretod rationale rdmd regular-expression safed			\
-	std_consolidated_header template-comparison templates-revisited tuple	\
-	variadic-function-templates warnings wc windbg windows
+	std_consolidated_header team template-comparison templates-revisited	\
+	tuple variadic-function-templates warnings wc windbg windows
 
 TARGETS=$(addsuffix .html,$(PAGES_ROOT))
 

--- a/team.dd
+++ b/team.dd
@@ -1,0 +1,73 @@
+Ddoc
+
+<!-- Github ribbon -->
+<a href="http://github.com/D-Programming-Language"><img id="github-ribbon"
+src="/images/github-ribbon.png" alt="Fork D on GitHub"></a>
+
+$(D_S Team,
+
+$(P Core contributors to the D Programming Language are listed here, a longer list of contributors can be found in the Acknowledgements.
+)
+
+$(TABLEDL DMD - The Reference Compiler,
+
+	$(TR
+	$(TD $(PHOTO http://dconf.org/2014/images/bright_134.jpg, Walter Bright))
+        $(TD Walter Bright is the creator and first implementer of the D programming language and has implemented compilers for several other languages. He's an expert in all areas of compiler technology, including front ends, optimizers, code generation, interpreter engines and runtime libraries. Walter regularly writes articles about compilers and programming, is known for engaging and informative presentations, and provides training in compiler development techniques. Many are surprised to discover that Walter is also the creator of the wargame Empire, which is still popular today over 30 years after its debut.)
+	)
+
+	$(TR
+	$(TD $(PHOTO http://images.elfwood.com/art/t/a/tansyanne/warlock.jpg, Kenji Hara))
+        $(TD Kenji Hara, please provide an image and write up a bio.) 
+	)
+
+	$(TR
+	$(TD $(PHOTO http://cdn.obsidianportal.com/assets/45599/OP_Shapeshifters.jpg, Daniel Murphy))
+        $(TD Daniel Murphy, please provide an image and write up a bio.) 
+	)
+
+	$(TR
+	$(TD $(PHOTO http://dconf.org/2014/images/clugston.jpg, Don Clugston))
+        $(TD Don is a Senior Software Developer at Sociomantic Labs, Berlin. He has contributed to the D language since 2005, mainly in the areas of mathematics and metaprogramming. Before joining Sociomantic as a full-time D programmer, he worked in the solar photovoltaic industry on numerical modelling, measurement, and industrial inkjet. His 'FastDelegate' library is well known in the C++ community. He has two sons, and a daughter with superpowers.) 
+	)
+)
+
+$(TABLEDL DRUNTIME - Runtime Library for D,
+
+	$(TR
+	$(TD $(PHOTO http://www.wow.si/images/stories/fr_tcg_dwarf_miner.jpg, Sean Kelly))
+        $(TD Sean Kelly, please provide an image and write up a bio.)
+	)
+
+	$(TR
+	$(TD $(PHOTO http://dconf.org/2013/images/Martin.jpg, Martin Nowak))
+        $(TD I started to learn C++ in 2009 when I worked as DSP and application developer at Ableton. Two years later I was lucky enough to delve into D. Contributing to dmd and druntime has accompanied my discovery of programming since then. I still look forward to finish my studies of electrical engineering and I'm an Emacser.)
+	)
+)
+
+$(TABLEDL PHOBOS - The Standard Library,
+
+	$(TR
+	$(TD $(PHOTO http://erdani.com/media/2012-07-16%20Professional%20Photo%205.jpg, Andrei Alexandrescu))
+        $(TD Andrei Alexandrescu coined the colloquial term "modern C++" (adapted from his award-winning book Modern C++ Design), used today to describe a collection of important C++ styles and idioms. He is also the coauthor (with Herb Sutter) of C++ Coding Standards and the author of The D Programming Language book. With Walter Bright, Andrei co-designed many important features of D and authored a large part of D's standard library. His research on Machine Learning and Natural Language Processing completes a broad spectrum of expertise. Andrei holds a Ph.D. in Computer Science from the University of Washington and a B.Sc. in Electrical Engineering from University "Politehnica" Bucharest. He works as a Research Scientist for Facebook.)
+	)
+
+	$(TR
+	$(TD $(PHOTO https://avatars3.githubusercontent.com/u/579956?s=460, Jonatham M Davis))
+        $(TD Jonathan Davis, please provide an image and write up a bio.)
+	)
+
+	$(TR
+	$(TD $(PHOTO https://avatars1.githubusercontent.com/u/1911406?s=400, monarch dodra))
+        $(TD monarch dodra, please provide an image and write up a bio.)
+	)
+)
+
+)
+
+Macros:
+	TITLE=Team
+	WIKI=Team
+	TABLEDL = <center><table width="100%" border=1 cellpadding=4 cellspacing=0><caption>$(H2 $1)</caption>$+</table></center>
+	TDL=<td style="text-align: left;">$0</td>
+	PHOTO=<img src="$1" alt="$2" height="170">


### PR DESCRIPTION
I think D would benefit from introducing visitors to the website to who some of the people behind the language are.  I went through and found the top committers to dmd, druntime, and phobos and created a page with bios for them (some who would qualify for multiple projects, like Kenji, were only listed once), at least for those who talked at DConf before.  I don't know exactly who belongs on this page, this is just my guess.  Any beginning blogger is told to create an About page with their name, photo, and some info about themselves and while I don't think it's necessary for bloggers, it would help for a larger project like this.

More importantly, the review process for pull requests needs to be documented.  [I've created a stub page for this on the wiki](http://wiki.dlang.org/Review_process), the real details should be filled in.  Even if the process is as vague as "Some people look at your code and eventually one of the committers will merge it if good enough," it needs to be documented, so that contributors know what to expect.

There's been a lot of talk about professionalism, but that starts with the project leaders.  These types of pages should have been written a long time ago.
