### PR TITLE
Fix typo in pull #620

### DIFF
--- a/operatoroverloading.dd
+++ b/operatoroverloading.dd
@@ -14,8 +14,8 @@ $(SPEC_S Operator Overloading,
 	$(LI $(RELATIVE_LINK2 eqcmp, Overloading the Comparison Operators)
 		$(UL
 		$(LI $(RELATIVE_LINK2 equals, Overloading $(D ==) and $(D !=)))
-		$(LI $(RELATIVE_LINK2 compare, Overloading $(D <), $(D <)$(D =),
-		$(D <), and $(D <)$(D =)))
+		$(LI $(RELATIVE_LINK2 compare, Overloading $(D <), $(D <=),
+		$(D >), and $(D >=)))
 		)
 	)
 	$(LI $(RELATIVE_LINK2 FunctionCall, Function Call Operator Overloading))


### PR DESCRIPTION
Not sure how it passed review, but [pull #620](https://github.com/D-Programming-Language/dlang.org/pull/620) had an embarrassing typo.
