### PR TITLE
Issue 13525 - Redundant SpecialKeyword grammar listd in DefaultInitializerExpression

### DIFF
--- a/function.dd
+++ b/function.dd
@@ -30,7 +30,7 @@ $(GNAME ParameterList):
 $(GNAME Parameter):
     $(I InOut)$(OPT) $(GLINK2 declaration, BasicType) $(GLINK2 declaration, Declarator)
     $(I InOut)$(OPT) $(GLINK2 declaration, BasicType) $(GLINK2 declaration, Declarator) $(D ...)
-    $(I InOut)$(OPT) $(GLINK2 declaration, BasicType) $(GLINK2 declaration, Declarator) = $(GLINK DefaultInitializerExpression)
+    $(I InOut)$(OPT) $(GLINK2 declaration, BasicType) $(GLINK2 declaration, Declarator) = $(ASSIGNEXPRESSION)
     $(I InOut)$(OPT) $(GLINK2 declaration, Type)
     $(I InOut)$(OPT) $(GLINK2 declaration, Type) $(D ...)
 
@@ -67,10 +67,6 @@ $(GNAME MemberFunctionAttribute):
     $(D inout)
     $(D shared)
     $(GLINK FunctionAttribute)
-
-$(GNAME DefaultInitializerExpression):
-    $(ASSIGNEXPRESSION)
-    $(GLINK2 traits, SpecialKeyword)
 )
 
 $(GRAMMAR

--- a/grammar.dd
+++ b/grammar.dd
@@ -1145,7 +1145,7 @@ $(GNAME ParameterList):
 $(GNAME Parameter):
     $(I InOut)$(OPT) $(GLINK BasicType) $(GLINK Declarator)
     $(I InOut)$(OPT) $(GLINK BasicType) $(GLINK Declarator) $(D ...)
-    $(I InOut)$(OPT) $(GLINK BasicType) $(GLINK Declarator) = $(GLINK DefaultInitializerExpression)
+    $(I InOut)$(OPT) $(GLINK BasicType) $(GLINK Declarator) = $(ASSIGNEXPRESSION)
     $(I InOut)$(OPT) $(GLINK Type)
     $(I InOut)$(OPT) $(GLINK Type) $(D ...)
 
@@ -1182,10 +1182,6 @@ $(GNAME MemberFunctionAttribute):
     $(D inout)
     $(D shared)
     $(GLINK FunctionAttribute)
-
-$(GNAME DefaultInitializerExpression):
-    $(ASSIGNEXPRESSION)
-    $(GLINK SpecialKeyword)
 )
 
 $(GRAMMAR


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13525

Remove `DefaultInitializerExpression` and replace with `AssignExpression`.
