### PR TITLE
Revert "Document unittest attributes."

### DIFF
--- a/grammar.dd
+++ b/grammar.dd
@@ -1258,7 +1258,7 @@ $(GNAME Invariant):
     $(D invariant ( )) $(GLINK BlockStatement)
 
 $(GNAME UnitTest):
-    $(GLINK FunctionAttribute) $(D unittest) $(GLINK BlockStatement)
+    $(D unittest) $(GLINK BlockStatement)
 )
 
 $(GRAMMAR

--- a/unittest.dd
+++ b/unittest.dd
@@ -4,7 +4,7 @@ $(SPEC_S Unit Tests,
 
 $(GRAMMAR
 $(GNAME UnitTest):
-    $(GLINK2 function, FunctionAttribute) $(D unittest) $(GLINK2 statement, BlockStatement)
+    $(D unittest) $(GLINK2 statement, BlockStatement)
 )
 
 	$(P Unit tests are a series of test cases applied to a module to determine


### PR DESCRIPTION
Reverts D-Programming-Language/dlang.org#685

It is unnecessary so the prefix attributes on unittest block had been already supported in grammar.
