### PR TITLE
Fix DMD version links in changelog

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -9876,7 +9876,7 @@ Macros:
 	<div class="version">
 	$(B $(LARGE <a name="new2_$1">
 	  Version
-	  <a HREF="http://dlang.org/download.html" title="D 2.$1">D 2.$1</a>
+	  <a HREF="http://ftp.digitalmars.com/dmd.2.$1.zip" title="D 2.$1">D 2.$1</a>
 	))
 	$(SMALL $(I $2, $3))
 	$5


### PR DESCRIPTION
Allow for previous versions of dmd to be downloaded from the changelog page.
