### PR TITLE
Remove leading dot from DDOC_ANCHOR

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -123,8 +123,8 @@ DDOC_PARAM_ID  = <td class="param_id">$0</td>
 DDOC_PARAM_DESC  = <td class="param_desc">$0</td>
 DDOC_PARAMS    = $(DDOCKEYVAL Parameters, <table class="params">$0</table>)
 DDOC_BLANKLINE	= $(P)
-DDOC_PSYMBOL = $(ADEF $0)$(SPANC ddoc_psymbol, $0)
-DDOC_ANCHOR = $(ADEF .$1)$(DIVCID quickindex, quickindex.$1, )
+DDOC_PSYMBOL = $(SPANC ddoc_psymbol, $0)
+DDOC_ANCHOR = $(ADEF $1)$(DIVCID quickindex, quickindex.$1, )
 DDOC_DECL  = $(TC dt, d_decl, $0)
 DDOC_UNDEFINED_MACRO = $(DDOC_COMMENT UNDEFINED MACRO: "$1")
 DDOCCODE=$(TC pre, ddoccode notranslate, $0)

--- a/html.ddoc
+++ b/html.ddoc
@@ -4,7 +4,7 @@ here for completeness. Macros defer wherever possible to style classes.
 _=Simple tags, ordered alphabetically
 
 A = <a href="$1">$+</a>
-ADEF = <a name="$0"></a>
+ADEF = <a id="$0"></a>
 AHTTP = <a href="http://$1">$+</a>
 AHTTPS = <a class="https" href="https://$1">$+</a>
 ALOCAL = <a href="#$1">$+</a>

--- a/js/listanchors.js
+++ b/js/listanchors.js
@@ -59,7 +59,7 @@ function listanchors()
             var a = arr[i];
             var text = lastName(a);
             if (i != 0) newText += " &middot;"; 
-            newText += ' <a href="#' + a +
+            newText += ' <a href="#' + a.slice(1) + // Skip dot
                 '">' + text + '</a>';
         }
         if (newText != "")


### PR DESCRIPTION
The leading dot was introduced in #179 to avoid conflicts with legacy fragment names.

However, the legacy fragment name scheme is not compatible with HTML. Fragment names must be unique in the document, whether using `name` (removed in HTML5) or `id`, otherwise behaviour is undefined. For example, for http://dlang.org/phobos/std_stdio#writeln, Firefox links to the `name="writeln"` appearing earliest in the document, which is actually `std.stdio.File.writeln`, as opposed to the `std.stdio.writeln` one would expect.

With this PR, only the qualified name (rooted in the module) emits a fragment, so we can remove the leading dot.

Apropos `name`, it should be changed to `id` everywhere for HTML5 compatbility. This PR only does it in one place.
