### PR TITLE
Use lower_underscore names for the DDOX documentation instead of purelowercase.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -303,12 +303,12 @@ apidocs-serve : docs-prerelease.json
 	  --git-target=master --web-file-dir=. docs-prerelease.json
 
 ${DOC_OUTPUT_DIR}/library-prerelease/sitemap.xml : docs-prerelease.json
-	${DPL_DOCS} generate-html --lowercase-names --std-macros=std.ddoc --std-macros=std-ddox.ddoc \
+	${DPL_DOCS} generate-html --file-name-style=lowerUnderscored --std-macros=std.ddoc --std-macros=std-ddox.ddoc \
 	  --override-macros=std-ddox-override.ddoc --package-order=std \
 	  --git-target=master docs-prerelease.json ${DOC_OUTPUT_DIR}/library-prerelease
 
 ${DOC_OUTPUT_DIR}/library/sitemap.xml : docs.json
-	${DPL_DOCS} generate-html --lowercase-names --std-macros=std.ddoc --std-macros=std-ddox.ddoc \
+	${DPL_DOCS} generate-html --file-name-style=lowerUnderscored --std-macros=std.ddoc --std-macros=std-ddox.ddoc \
 	  --override-macros=std-ddox-override.ddoc --package-order=std \
 	  --git-target=v${LATEST} docs.json ${DOC_OUTPUT_DIR}/library
 

--- a/win32.mak
+++ b/win32.mak
@@ -303,7 +303,7 @@ clean:
 ################# DDOX based API docs #########################
 
 apidocs: docs.json
-	$(DPL_DOCS) generate-html --lowercase-names --std-macros=std.ddoc --std-macros=std-ddox.ddoc --override-macros=std-ddox-override.ddoc --package-order=std --git-target=master docs.json library
+	$(DPL_DOCS) generate-html --file-name-style=lowerUnderscored --std-macros=std.ddoc --std-macros=std-ddox.ddoc --override-macros=std-ddox-override.ddoc --package-order=std --git-target=master docs.json library
 
 apidocs-serve: docs.json
 	$(DPL_DOCS) serve-html --std-macros=std.ddoc --std-macros=std-ddox.ddoc --override-macros=std-ddox-override.ddoc --package-order=std --git-target=master --web-file-dir=. docs.json


### PR DESCRIPTION
As per discussion with @andralex, this changes the file name style for the DDOX based documentation. Pure lowercase names ("boyermoorefinder.html") are now separated by underscores ("boyer_moore_finder.html"). See D-Programming-Language/tools#132 for the accompanying pull request for the dpl-docs documentation generator.
