### PR TITLE
Bump Visual D version to 0.3.39

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -201,8 +201,8 @@ $(TABLEDL IDE Support,
 	)
 
 	$(TR
-	 $(TDL $(LINK2 https://github.com/D-Programming-Language/visuald/releases/download/v0.3.37/VisualD-v0.3.37.exe, VisualD-v0.3.37.exe))
-	 $(TD 0.3.37)
+	 $(TDL $(LINK2 https://github.com/D-Programming-Language/visuald/releases/download/v0.3.39/VisualD-v0.3.39.exe, VisualD-v0.3.39.exe))
+	 $(TD 0.3.39)
 	 $(TD i386)
 	 $(TD $(WIN32))
 	 $(TD Visual D, plugin for Visual Studio 2005-13)


### PR DESCRIPTION
New version just released. The link was outdated for some time anyway.
