### PR TITLE
Dynamic arrays: Fix some doc errors, and introduce the term 'array reference' to reduce confusion.

### DIFF
--- a/abi.dd
+++ b/abi.dd
@@ -161,15 +161,15 @@ $(SECTION3 Interfaces,
 
 $(SECTION3 Arrays,
 
-	$(P A dynamic array consists of:)
+	$(P An array reference consists of:)
 
-$(TABLE2 Dynamic Array Layout,
+$(TABLE2 Array Reference Layout,
 $(THEAD offset, property, contents)
 $(TROW $(D 0), $(D .length), array dimension)
 $(TROW $(D size_t), $(D .ptr), pointer to array data)
 )
 
-	$(P A dynamic array is declared as:)
+	$(P An array reference is declared as:)
 
 ---------
 type[] array;
@@ -182,7 +182,7 @@ type[dimension] array;
 ---------
 
 	$(P Thus, a static array always has the dimension statically available as part of the type, and
-	so it is implemented like in C. Static array's and Dynamic arrays can be easily converted back
+	so it is implemented like in C. Static arrays and array references can be easily converted back
 	and forth to each other.
 	)
 )
@@ -642,7 +642,7 @@ $(SECTION4 Return Value,
 	$(LI cfloat, cdouble, creal are returned in ST1,ST0 where ST1
 	is the real part and ST0 is the imaginary part.)
 
-	$(LI Dynamic arrays are returned with the pointer in EDX
+	$(LI Array references are returned with the pointer in EDX
 	and the length in EAX.)
 
 	$(LI Associative arrays are returned in EAX.)
@@ -731,7 +731,7 @@ $(SECTION4 Parameters,
 	$(TR $(TD this))
 	)
 
-	$(P The variadic part is converted to a dynamic array and the
+	$(P The variadic part is converted to an array reference and the
 	rest is the same as for non-variadic functions.)
 
 	$(P The parameters to the variadic function:)
@@ -879,7 +879,7 @@ $(SECTION3 Unit Testing,
 $(SECTION2 Symbolic Debugging,
 
 	$(P D has types that are not represented in existing C or C++ debuggers.
-	These are dynamic arrays, associative arrays, and delegates.
+	These are array references, associative arrays, and delegates.
 	Representing these types as structs causes problems because function
 	calling conventions for structs are often different than that for
 	these types, which causes C/C++ debuggers to misrepresent things.
@@ -891,7 +891,7 @@ $(SECTION2 Symbolic Debugging,
 
 	$(TABLE2 Types for C Debuggers,
 	$(THEAD D type, C representation)
-	$(TROW dynamic array, $(D unsigned long long))
+	$(TROW array reference, $(D unsigned long long))
 	$(TROW associative array, $(D void*))
 	$(TROW delegate, $(D long long))
 	$(TROW $(D dchar), $(D unsigned long))
@@ -913,7 +913,7 @@ $(SECTION3 $(LNAME2 codeview, Codeview Debugger Extensions),
 	$(TROW field size, 2, 2, 2, 2, 2, 2)
 	$(THEAD D Type, Leaf Index, OEM Identifier, recOEM, num indices,
 	type index, type index)
-	$(TROW dynamic array, $(D LF_OEM), $(I OEM), 1, 2, @$(I index), @$(I element))
+	$(TROW array reference, $(D LF_OEM), $(I OEM), 1, 2, @$(I index), @$(I element))
 	$(TROW associative array, $(D LF_OEM), $(I OEM), 2, 2, @$(I key), @$(I element))
 	$(TROW delegate, $(D LF_OEM), $(I OEM), 3, 2, @$(I this), @$(I function)))
 
@@ -940,7 +940,7 @@ $(SECTION3 $(LNAME2 dwarf, Dwarf Debugger Extensions),
 
 	$(TABLE2 Dwarf Extensions for D,
 	$(THEAD D type, ID, Value, Format)
-	$(TROW $(ARGS dynamic array)
+	$(TROW $(ARGS array reference)
 	, $(ARGS $(D DW_TAG_darray_type))
 	, $(ARGS 0x41)
 	, $(ARGS $(D DW_AT_type) is element type))

--- a/arrays.dd
+++ b/arrays.dd
@@ -545,7 +545,7 @@ Returns an array literal with each element of the literal being the $(D .init) p
     $(TABLE_2COLS Array Reference Properties,
         $(THEAD Property, Description)
         $(TROW $(D .init), Returns $(D null).)
-        $(TROW $(D .sizeof), $(ARGS Returns the size of the dynamic array reference,
+        $(TROW $(D .sizeof), $(ARGS Returns the size of the array reference,
         which is 8 in 32-bit builds and 16 on 64-bit builds.))
         $(TROW $(D .length), Get/set number of elements in the
         array. It is of type $(D size_t).)
@@ -786,7 +786,7 @@ $(H4 $(LNAME2 default-initialization, Default Initialization))
         $(LI Pointers are initialized to $(D null).)
         $(LI Static array contents are initialized to the default
         initializer for the array element type.)
-        $(LI Dynamic arrays are initialized to having 0 elements.)
+        $(LI Array references are initialized to having 0 elements.)
         $(LI Associative arrays are initialized to having 0 elements.)
         )
 

--- a/builtin.dd
+++ b/builtin.dd
@@ -9,7 +9,7 @@ $(COMMUNITY Core Language Features vs Library Implementation,
 	)
 
 	$(OL
-	$(LI Dynamic Arrays)
+	$(LI Array References)
 	$(LI Strings)
 	$(LI Associative Arrays)
 	)
@@ -62,7 +62,7 @@ $(COMMUNITY Core Language Features vs Library Implementation,
 	$(P More specific comments:
 	)
 
-$(SECTION2 Dynamic Arrays,
+$(SECTION2 Array References,
 
 	$(P C++ has builtin core arrays. It's just that they don't work very
 	well. Rather than fix them, several different array types were

--- a/declaration.dd
+++ b/declaration.dd
@@ -329,8 +329,8 @@ auto c = new C();  // c is a handle to an instance of class C
         )
 
         $(P An $(GLINK2 expression, ArrayLiteral)
-        is inferred to be a dynamic array
-        type rather than a static array:)
+        is inferred to be an array reference,
+        rather than a static array:)
 
 ---
 auto v = ["hello", "world"]; // type is string[], not string[2]

--- a/expression.dd
+++ b/expression.dd
@@ -320,7 +320,7 @@ if (c is null)  // ok
   ...
 ---
 
-        $(P For static and dynamic arrays, equality is defined as the
+        $(P For static arrays and array references, equality is defined as the
         lengths of the arrays
         matching, and all the elements are equal.
         )
@@ -349,8 +349,12 @@ $(GNAME IdentityExpression):
         struct being identical.
         )
 
-        $(P For static and dynamic arrays, identity is defined as referring
+        $(P For static arrays, identity is defined as referring
         to the same array elements and the same number of elements.
+        )
+
+        $(P For array references, identity is defined as referring
+        to the same array allocation, and having the same length.
         )
 
         $(P For other operand types, identity is defined as being the same
@@ -391,7 +395,7 @@ $(GNAME RelExpression):
 
         $(P It is an error to compare objects if one is $(D null).)
 
-        $(P For static and dynamic arrays, the result of the relational
+        $(P For static arrays and array references, the result of the relational
         op is the result of the operator applied to the first non-equal
         element of the array. If two arrays compare equal, but are of
         different lengths, the shorter array compares as "less" than the
@@ -700,7 +704,7 @@ $(GNAME ArgumentList):
         )
 
 -------------
-char[][] foo;   // dynamic array of strings
+char[][] foo;   // reference to array of strings
 ...
 foo = new char[][30]; // allocate array of 30 strings
 -------------
@@ -769,14 +773,14 @@ $(GNAME DeleteExpression):
         the instance, undefined behavior will result.
         )
 
-        $(P If the $(I UnaryExpression) is a pointer or a dynamic array,
+        $(P If the $(I UnaryExpression) is a pointer or an array reference,
         the garbage collector is called to immediately release the
         memory.
         If the garbage collector was not used to allocate the memory for
         the instance, undefined behavior will result.
         )
 
-        $(P The pointer, dynamic array, or reference is set to $(D null)
+        $(P The pointer, array reference, or reference is set to $(D null)
         after the delete is performed.
         Any attempt to reference the data after the deletion via another
         reference to it will result in undefined behavior.
@@ -842,7 +846,7 @@ $(GNAME CastExpression):
         $(P Casting a pointer type to and from a class type is done as a type paint
         (i.e. a reinterpret cast).)
 
-        $(P Casting a dynamic array to another dynamic array is done only if the
+        $(P Casting an array reference to another array reference is done only if the
         array lengths multiplied by the element sizes match. The cast is done
         as a type paint, with the array length adjusted to match any change in
         element size. If there's not a match, a runtime error is generated.)
@@ -962,7 +966,7 @@ $(GNAME IndexExpression):
         $(P $(I PostfixExpression) is evaluated.
 
         If $(I PostfixExpression) is an expression of type
-        static array or dynamic array, the symbol $(DOLLAR) is
+        static array or array reference, the symbol $(DOLLAR) is
         set to be the the number of elements in the array.
 
         If $(I PostfixExpression) is an $(I ExpressionTuple),
@@ -992,7 +996,7 @@ $(GNAME SliceExpression):
 
         $(P $(I PostfixExpression) is evaluated.
         if $(I PostfixExpression) is an expression of type
-        static array or dynamic array, the variable $(D length)
+        static array or array reference, the variable $(D length)
         (and the special variable $(DOLLAR))
         is declared and set to be the length of the array.
         A new declaration scope is created for the evaluation of the
@@ -1012,7 +1016,7 @@ $(GNAME SliceExpression):
         array.
         )
 
-        $(P The type of the slice is a dynamic array of the element
+        $(P The type of the slice is an array reference of the element
         type of the $(I PostfixExpression).
         )
 
@@ -1115,7 +1119,7 @@ $(H4 $(LNAME2 null, null))
 
         $(P $(D null) represents the null value for
         pointers, pointers to functions, delegates,
-        dynamic arrays, associative arrays,
+        array references, associative arrays,
         and class objects.
         If it has not already been cast to a type,
         it is given the type (void *) and it is an exact conversion

--- a/function.dd
+++ b/function.dd
@@ -896,7 +896,7 @@ def(z);
 // z is now 4
 ------------
 
-        $(P For dynamic array and object parameters, which are passed
+        $(P For array references and object parameters, which are passed
         by reference, in/out/ref
         apply only to the reference and not the contents.
         )
@@ -1699,8 +1699,8 @@ $(H3 $(LNAME2 interpretation, Compile Time Function Execution (CTFE)))
     $(UL
         $(LI
         C-style semantics on pointer arithmetic are strictly enforced.
-        Pointer arithmetic is permitted only on pointers which point to static
-        or dynamic array elements. Such pointers must point to an element of
+        Pointer arithmetic is permitted only on pointers which point to array elements. 
+        Such pointers must point to an element of
         the array, or to the first element past the array.
         Pointer arithmetic is completely forbidden on pointers which are null,
         or which point to a non-array.

--- a/garbage.dd
+++ b/garbage.dd
@@ -320,7 +320,7 @@ char[] q = p[3..6];
 	features
 	rendering most explicit pointer uses obsolete, such as reference
 	objects,
-	dynamic arrays, and garbage collection. Pointers
+	array references, and garbage collection. Pointers
 	are provided in order to interface successfully with C APIs and for
 	some low level work.
 	)

--- a/hash-map.dd
+++ b/hash-map.dd
@@ -266,7 +266,7 @@ Properties for associative arrays are:
         $(TROW $(D .sizeof), Returns the size of the reference to the associative
         array; it is 4 in 32-bit builds and 8 on 64-bit builds.)
         $(TROW $(D .length), $(ARGS Returns number of values in the
-        associative array. Unlike for dynamic arrays, it is read-only.))
+        associative array. Unlike for array references, it is read-only.))
         $(TROW $(D .dup), Create a new associative array of the same size
         and copy the contents of the associative array into it.)
         $(TROW $(D .keys), $(ARGS Returns dynamic array, the elements of which are the keys in

--- a/interfaceToC.dd
+++ b/interfaceToC.dd
@@ -209,8 +209,8 @@ $(H2 Calling printf())
 	$(XLINK2 http://www.digitalmars.com/rtl/stdio.html#printf, printf format specifier)
 	matches the corresponding D data type.
 	Although printf is designed to handle 0 terminated strings,
-	not D dynamic arrays of chars, it turns out that since D
-	dynamic arrays are a length followed by a pointer to the data,
+	not D arrays of chars, it turns out that since D
+	array references are a length followed by a pointer to the data,
 	the $(D %.*s) format works:
 	)
 

--- a/overview.dd
+++ b/overview.dd
@@ -907,7 +907,7 @@ synchronized int func() { ... }
     $(SECTION4 Support for Robust Techniques,
 
 	$(UL
-	$(LI Dynamic arrays instead of pointers)
+	$(LI Array references instead of pointers)
 
 	$(LI Reference variables instead of pointers)
 

--- a/statement.dd
+++ b/statement.dd
@@ -431,7 +431,7 @@ $(GNAME ForeachAggregate):
 
 $(P
         $(I ForeachAggregate) is evaluated. It must evaluate to an expression
-        of type static array, dynamic array, associative array,
+        of type static array, array reference, associative array,
         struct, class, delegate, or tuple.
         The $(PS0) is executed, once for each element of the
         aggregate.
@@ -450,7 +450,7 @@ $(P
 $(H4 Foreach over Arrays)
 
 $(P
-        If the aggregate is a static or dynamic array, there
+        If the aggregate is a static array or array reference, there
         can be one or two variables declared. If one, then the variable
         is said to be the $(I value) set to the elements of the array,
         one by one. The type of the
@@ -481,7 +481,7 @@ foreach (int i, char c; a)
 
 $(H4 Foreach over Arrays of Characters)
 
-        $(P If the aggregate expression is a static or dynamic array of
+        $(P If the aggregate expression is a static array or array reference of
         $(D char)s, $(D wchar)s, or $(D dchar)s, then the $(I Type) of
         the $(I value)
         can be any of $(D char), $(D wchar), or $(D dchar).

--- a/template.dd
+++ b/template.dd
@@ -976,7 +976,7 @@ $(H2 $(LNAME2 function-templates, Function Templates))
         ------
     )
 
-    $(P The deduced type parameter for dynamic array and pointer arguments
+    $(P The deduced type parameter for array reference and pointer arguments
         has an unqualified head:
 
         ------


### PR DESCRIPTION
Discussion thread: http://forum.dlang.org/post/loekwubzykmysrdzwpak@forum.dlang.org

Changes:
- Where it says 'dynamic array', instead say 'array reference'.
  Rationale:
  1) When an array reference is an lvalue, it behaves like a reference, not a dynamic array.
  2) When you shrink and later regrow an array reference, without using assumeSafeAppend(),
     reallocation occurs. This behavior seems reasonable, but it is not expected behavior
     for a dynamic array.
- Retain the term 'dynamic array' when we're referring to the GC-allocated array
  that these types often refer to. Those act like arrays and are somewhat dynamic.
- Clarify expression.dd - the definition of identity for array references. (Initially I thought it was
  incorrect, but I'd misread. Changing it to clarify.)

In arrays.dd:
- Fix some example code which didn't compile (especially around pointers).
- Reorder - introduce slices early, 'slicing' much later. Move "Array Declarations" later still.
- Add code cases around "s = <foo>" where s is a static array. The current version of arrays.dd
  seems to think this is meaningless, but I found otherwise through experimentation.

Notes (things I didn't do):
- abi.dd: The section named "Reference types" is slightly affected. It could add that array references are
  an exception to what it says there.
- d-array-article.dd: Some of this article is affected, it needs careful editing. Perhaps
  the need for it is eliminated but perhaps not.
- ctod.dd: This makes the claim that "D supports dynamic arrays, which can be easily resized", which
  I feel overstates it. The example given only shows growing, not shrinking, and
  it shows only a single array reference giving the impression of a one-to-one relationship
  where there is actually in general a many-to-one relationship.
- My search/replace would have missed where "dynamic array" has a linebreak between the two words
  in the .dd file. I noticed one case in overview.dd (but for that one, I prefer to leave it saying
  "dynamic array").
- Where I found "static or dynamic array" I wrote "static array or array reference".
  I'm inclined to think we don't need the "static" qualifier anymore, so
  maybe these should now read "array or array reference".
