### PR TITLE
unions may not have postblits, destructors, or invariants

### DIFF
--- a/struct.dd
+++ b/struct.dd
@@ -605,6 +605,10 @@ $(H2 $(LNAME2 nested, Nested Structs))
         ---
     )
 
+$(H2 Unions and Special Member Functions)
+
+    $(P Unions may not have postblits, destructors, or invariants.)
+
 )
 
 Macros:


### PR DESCRIPTION
This has always been true, but never written in the spec.

https://issues.dlang.org/show_bug.cgi?id=4421
