### PR TITLE
Better wording about difference between void[] and ubyte[].

### DIFF
--- a/arrays.dd
+++ b/arrays.dd
@@ -988,9 +988,9 @@ void main()
     being presumed to contain only pure byte data, not pointers. However, it
     $(I will) scan $(D void[]) arrays for pointers, since such an array may
     have been implicitly converted from an array of pointers or an array of
-    elements that contain pointers.  Casting an array that contains pointers to
-    $(D ubyte[]) may run the risk of the GC collecting live memory if it
-    becomes the only remaining references to the pointers' targets.)
+    elements that contain pointers.  Allocating an array that contains pointers
+    as $(D ubyte[]) may run the risk of the GC collecting live memory if these
+    pointers are the only remaining references to their targets.)
 
 $(H2 $(LNAME2 implicit-conversions, Implicit Conversions))
 


### PR DESCRIPTION
Follow-up fix for https://github.com/D-Programming-Language/dlang.org/pull/715
