### PR TITLE
Add CXREF to changelog.dd.

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -8965,3 +8965,4 @@ Macros:
 
     STDMODREF = <a href="phobos/std_$1.html">$(D $2)</a>
     XREF = <a href="phobos/std_$1.html#$2">$(D $2)</a>
+    CXREF = <a href="phobos/core_$1.html#$2">$(D $2)</a>


### PR DESCRIPTION
The section on split needs to reference core.time, and changelog.dd does
not appear to use std.ddoc, so CXREF needs to be defined in changelog.dd
so that the links to core.time work.
