### PR TITLE
Issue 12858:  Document opEquals usage in AAs

### DIFF
--- a/hash-map.dd
+++ b/hash-map.dd
@@ -88,10 +88,11 @@ $(H3 Using Classes as the KeyType)
         this is not the case, the associative array will not function properly.
         Also note that $(D opCmp) is not used to check for equality by the
         associative array. However, since the actual $(D opEquals) or $(D
-        opCmp) called is not decided until runtime, the compiler cannot detect
-        mismatched functions. Unlike structs, classes that define only $(D
-        opCmp) will be allowed to compile, and may behave differently than
-        under prior versions that used $(D opCmp) to check for equality.)
+        opCmp) called is not decided until runtime, the compiler cannot always
+        detect mismatched functions. Because of legacy issues, the compiler may
+        reject an associative array key type that overrides $(D opCmp) but not
+        $(D opEquals). This restriction may be removed in future versions of
+        D.)
 
 $(H3 Using Structs or Unions as the KeyType)
 


### PR DESCRIPTION
AA runtime has changed to use `opEquals` instead of `opCmp`. Also the compiler has been adjusted to reject AA struct keys that only define `opCmp` and not `opEquals` to avoid regressions. These documentation changes reflect those changes.

Note, I did NOT build the docs (I don't know how!). Please take care when reviewing to ensure I did all the macros correctly.
