### PR TITLE
Issue 10232 - AndExpression grammar is not correct

### DIFF
--- a/expression.dd
+++ b/expression.dd
@@ -185,8 +185,6 @@ $(GRAMMAR
 $(GNAME AndAndExpression):
     $(GLINK OrExpression)
     $(I AndAndExpression) $(CODE_AMP)$(CODE_AMP) $(GLINK OrExpression)
-    $(GLINK CmpExpression)
-    $(I AndAndExpression) $(CODE_AMP)$(CODE_AMP) $(GLINK CmpExpression)
 )
 
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=10232

And fix `AndAndExpression` grammar to fit current [parser implementation](https://github.com/D-Programming-Language/dmd/blob/3c5d1cd0365891b0a0bc977ab5b8479cd41d065d/src/parse.c#L7280).
