### PR TITLE
Clarification on using `private` in `package.d`

### DIFF
--- a/attribute.dd
+++ b/attribute.dd
@@ -336,7 +336,8 @@ $(GNAME ProtectionAttribute):
 
         $(P Private means that only members of the enclosing class can access
         the member, or members and functions in the same module as the
-        enclosing class.
+        enclosing class.  
+        Private members of a $(D package.d) file are only accessible within that file.
         Private members cannot be overridden.
         Private module members are equivalent to $(D static) declarations
         in C programs.


### PR DESCRIPTION
I hope I have it right.  My tests indicate this is the way it works.
