### PR TITLE
Fix grammar in attribute.dd

### DIFF
--- a/attribute.dd
+++ b/attribute.dd
@@ -328,6 +328,7 @@ $(GRAMMAR
 $(GNAME ProtectionAttribute):
     $(D private)
     $(D package)
+    $(D package) $(D $(LPAREN)) (GLINK IdentifierList) $(D $(RPAREN))
     $(D protected)
     $(D public)
     $(D export)


### PR DESCRIPTION
This is a supplemental fix of #591 that I had overlooked in my reviewing.
