### PR TITLE
Issue 6620 - argument evaluation order inversed for extern(C)

### DIFF
--- a/expression.dd
+++ b/expression.dd
@@ -66,8 +66,7 @@ assert(text(++i, ++i) == "12"); // left to right evaluation of arguments
 
         $(P But even though the order of evaluation is well defined writing code that
         depends on it is rarely recommended.
-        $(B Note that dmd currently does not comply with left to right evaluation of
-        function arguments.))
+        )
 
 $(H3 $(LEGACY_LNAME2 Expression, expression, Expressions))
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=6620

Remove note (it was added in #6) for issue 6620.

Do not pull this documentation fix until dmd is actually fixed by https://github.com/D-Programming-Language/dmd/pull/4035 .
