### PR TITLE
URL encode characters in the "DConf 2014 videos" link

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -6,7 +6,7 @@ $(SECTION3 The D programming language. Modern
 convenience. Modeling power. Native efficiency.,
 
 $(P $(RED $(B Version 2.066 Goes Beta June 30.)))
-$(P Videos for DConf 2014 are available on $(LINK2 https://archive.org/search.php?query=creator%3A"DConf 2014", archive.org).)
+$(P Videos for DConf 2014 are available on $(LINK2 https://archive.org/search.php?query=creator%3A%22DConf%202014%22, archive.org).)
 $(P Videos and slides for DConf 2013 are available on $(LINK2 http://dconf.org/2013/schedule/index.html, dconf.org).)
 $(BR)
 


### PR DESCRIPTION
Currently the link contains raw double-quote characters and space characters and cannot be followed.  This URL-encodes those characters so the link can be followed.
