### PR TITLE
Improve wording for foreach/foreach_reverse over struct/class.

### DIFF
--- a/statement.dd
+++ b/statement.dd
@@ -559,9 +559,9 @@ foreach (string s, double d; a)
 
 $(H4 $(LNAME2 foreach_with_ranges, Foreach over Structs and Classes with Ranges))
 
-        $(P Iteration over struct and class objects can be done with
-	ranges. For $(D foreach), this means the following properties and
-	methods must be defined:
+        $(P Iteration over struct and class objects can be done with ranges.
+        For $(D foreach), this means the following properties and methods must
+        be defined:
         )
 
         $(TABLE2 Foreach Range Properties,
@@ -572,8 +572,8 @@ $(H4 $(LNAME2 foreach_with_ranges, Foreach over Structs and Classes with Ranges)
 
         $(TABLE2 Foreach Range Methods,
         $(THEAD Method, Purpose)
-	$(TROW $(ARGS $(D .popFront())), $(ARGS move the left edge of the range
-		right by one))
+        $(TROW $(ARGS $(D .popFront())), $(ARGS move the left edge of the range
+        right by one))
         )
 
         $(P Meaning:)
@@ -592,9 +592,9 @@ for (auto __r = range; !__r.empty; __r.popFront())
 }
 ---
 
-	$(P Similarly, for $(D foreach_reverse), the following properties and
-	methods must be defined:
-	)
+        $(P Similarly, for $(D foreach_reverse), the following properties and
+        methods must be defined:
+        )
 
         $(TABLE2 Foreach_reverse Range Properties,
         $(THEAD Property, Purpose)
@@ -604,8 +604,8 @@ for (auto __r = range; !__r.empty; __r.popFront())
 
         $(TABLE2 Foreach_reverse Range Methods,
         $(THEAD Method, Purpose)
-	$(TROW $(ARGS $(D .popBack())), $(ARGS move the right edge of the range
-		left by one))
+        $(TROW $(ARGS $(D .popBack())), $(ARGS move the right edge of the range
+        left by one))
         )
 
         $(P Meaning:)
@@ -624,19 +624,19 @@ for (auto __r = range; !__r.empty; __r.popBack())
 }
 ---
 
-	$(P If the $(D foreach) or $(D foreach_reverse) range properties do not
-	exist, the $(D opApply) or $(D opApplyReverse) method, respectively,
-	will be used instead.
+        $(P If the $(D foreach) or $(D foreach_reverse) range properties do not
+        exist, the $(D opApply) or $(D opApplyReverse) method, respectively,
+        will be used instead.
         )
 
 
 $(H4 Foreach over Structs and Classes with opApply)
 
-	$(P If the aggregate expression is a struct or class object, and the
-	range properties do not exist, then the $(D foreach) is defined by the
-	special $(LNAME2 opApply, $(D opApply)) member function, and the
-	$(D foreach_reverse) behavior is defined by the special
-	$(LNAME2 opApplyReverse, $(D opApplyReverse)) member function.
+        $(P If the aggregate expression is a struct or class object, and the
+        range properties do not exist, then the $(D foreach) is defined by the
+        special $(LNAME2 opApply, $(D opApply)) member function, and the $(D
+        foreach_reverse) behavior is defined by the special
+        $(LNAME2 opApplyReverse, $(D opApplyReverse)) member function.
         These functions have the type:
         )
 


### PR DESCRIPTION
The current wording is a bit ambiguous and confusing to read, so I split up the docs for `foreach` vs. `foreach_reverse`.
Also, fixed some grammar issues.
And improved wording of docs for foreach with `opApply`, including fixing some inconsistent formatting for `opApply` and `opApplyReverse`.
