### PR TITLE
Add the Z 'type' to the mangling ABI to denote internal symbols.

### DIFF
--- a/abi.dd
+++ b/abi.dd
@@ -410,6 +410,7 @@ $(I Type):
     $(I TypeNull)
     $(I TypeTuple)
     $(I TypeVector)
+    $(I Internal)
 
 $(I Shared):
     $(B O) $(I Type)
@@ -591,6 +592,9 @@ $(I TypeNull):
 
 $(I TypeTuple):
     $(B B) $(I Number) $(I Arguments)
+
+$(I Internal):
+    $(B Z)
 )
 )
 


### PR DESCRIPTION
See discussion here: https://github.com/D-Programming-Language/druntime/pull/725

D already creates mangled names using the Z symbol for internal symbols, e.g.
_D3foo3Bar6__vtblZ for the virtual table for class foo.Bar. The ABI makes no
mention of these symbols. This pull request adds Z to the mangling ABI to make
these official symbols. The linked pull request implements that demangling.
