### PR TITLE
Issue 9655: Functions with identical bodies are allowed to be merged by compiler.

### DIFF
--- a/function.dd
+++ b/function.dd
@@ -1742,6 +1742,21 @@ void bar()
 }
 ------
 
+        $(P $(B Note:) Two functions with identical bodies, or two functions
+        that compile to identical assembly code, are not guaranteed to have
+        distinct function pointer values. The compiler is free to merge
+        functions bodies into one if they compile to identical code.)
+
+------
+int abc(int x) { return x + 1; }
+int def(int y) { return y + 1; }
+
+int function() fp1 = &abc;
+int function() fp2 = &def;
+// Do not rely on fp1 and fp2 being different values; the compiler may merge
+// them.
+------
+
         $(P A delegate can be set to a non-static nested function:)
 
 ------


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=9655
