### PR TITLE
Change named/anchored text ($(LNAME2 ...)) into subtle links to themselves

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -156,6 +156,30 @@ a:visited
 	color: #606;
 }
 
+/*
+Styling for page anchor self-links.
+
+These links look like regular headers unless hovered, in which case
+they are underlined and display a pilcrow after them.
+*/
+a.anchor
+{
+	color: #633; /* Use the regular header text color */
+	text-decoration: none; /* Don't underline unless hovered */
+}
+
+a.anchor:hover
+{
+	text-decoration: underline; /* See above */
+}
+
+a.anchor:hover:after
+{
+	content: " \00B6"; /* Unicode pilcrow symbol */
+	color: black; /* Pilcrow should not use the regular header text color */
+	font-style: normal; /* ... and should not be italic */
+}
+
 /* These are different kinds of <pre> sections */
 .bnf /* grammar */
 {

--- a/doc.ddoc
+++ b/doc.ddoc
@@ -332,8 +332,8 @@ TH=<th scope="col">$0</th>
 BLOCKQUOTE = <blockquote><p>$+</p><cite>$1</cite></blockquote>
 BLOCKQUOTE_PLAIN = <blockquote><p>$0</p></blockquote>
 TT=<tt>$0</tt>
-LNAME2=<a id="$1">$+</a>
-LEGACY_LNAME2=$(LNAME2 $1, $(LNAME2 $+))
+LNAME2=<a class="anchor" title="Permalink to this section" id="$1" href="#$1">$+</a>
+LEGACY_LNAME2=<span id="$1">$(LNAME2 $+)</span>
 SECTION1=<h1>$1</h1>$+
 SECTION2=$(H2 $1)$+
 SECTION3=<h3>$1</h3>$+
@@ -393,7 +393,7 @@ GLINK=$(RELATIVE_LINK2 $0, $(I $0))
 GLINK2=$(LINK2 $1.html#$2, $(I $2))
 GLINK2=$(DDSUBLINK $1,$2,$(I $2))
 DPLLINK=$(LINK2 $1,$+)
-GNAME=$(LNAME2 $0, $(I $0))
+GNAME=<a id="$0">$(I $0)</a>
 NOT_EBOOK=$0
 PHOBOS=<a href="phobos/std_$1.html#$2">$3</a>
 


### PR DESCRIPTION
Resumption of #497.

Difference from the original PR:
- `GNAME` was changed to use the `id` attribute instead of the `name` attribute, as the latter is deprecated.
- This PR now also changes `LEGACY_LNAME2` to use the `span` tag instead of the `a` tag for the legacy name, as it is illegal to nest `a` tags.
