### PR TITLE
Upgrade dpl docs dependencies

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1119,6 +1119,12 @@ These classes come from prettify.js:
     color: #4040DC;
 }
 
+.typ
+{
+    color: #4040DC;
+}
+
+
 .d_param
 {
     font-style: italic;

--- a/dpl-docs/dub.json
+++ b/dpl-docs/dub.json
@@ -1,7 +1,7 @@
 {
 	"name": "dpl-docs",
 	"dependencies": {
-		"ddox": "~>0.14.0"
+		"ddox": "~>0.15.0"
 	},
 	"versions": ["VibeCustomMain"]
 }

--- a/dpl-docs/dub.json
+++ b/dpl-docs/dub.json
@@ -1,7 +1,7 @@
 {
 	"name": "dpl-docs",
 	"dependencies": {
-		"ddox": "~>0.13.0"
+		"ddox": "~>0.14.0"
 	},
 	"versions": ["VibeCustomMain"]
 }

--- a/dpl-docs/dub.selections.json
+++ b/dpl-docs/dub.selections.json
@@ -2,7 +2,7 @@
 	"fileVersion": 1,
 	"versions": {
 		"backtrace-d": "~master",
-		"ddox": "0.13.5",
+		"ddox": "0.14.2",
 		"experimental_allocator": "2.70.0-b1",
 		"hyphenate": "1.1.1",
 		"libasync": "0.7.9",

--- a/dpl-docs/dub.selections.json
+++ b/dpl-docs/dub.selections.json
@@ -2,7 +2,7 @@
 	"fileVersion": 1,
 	"versions": {
 		"backtrace-d": "~master",
-		"ddox": "0.14.3",
+		"ddox": "0.15.0",
 		"experimental_allocator": "2.70.0-b1",
 		"hyphenate": "1.1.1",
 		"libasync": "0.7.9",

--- a/dpl-docs/dub.selections.json
+++ b/dpl-docs/dub.selections.json
@@ -2,7 +2,7 @@
 	"fileVersion": 1,
 	"versions": {
 		"backtrace-d": "~master",
-		"ddox": "0.14.2",
+		"ddox": "0.14.3",
 		"experimental_allocator": "2.70.0-b1",
 		"hyphenate": "1.1.1",
 		"libasync": "0.7.9",

--- a/posix.mak
+++ b/posix.mak
@@ -25,7 +25,7 @@ REMOTE_DIR=d-programming@digitalmars.com:data
 GENERATED=.generated
 
 # stable dub and dmd versions used to build dpl-docs
-DUB_VER=0.9.24
+DUB_VER=0.9.25-alpha.1
 STABLE_DMD_VER=2.069.2
 STABLE_DMD_ROOT=/tmp/.stable_dmd-$(STABLE_DMD_VER)
 STABLE_DMD_URL=http://downloads.dlang.org/releases/2.x/$(STABLE_DMD_VER)/dmd.$(STABLE_DMD_VER).$(OS).zip

--- a/std-ddox.ddoc
+++ b/std-ddox.ddoc
@@ -1,9 +1,9 @@
-D = <code class="prettyprint lang-d">$0</code>
-XREF = std.$1.$2
-XREF_PACK = std.$1.$2.$3
-CXREF = core.$1.$2
-ECXREF = etc.$1.$2
-LREF = $1
+D = <code class="lang-d">$0</code>
+XREF = $(D std.$1.$2)
+XREF_PACK = $(D std.$1.$2.$3)
+CXREF = $(D core.$1.$2)
+ECXREF = $(D etc.$1.$2)
+LREF = $(D $1)
 ROOT_DIR=/
 _=
 


### PR DESCRIPTION
Fixes:
- Types now have some CSS styling
- Cross references within backtick code work again
- Fixed invalid nesting of HTML elements in some cases
- Function attributes are highlighted
- Automatic cross-referencing outside of D code is now disabled
- `@...` built-in attributes are now highlighted as keywords

Still missing: sometimes keywords are not recognized as such, seems to be [a bug](https://github.com/Hackerpilot/libdparse/issues/94) in libdparse.