### PR TITLE
Remove exception for eponymous template

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -64,15 +64,6 @@ struct FooAndBar;
 -------------------------------
     )
 
-    $(DD An exception is that eponymous templates that return a value instead of
-         a type should not be capitalized, as they are conceptually more similar
-         to functions.
-
--------------------------
-template GetSomeType(T) { alias GetSomeType = T; }
-template isSomeType(T) { enum isSomeType = is(T == SomeType); }
--------------------------
-     )
 
     $(DT Functions)
     $(DD Function names should be camelCased, so their first letter is lowercase.


### PR DESCRIPTION
I would like to remove this exception from the style guide.

It was originally added some 4 years ago (0749288c6f5379fd11c5ee933b34133e45edc573), but there's no PR for it so I couldn't find any relevant discussion).
It looks like that was a de-facto standard, as e.g. `std.typetuple.IndexOf` was renamed to `indexOf` in 2007 ([relevant Phobos commit](https://github.com/D-Programming-Language/phobos/commit/a9bc53273c7930c9b2cf442e3d8bc4e28d65ee4b)).
I think the reason was to make the intent of the template clear to the reader. However, it overlooked the fact that such templates are often CT implementations of RT function, and thus we got name clashes. This leads to a situation where we have inconsistent name between CT and RT version.
Example:
- std.algorithm.all / std.typetuple.allSatisfy;
- std.algorithm.any / std.typetuple.anySatisfy;
- std.algorithm.map / std.typetuple.staticMap;
- indexOf / staticIndexOf;

With the effort to move `std.typetuple` to `std.meta.list` and draw a clearer separation between tuple and argument list (https://github.com/D-Programming-Language/phobos/pull/2687), it could also be a good time to consolidate the naming between CT and RT algorithm, and avoid double deprecation time.
