### PR TITLE
remove google translate link

### DIFF
--- a/doc.ddoc
+++ b/doc.ddoc
@@ -95,20 +95,6 @@ PAGE_TOOLS=
     </span>
 </div>
 
-GOOGLE_TRANSLATE=
-<div id="translate" class="tool">Translate this page:
-    <div id="google_translate_element"></div><script type="text/javascript">
-    function googleTranslateElementInit() {
-      new google.translate.TranslateElement({
-        pageLanguage: 'en',
-        autoDisplay: false,
-        layout: google.translate.TranslateElement.InlineLayout.SIMPLE
-      }, 'google_translate_element');
-    }
-    </script>
-<script type="text/javascript" src="http://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
-</div>
-
 COPYRIGHT=
 Copyright &copy; 1999-$(YEAR) by Digital Mars &reg;, All Rights Reserved
 
@@ -297,7 +283,6 @@ COMMUNITY= $(LAYOUT $(NAVIGATION),$1,$(ARGS $+))
 LAYOUT=
 <div id="navigation">
   $1
-  $(GOOGLE_TRANSLATE)
 </div><!--/navigation-->
 <div id="content" class='hyphenate'>
   $(PAGE_TOOLS)

--- a/index.dd
+++ b/index.dd
@@ -561,7 +561,6 @@ $(TAG2 div, id="a$1" class="answer-nojs", $2)
     LAYOUT=
 <div id="navigation">
   $1
-  $(GOOGLE_TRANSLATE)
 </div>
 <div id="twitter">
 <a class="twitter-timeline" data-dnt="true" href="https://twitter.com/D_Programming" data-widget-id="358057551562162176">Tweets by @D_Programming</a>


### PR DESCRIPTION
- website translation is already integrated in browsers
  or can easily be added as plugin
- people already know how to translate websites if necessary
