### PR TITLE
Shorten std.ddoc by removing redundant stuff from it, and by moving non-...

### DIFF
--- a/html.ddoc
+++ b/html.ddoc
@@ -20,6 +20,7 @@ DL = <dl>$0</dl>
 DOUBLEQUOTE = $(LDQUO)$0$(RDQUO)
 DT = <dt>$0</dt>
 ENUMERATE = $(OL $(ITEMS_HELPER $1, $+))
+GREATER = &gt;
 ITEMIZE = $(UL $(ITEMS_HELPER $1, $+))
 ITEMS_HELPER = $(LI $1)$(ITEMS_HELPER $+)
 FONT = <font $1>$+</font>
@@ -31,9 +32,11 @@ H5 = <h5>$0</h5>
 HR = <hr>
 I = <i>$0</i>
 LI = <li>$0</li>
+LESS = &lt;
 OL = <ol>$0</ol>
 P = <p>$0</p>
 PRE = <pre>$0</pre>
+SCRIPT = <script type="text/javascript">$0</script>
 SINGLEQUOTE = $(LSQUO)$0$(RSQUO)
 SMALL = <small>$0</small>
 SPAN = <span $1>$+</span>
@@ -54,16 +57,21 @@ _=Defining anchors and linking
 
 LINK = $(A $0, $0)
 LINK2 = $(A $1, $+)
+HTTP = $(LINK2 http://$1,$2)
+HTTPS = $(LINK2 https://$1,$2)
+WEB = $(HTTP $1,$2)
+LUCKY = $(HTTP
+google.com/search?btnI=I%27m+Feeling+Lucky&amp;ie=UTF-8&amp;oe=UTF-8&amp;q=$0,$0)
 
 _=Colors
 
 COLOR = $(FONT color=$1, $+)
-RED = $(COLOR red, $0)
-BLUE = $(COLOR blue, $0)
-GREEN = $(COLOR green, $0)
-YELLOW = $(COLOR yellow, $0)
-BLACK = $(COLOR black, $0)
-WHITE = $(COLOR white, $0)
+RED    = <span style="color:red">$0</span>
+GREEN  = <span style="color:green">$0</span>
+BLUE   = <span style="color:blue">$0</span>
+YELLOW = <span style="color:yellow">$0</span>
+BLACK  = <span style="color:black">$0</span>
+WHITE  = <span style="color:white">$0</span>
 
 _=Explanatory stuff of the kind "Throws: blah" or "Returns:
 blah". Note that if you want to make a SPAN-like (brief) explanation,
@@ -74,7 +82,7 @@ DDOC_EXPLANATORY=$(DIVC explanatory, $(SPANC explanation_item, $1:) $(DIVC $1, $
 
 _=Predefined D-related stuff
 
-D_CODE = $(DIVC d_code, $0)
+D_CODE = <pre class="d_code">$0</pre>
 D_COMMENT = $(SPANC d_comment, $0)
 D_STRING  = $(SPANC d_string, $0)
 D_KEYWORD = $(SPANC d_keyword, $0)
@@ -94,44 +102,58 @@ $(BODY)
 
 _=DDoc-related stuff
 
-DDOC_COMMENT   = <!--$0-->
-DDOC_DECL      = $(SPANC d_decl, $0)
-DDOC_DECL_DD   = $(DIVC d_decl_dd, $0)
+DDOC_COMMENT   = <!-- $0 -->
+DDOC_DECL      = $(DT $(BIG $0))
+DDOC_DECL_DD   = $(DD $0)
 DDOC_DITTO     = $(BR)$0
-DDOC_SECTIONS  = $(DIVC sections, $0)
-DDOC_SUMMARY   = $(DIVC summary, $0)
-DDOC_DESCRIPTION = $(DIVC description, $0)
-DDOC_AUTHORS   = $(DDOC_EXPLANATORY Authors, $0)
-DDOC_BUGS      = $(DDOC_EXPLANATORY Bugs, $0)
-DDOC_COPYRIGHT = $(DDOC_EXPLANATORY Copyright, $0)
-DDOC_DATE      = $(DDOC_EXPLANATORY Date, $0)
-DDOC_DEPRECATED = $(DDOC_EXPLANATORY Deprecated, $0)
-DDOC_EXAMPLES  = $(DDOC_EXPLANATORY Examples, $0)
-DDOC_HISTORY   = $(DDOC_EXPLANATORY History, $0)
-DDOC_LICENSE   = $(DDOC_EXPLANATORY License, $0)
-DDOC_RETURNS   = $(DDOC_EXPLANATORY Returns, $0)
-DDOC_SEE_ALSO  = $(DDOC_EXPLANATORY See_Also, $0)
-DDOC_STANDARDS = $(DDOC_EXPLANATORY Standards, $0)
-DDOC_THROWS    = $(DDOC_EXPLANATORY Throws, $0)
-DDOC_VERSION   = $(DDOC_EXPLANATORY Version, $0)
-DDOC_SECTION_H = $(SPANC section_h, $0)
-DDOC_SECTION   = $(DIVC section, $0)
-DDOC_MEMBERS   = $(DIVC members, $0)
-DDOC_MODULE_MEMBERS   = $(DDOC_MEMBERS $(DIVC module_members, $0))
-DDOC_CLASS_MEMBERS    = $(DDOC_MEMBERS $(DIVC class_members, $0))
-DDOC_STRUCT_MEMBERS   = $(DDOC_MEMBERS $(DIVC struct_members, $0))
-DDOC_ENUM_MEMBERS     = $(DDOC_MEMBERS $(DIVC enum_members, $0))
-DDOC_TEMPLATE_MEMBERS = $(DDOC_MEMBERS $(DIVC template_members, $0))
-DDOC_PARAMS    = $(DDOC_EXPLANATORY Params, $(TABLEC params, $0))
+DDOC_SECTIONS  = $0
+DDOC_SUMMARY   = $0$(BR)$(BR)
+DDOC_DESCRIPTION = $0$(BR)$(BR)
+DDOC_AUTHORS   = $(B Authors:)$(BR)
+        $0$(BR)$(BR)
+DDOC_BUGS      = $(RED BUGS:)$(BR)
+        $0$(BR)$(BR)
+DDOC_COPYRIGHT = $(B Copyright:)$(BR)
+        $0$(BR)$(BR)
+DDOC_DATE      = $(B Date:)$(BR)
+        $0$(BR)$(BR)
+DDOC_DEPRECATED = $(RED Deprecated:)$(BR)
+        $0$(BR)$(BR)
+DDOC_EXAMPLES  = $(B Examples:)$(BR)
+        $0$(BR)$(BR)
+DDOC_HISTORY   = $(B History:)$(BR)
+        $0$(BR)$(BR)
+DDOC_LICENSE   = $(B License:)$(BR)
+        $0$(BR)$(BR)
+DDOC_RETURNS   = $(B Returns:)$(BR)
+        $0$(BR)$(BR)
+DDOC_SEE_ALSO  = $(B See Also:)$(BR)
+        $0$(BR)$(BR)
+DDOC_STANDARDS = $(B Standards:)$(BR)
+        $0$(BR)$(BR)
+DDOC_THROWS    = $(B Throws:)$(BR)
+        $0$(BR)$(BR)
+DDOC_VERSION   = $(B Version:)$(BR)
+        $0$(BR)$(BR)
+DDOC_SECTION_H = $(B $0)$(BR)$(BR)
+DDOC_SECTION   = $0$(BR)$(BR)
+DDOC_MEMBERS   = $(DL $0)
+DDOC_MODULE_MEMBERS   = $(DDOC_MEMBERS $0)
+DDOC_CLASS_MEMBERS    = $(DDOC_MEMBERS $0)
+DDOC_STRUCT_MEMBERS   = $(DDOC_MEMBERS $0)
+DDOC_ENUM_MEMBERS     = $(DDOC_MEMBERS $0)
+DDOC_TEMPLATE_MEMBERS = $(DDOC_MEMBERS $0)
+DDOC_PARAMS    = $(B Params:)$(BR)
+$(TABLE $0)$(BR)
 DDOC_PARAM_ROW = $(TR $0)
-DDOC_PARAM_ID  = $(TD $(SPANC param_id, $0))
-DDOC_PARAM_DESC  = $(TD $(SPANC param_desc, $0))
-DDOC_BLANKLINE = $(BR)
+DDOC_PARAM_ID  = $(TD $0)
+DDOC_PARAM_DESC  = $(TD $0)
+DDOC_BLANKLINE = $(BR)$(BR)
 
-DDOC_ANCHOR  = $(ADEF $1)
-DDOC_PSYMBOL = $(SPANC psymbol, $0)
-DDOC_KEYWORD = $(SPANC ddoc_keyword, $0)
-DDOC_PARAM   = $(SPANC param, $0)
+DDOC_ANCHOR  = <a name="$1"></a>
+DDOC_PSYMBOL = $(U $0)
+DDOC_KEYWORD = $(B $0)
+DDOC_PARAM   = $(I $0)
 
 _=HTML named entities, ordered approximately as in http://dlang.org/entity.html
 

--- a/posix.mak
+++ b/posix.mak
@@ -266,7 +266,7 @@ ${DOC_OUTPUT_DIR}/phobos-prerelease/object.html : ${DMD_DIR}/src/dmd
 	rm -f $@
 	${MAKE} --directory=${DRUNTIME_DIR} -f posix.mak -j 4 \
 		DOCDIR=${DOC_OUTPUT_DIR}/phobos-prerelease \
-		DOCFMT="`pwd`/std_navbar-prerelease.ddoc `pwd`/std.ddoc `pwd`/macros.ddoc"
+		DOCFMT="`pwd`/html.ddoc `pwd`/std_navbar-prerelease.ddoc `pwd`/std.ddoc `pwd`/macros.ddoc"
 
 druntime-release : ${DRUNTIME_DIR}-${LATEST}/.cloned ${DOC_OUTPUT_DIR}/phobos/object.html
 ${DOC_OUTPUT_DIR}/phobos/object.html : ${DMD_DIR}-${LATEST}/src/dmd
@@ -275,27 +275,28 @@ ${DOC_OUTPUT_DIR}/phobos/object.html : ${DMD_DIR}-${LATEST}/src/dmd
 	${MAKE} --directory=${DRUNTIME_DIR}-${LATEST} -f posix.mak \
 	  DMD=${DMD_DIR}-${LATEST}/src/dmd \
 	  DOCDIR=${DOC_OUTPUT_DIR}/phobos \
-	  DOCFMT="`pwd`/std_navbar-$(LATEST).ddoc `pwd`/std.ddoc `pwd`/macros.ddoc" -j 4
+	  DOCFMT="`pwd`/html.ddoc `pwd`/std_navbar-$(LATEST).ddoc `pwd`/std.ddoc `pwd`/macros.ddoc" -j 4
 
 ################################################################################
 # phobos, latest released build and current build
 ################################################################################
 
 phobos-prerelease : ${PHOBOS_DIR}/.cloned ${DOC_OUTPUT_DIR}/phobos-prerelease/index.html
-${DOC_OUTPUT_DIR}/phobos-prerelease/index.html : std.ddoc macros.ddoc \
+${DOC_OUTPUT_DIR}/phobos-prerelease/index.html : html.ddoc std.ddoc macros.ddoc \
 	    ${DOC_OUTPUT_DIR}/phobos-prerelease/object.html
 	${MAKE} --directory=${PHOBOS_DIR} -f posix.mak \
+	STDDOC="`pwd`/html.ddoc `pwd`/std_navbar-prerelease.ddoc `pwd`/std.ddoc `pwd`/macros.ddoc" \
 	DOC_OUTPUT_DIR=${DOC_OUTPUT_DIR}/phobos-prerelease html -j 4
 
 phobos-release : ${PHOBOS_DIR}-${LATEST}/.cloned ${DOC_OUTPUT_DIR}/phobos/index.html
-${DOC_OUTPUT_DIR}/phobos/index.html : std.ddoc macros.ddoc ${LATEST}.ddoc \
+${DOC_OUTPUT_DIR}/phobos/index.html : html.ddoc std.ddoc macros.ddoc ${LATEST}.ddoc \
 	    ${DOC_OUTPUT_DIR}/phobos/object.html
 	${MAKE} --directory=${PHOBOS_DIR}-${LATEST} -f posix.mak -j 4 \
 	  all html \
 	  DMD=${DMD_DIR}-${LATEST}/src/dmd \
 	  DRUNTIME_PATH=${DRUNTIME_DIR}-${LATEST} \
 	  DOC_OUTPUT_DIR=${DOC_OUTPUT_DIR}/phobos \
-	  STDDOC="`pwd`/$(LATEST).ddoc `pwd`/std_navbar-$(LATEST).ddoc `pwd`/std.ddoc `pwd`/macros.ddoc"
+	  STDDOC="`pwd`/html.ddoc `pwd`/$(LATEST).ddoc `pwd`/std_navbar-$(LATEST).ddoc `pwd`/std.ddoc `pwd`/macros.ddoc"
 
 ################################################################################
 # phobos and druntime, latest released build and current build (DDOX version)
@@ -304,19 +305,19 @@ ${DOC_OUTPUT_DIR}/phobos/index.html : std.ddoc macros.ddoc ${LATEST}.ddoc \
 apidocs-prerelease : ${DOC_OUTPUT_DIR}/library-prerelease/sitemap.xml
 apidocs-release : ${DOC_OUTPUT_DIR}/library/sitemap.xml
 apidocs-serve : docs-prerelease.json
-	${DPL_DOCS} serve-html --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
+	${DPL_DOCS} serve-html --std-macros=html.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
 	  --override-macros=std-ddox-override.ddoc --package-order=std \
 	  --git-target=master --web-file-dir=. docs-prerelease.json
 
 ${DOC_OUTPUT_DIR}/library-prerelease/sitemap.xml : docs-prerelease.json
 	@mkdir -p $(dir $@)
-	${DPL_DOCS} generate-html --file-name-style=lowerUnderscored --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
+	${DPL_DOCS} generate-html --file-name-style=lowerUnderscored --std-macros=html.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
 	  --override-macros=std-ddox-override.ddoc --package-order=std \
 	  --git-target=master docs-prerelease.json ${DOC_OUTPUT_DIR}/library-prerelease
 
 ${DOC_OUTPUT_DIR}/library/sitemap.xml : docs.json
 	@mkdir -p $(dir $@)
-	${DPL_DOCS} generate-html --file-name-style=lowerUnderscored --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
+	${DPL_DOCS} generate-html --file-name-style=lowerUnderscored --std-macros=html.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
 	  --override-macros=std-ddox-override.ddoc --package-order=std \
 	  --git-target=v${LATEST} docs.json ${DOC_OUTPUT_DIR}/library
 

--- a/std.ddoc
+++ b/std.ddoc
@@ -1,5 +1,3 @@
-BR =	<br>
-DDOC_DITTO     = $(BR)$0
 DDOC_SUMMARY   = $0$(P)
 DDOC_DESCRIPTION = $0$(P)
 DDOC_AUTHORS   = $(B Authors:)$(BR)$0$(P)
@@ -19,7 +17,6 @@ DDOC_SECTION_H = $(B $0)$(BR)
 DDOC_SECTION   = $0$(P)
 DDOC_PARAMS    = $(B Parameters:)<table class=parms>$0</table>$(P)
 DDOC_BLANKLINE	= $(P)
-ARGS=$0
 D_RUN_CODE =
 <div>
 <div class="d_code">$1</div>
@@ -194,27 +191,6 @@ TOP=
 </div>
 </div>
 
-RED    = <span style="color:red">$0</span>
-GREEN  = <span style="color:green">$0</span>
-BLUE   = <span style="color:blue">$0</span>
-YELLOW = <span style="color:yellow">$0</span>
-BLACK  = <span style="color:black">$0</span>
-WHITE  = <span style="color:white">$0</span>
-
-D_COMMENT = <span class="d_comment">$0</span>
-D_STRING  = <span class="d_string">$0</span>
-D_KEYWORD = <span class="d_keyword">$0</span>
-D_PSYMBOL = <span class="d_psymbol">$0</span>
-D_PARAM   = <span class="d_param">$0</span>
-RPAREN = )
-LPAREN = (
-LESS = &lt;
-GREATER = &gt;
-HTTP = $(LINK2 http://$1,$2)
-HTTPS = $(LINK2 https://$1,$2)
-WEB = $(HTTP $1,$2)
-LUCKY = $(HTTP
-google.com/search?btnI=I%27m+Feeling+Lucky&amp;ie=UTF-8&amp;oe=UTF-8&amp;q=$0,$0)
 D = <span class="d_inlinecode">$0</span>
 BIGOH = <b><i>&Omicron;</i>(</b>$(D $0)<b><i>)</i></b>
 GLOSSARY = $(LINK2 ../glossary.html#$0, $0)
@@ -227,7 +203,6 @@ CXREF = <a href="core_$1.html#$2">$(D core.$1.$2)</a>
 ECXREF = <a href="etc_c_$1.html#$2">$(D etc.c.$1.$2)</a>
 LREF = <a href="#$1">$(D $1)</a>
 BUGZILLA = $(LINK2 https://issues.dlang.org/show_bug.cgi?id=$0, Bugzilla $0)
-PRE = <pre>$0</pre>
 PHOBOSSRC=$(LINK2 https://github.com/D-Programming-Language/phobos/blob/master/$0, $0)
 DRUNTIMESRC=$(LINK2 https://github.com/D-Programming-Language/druntime/blob/master/src/$0, $0)
 SAMPLESRC=$(LINK2 https://github.com/D-Programming-Language/dmd/blob/master/samples/$0, /dmd/samples/d/$0)
@@ -238,11 +213,5 @@ TABLE = <table cellspacing=0 cellpadding=5><caption>$1</caption>$2</table>
 TD = <td valign=top>$0</td>
 TDNW = <td valign=top class="donthyphenate" nowrap>$0</td>
 SUB_IS_DEPRECATED=kept for compatibility, but collides with SUB=&sub; use SUBSCRIPT instead (this is a comment and can be changed into one if ddoc files ever start supporting comments)
-SUB = <sub>$0</sub>
-SUPERSCRIPT = <sup>$0</sup>
-SUBSCRIPT = <sub>$0</sub>
 
 COPYRIGHT= Copyright &copy; 1999-$(YEAR) by Digital Mars, All Rights Reserved
-
-H2=<h2>$0</h2>
-SCRIPT = <script type="text/javascript">$0</script>

--- a/win32.mak
+++ b/win32.mak
@@ -303,10 +303,10 @@ clean:
 ################# DDOX based API docs #########################
 
 apidocs: docs.json
-	$(DPL_DOCS) generate-html --file-name-style=lowerUnderscored --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc --override-macros=std-ddox-override.ddoc --package-order=std --git-target=master docs.json library
+	$(DPL_DOCS) generate-html --file-name-style=lowerUnderscored --std-macros=html.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc --override-macros=std-ddox-override.ddoc --package-order=std --git-target=master docs.json library
 
 apidocs-serve: docs.json
-	$(DPL_DOCS) serve-html --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc --override-macros=std-ddox-override.ddoc --package-order=std --git-target=master --web-file-dir=. docs.json
+	$(DPL_DOCS) serve-html --std-macros=html.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc --override-macros=std-ddox-override.ddoc --package-order=std --git-target=master --web-file-dir=. docs.json
 
 docs.json: $(DPL_DOCS)
 	mkdir .tmp


### PR DESCRIPTION
...dlang.org specific stuff in it to html.ddoc

This is also conservative (does not change the generated site yet).
