### PR TITLE
Issue 13696: Document meaning of escape sequences.

### DIFF
--- a/lex.dd
+++ b/lex.dd
@@ -554,6 +554,42 @@ q{ __TIME__ }       // " __TIME__ "
     // __EOF__ is not a token, it's end of file
 ---
 
+$(H4 Escape Sequences)
+
+    $(P The following table explains the meaning of the escape sequences listed
+    in $(GLINK EscapeSequence):)
+
+    $(TABLE2 Escape Sequences
+    $(THEAD Sequence, Meaning)
+    $(TROW $(D \'), Literal single-quote: $(D '))
+    $(TROW $(D \"), Literal double-quote: $(D "))
+    $(TROW $(D \?), Literal question mark: $(D ?))
+    $(TROW $(D \\), Literal backslash: $(D \))
+    $(TROW $(D \0), Binary zero (NUL, U+0000).)
+    $(TROW $(D \a), BEL (alarm) character (U+0007).)
+    $(TROW $(D \b), Backspace (U+0008).)
+    $(TROW $(D \f), Form feed (FF) (U+000C).)
+    $(TROW $(D \n), End-of-line (U+000A).)
+    $(TROW $(D \r), Carriage return (U+000D).)
+    $(TROW $(D \t), Horizontal tab (U+0009).)
+    $(TROW $(D \v), Vertical tab (U+000B).)
+    $(TROW $(D \x)$(I nn), Byte value in hexadecimal$(COMMA) where $(I nn) is
+        specified as two hexadecimal digits.$(BR)For example: $(D \xFF)
+        represents the character with the value 255.)
+    $(TROW $(D \)$(I n)$(BR)$(D \)$(I nn)$(BR)$(D \)$(I nnn), Byte value in
+        octal.$(BR)For example: $(D \775) represents the character with the
+        value 509.)
+    $(TROW $(D \u)$(I nnnn), Unicode character U+$(I nnnn)$(COMMA) where
+        $(I nnnn) are four hexadecimal digits.$(BR)For example$(COMMA)
+        $(D \u042F) represents the Unicode character Я (U+42F).)
+    $(TROW $(D \U)$(I nnnnnnnn), Unicode character U+$(I nnnnnnnn)$(COMMA)
+        where $(I nnnnnnnn) are 8 hexadecimal digits.$(BR)For example$(COMMA)
+        $(D \U0001F603) represents the Unicode character U+1F603 (SMILING FACE
+        WITH OPEN MOUTH).)
+    $(TROW $(D \)$(I name), Named character entity from the HTML5
+        specification. See $(GLINK2 entity, NamedCharacterEntity) for more
+        details.)
+    )
 
 
 $(H3 $(LNAME2 characterliteral, Character Literals))


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=13696
