### PR TITLE
Explain usage of attributed unittests.

### DIFF
--- a/unittest.dd
+++ b/unittest.dd
@@ -57,6 +57,36 @@ class Sum
 }
 ------
 
+$(H4 Attributed Unittests)
+
+$(P A unittest may be attributed with any of the global function attributes.
+Such unittests are useful in verifying the given attribute(s) on a template
+function:)
+
+------
+void myFunc(T)(T[] data)
+{
+    if (data.length > 2)
+        data[0] = data[1];
+}
+
+@safe nothrow unittest
+{
+    auto arr = [1,2,3];
+    myFunc(arr);
+    assert(arr == [2,2,3]);
+}
+------
+
+$(P This unittest verifies that $(D myFunc) contains only $(D @safe), $(D
+nothrow) code. Although this can also be accomplished by attaching these
+attributes to $(D myFunc) itself, that would prevent $(D myFunc) from being
+instantiated with types $(D T) that have $(D @system) or throwing code in their
+$(D opAssign) method, or other methods that $(D myFunc) may call. The above
+idiom allows $(D myFunc) to be instantiated with such types, yet at the same
+time verify that the $(D @system) and throwing behaviour is not introduced by
+the code within $(D myFunc) itself.)
+
 $(H4 $(LNAME2 documented-unittests, Documented Unittests))
 
 $(P Documented unittests allow the developer to deliver code examples to the user,


### PR DESCRIPTION
Address underlying issue behind https://github.com/D-Programming-Language/dlang.org/pull/685 even though the grammar change was redundant and reverted by https://github.com/D-Programming-Language/dlang.org/pull/688 .
