### PR TITLE
Remove unexpanded CODE_HIGHLIGHT macro in comment

### DIFF
--- a/hash-map.dd
+++ b/hash-map.dd
@@ -13,7 +13,7 @@ $(SPEC_S Associative Arrays,
         ---------
         int[string] b;    // associative array b of ints that are
                           // indexed by an array of characters.
-                          // The $(CODE_HIGHLIGHT KeyType) is string
+                          // The KeyType is string
         b["hello"] = 3;   // set value associated with key "hello" to 3
         func(b["hello"]); // pass 3 as parameter to func()
         ---------


### PR DESCRIPTION
Macros in comments are not expanded (https://issues.dlang.org/show_bug.cgi?id=13211).
