### PR TITLE
Removed incorrect version in red.

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -5,7 +5,6 @@ $(D_S D Programming Language,
 $(SECTION3 The D programming language. Modern
 convenience. Modeling power. Native efficiency.,
 
-$(P $(RED $(B DMD v2.066 Beta is live. Now testing: $(LINK2 http://wiki.dlang.org/Beta_Testing, v2.066.0-rc2))))
 $(P Videos for DConf 2014 are available on $(LINK2 https://archive.org/search.php?query=title%3A%28DConf%202014%29&sort=+publicdate, archive.org).)
 $(P Videos and slides for DConf 2013 are available on $(LINK2 http://dconf.org/2013/schedule/index.html, dconf.org).)
 $(BR)


### PR DESCRIPTION
Main page still has the red line saying "DMD v2.066 Beta is live. Now testing: v2.066.0-rc2"...
