### PR TITLE
Issue 13538 & 13539 - Improve variable declaration grammar for old C style syntax

### DIFF
--- a/declaration.dd
+++ b/declaration.dd
@@ -32,8 +32,18 @@ $(GNAME DeclaratorIdentifierList):
     $(GLINK DeclaratorIdentifier) $(D ,) $(I DeclaratorIdentifierList)
 
 $(GNAME DeclaratorIdentifier):
+    $(GLINK VarDeclaratorIdentifier)
+    $(GLINK AltDeclaratorIdentifier)
+
+$(GNAME VarDeclaratorIdentifier):
     $(I Identifier)
     $(I Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK Initializer)
+
+$(GNAME AltDeclaratorIdentifier):
+    $(GLINK BasicType2) $(I Identifier) $(GLINK AltDeclaratorSuffixes)$(OPT)
+    $(GLINK BasicType2) $(I Identifier) $(GLINK AltDeclaratorSuffixes)$(OPT) $(D =) $(GLINK Initializer)
+    $(GLINK BasicType2)$(OPT) $(I Identifier) $(GLINK AltDeclaratorSuffixes)
+    $(GLINK BasicType2)$(OPT) $(I Identifier) $(GLINK AltDeclaratorSuffixes) $(D =) $(GLINK Initializer)
 
 $(GNAME Declarator):
     $(GLINK VarDeclarator)

--- a/grammar.dd
+++ b/grammar.dd
@@ -1024,8 +1024,18 @@ $(GNAME DeclaratorIdentifierList):
     $(GLINK DeclaratorIdentifier) $(D ,) $(I DeclaratorIdentifierList)
 
 $(GNAME DeclaratorIdentifier):
+    $(GLINK VarDeclaratorIdentifier)
+    $(GLINK AltDeclaratorIdentifier)
+
+$(GNAME VarDeclaratorIdentifier):
     $(I Identifier)
     $(I Identifier) $(GLINK TemplateParameters)$(OPT) $(D =) $(GLINK Initializer)
+
+$(GNAME AltDeclaratorIdentifier):
+    $(GLINK BasicType2) $(I Identifier) $(GLINK AltDeclaratorSuffixes)$(OPT)
+    $(GLINK BasicType2) $(I Identifier) $(GLINK AltDeclaratorSuffixes)$(OPT) $(D =) $(GLINK Initializer)
+    $(GLINK BasicType2)$(OPT) $(I Identifier) $(GLINK AltDeclaratorSuffixes)
+    $(GLINK BasicType2)$(OPT) $(I Identifier) $(GLINK AltDeclaratorSuffixes) $(D =) $(GLINK Initializer)
 
 $(GNAME Declarator):
     $(GLINK VarDeclarator)


### PR DESCRIPTION
[Issue 13538](https://issues.dlang.org/show_bug.cgi?id=13538) - Divide old C style syntax from D style grammar rule
[Issue 13539](https://issues.dlang.org/show_bug.cgi?id=13539) - Disallow optional template parameters with C-style syntax
