### PR TITLE
Move "NEW Library Reference Preview" menu entry to "Documentation".

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -235,13 +235,13 @@ NAVIGATION_DOCUMENTATION=
 $(SUBMENU
     $(ROOT_DIR)spec/spec.html, Language Reference,
     $(ROOT_DIR)phobos/index.html, Library Reference,
+    $(ROOT_DIR)library/index.html, NEW Library Reference Preview,
     $(ROOT_DIR)comparison.html, Feature Overview,
     $(ROOT_DIR)dmd-windows.html, DMD Manual,
     $(ROOT_DIR)articles.html, Articles
 )
 NAVIGATION_RESOURCES=
 $(SUBMENU
-    $(ROOT_DIR)library/index.html, NEW Library Reference Preview,
     $(ROOT_DIR)tools.html, D-Specific Tools,
     $(VISUALD), Visual D,
     https://wiki.dlang.org/Editors, Editors,

--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -52,6 +52,8 @@ html(lang='en-US')
                   li
                     a(href="#{root_dir}phobos/index.html") Library Reference
                   li
+                    a(href="#{root_dir}library/index.html") NEW Library Reference Preview
+                  li
                     a(href="#{root_dir}comparison.html") Feature Overview
                   li
                     a(href="#{root_dir}dmd-windows.html") DMD Manual
@@ -87,8 +89,6 @@ html(lang='en-US')
                 a.expand-toggle(href="#{root_dir}resources.html")
                   span Resources
                 ul
-                  li
-                    a(href="#{root_dir}library/index.html") NEW Library Reference Preview
                   li
                     a(href="#{root_dir}tools.html") D-Specific Tools
                   li


### PR DESCRIPTION
Since the new website layout now has distinct menus for each category, the menu entry can be moved to the other documentation sections, where it logically belongs, without occupying premium space, which was the reason to put it under "Resources" initially. This should increase the visibility considerably.