### PR TITLE
Make it clear that the CPU listed on the download page is the host, not target

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -12,7 +12,7 @@ $(TABLEDL DMD - Digital Mars D Programming Language version 2,
 	$(TR
 	$(TH Download)
 	$(TH Version)
-	$(TH CPU)
+	$(TH Host CPU)
 	$(TH Operating System)
 	$(TH Product)
 	)
@@ -142,7 +142,7 @@ $(TABLEDL LDC - the LLVM-based D compiler,
 	$(TR
 	$(TH Download)
 	$(TH Version)
-	$(TH CPU)
+	$(TH Host CPU)
 	$(TH Operating System(s))
 	$(TH Product)
 	)
@@ -195,7 +195,7 @@ $(TABLEDL IDE Support,
 	$(TR
 	$(TH Download)
 	$(TH Version)
-	$(TH CPU)
+	$(TH Host CPU)
 	$(TH Operating System(s))
 	$(TH Product)
 	)
@@ -217,7 +217,7 @@ $(TABLEDL DMD - Digital Mars D Programming Language version 1 $(BR)
 	$(TR
 	$(TH Download)
 	$(TH Version)
-	$(TH CPU)
+	$(TH Host CPU)
 	$(TH Operating System(s))
 	$(TH Product)
 	)
@@ -326,7 +326,7 @@ $(TABLEDL DMC - Digital Mars C and C++ Compiler,
 	$(TR
 	$(TH Download)
 	$(TH Version)
-	$(TH CPU)
+	$(TH Host CPU)
 	$(TH Operating System(s))
 	$(TH Product)
 	)


### PR DESCRIPTION
There [was some confusion](http://forum.dlang.org/post/tzutuouuvyzmziajsnyb@forum.dlang.org) after pull #593, which probably will require some documentation on Win64 also.  I'd like to also add somewhere that all dmd binaries support both i386 and x86_64 targets, but I'm not sure where to put it on the page.  It's unclear if gdc is only listing host CPUs or target CPUs also, so I left that one the way it is.
