### PR TITLE
Clarify which CPUs are supported by DMD on which platform

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -20,7 +20,7 @@ $(TABLEDL DMD - Digital Mars D Programming Language version 2,
 	$(TR
 	$(TDL <a HREF="$(DLSITE dmd.$(DMDV2).zip)" title="download D compiler">$(DOWNLOADIMG) dmd.$(DMDV2).zip</a>)
 	$(TD $(DMDV2))
-	$(TD i386, x86_64)
+	$(TD OSX: x86_64 $(BR) Windows: i386 $(BR) Linux/FreeBSD: both)
 	$(TDL $(WIN32) $(LINUX) $(OSX) $(FREEBSD))
 	$(TD dmd D 2.0 compiler, all platforms)
 	)


### PR DESCRIPTION
The binaries in the ZIP file on the download page don't run on x86 **and** x86_64 for all architectures, see here:
http://forum.dlang.org/thread/ezfhuuruflirphpyqxly@forum.dlang.org#post-lne8b0:2413r9:241:40digitalmars.com
