### PR TITLE
Fix broken bug graph image on bugstats.php

### DIFF
--- a/bugstats.php.dd
+++ b/bugstats.php.dd
@@ -36,7 +36,7 @@ $(DISPLAY All open, y_axis_field=bug_severity&query_format=report-table&product=
 $(DISPLAY All closed, y_axis_field=bug_severity&query_format=report-table&product=D&bug_severity=normal&bug_severity=minor&bug_severity=trivial&bug_severity=regression&bug_severity=blocker&bug_severity=critical&bug_severity=major&bug_severity=enhancement&bug_status=RESOLVED&bug_status=VERIFIED&bug_status=CLOSED)
 )
 
-$(P <center>$(LINK2 https://issues.dlang.org/reports.cgi?product=D&datasets=NEW&datasets=ASSIGNED&datasets=REOPENED&datasets=RESOLVED, <img border=1 src=https://issues.dlang.org/graphs/D_NEW_ASSIGNED_REOPENED_RESOLVED.png>)</center>)
+$(P <center>$(LINK2 https://issues.dlang.org/reports.cgi?product=D&datasets=NEW&datasets=ASSIGNED&datasets=REOPENED&datasets=RESOLVED, <img border=1 src="https://issues.dlang.org/graphs/mVH75HpydPklNqy3BSv8EvqlAOaP1WacmgYB1CsRbiM.png")</center>)
 
 )
 


### PR DESCRIPTION
Fixes: [issue 13012](https://issues.dlang.org/show_bug.cgi?id=13012)

The original image link appears to point to a non-existent file; furthermore, the link appears to be mangled with extraneous `%3A` characters. Fixing the link led to a working graph image, so replaced the image link with the address of that image. Not 100% sure this image URL will always work, though. Maybe the problem is that the image needs to be periodically updated?
