### PR TITLE
Upgrade to DDOX 0.15.1.

### DIFF
--- a/dpl-docs/dub.selections.json
+++ b/dpl-docs/dub.selections.json
@@ -2,7 +2,7 @@
 	"fileVersion": 1,
 	"versions": {
 		"backtrace-d": "~master",
-		"ddox": "0.15.0",
+		"ddox": "0.15.2",
 		"experimental_allocator": "2.70.0-b1",
 		"hyphenate": "1.1.1",
 		"libasync": "0.7.9",


### PR DESCRIPTION
- Fixes parsing function with auto return type and this modifiers
- Fixes duplicated symbols being output to doc pages and to the file system
- Fixes lookup of variadic template arguments