### PR TITLE
add anchors to declarations

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2006,3 +2006,15 @@ the home page, intro pitch and your-code-here layed out vertically */
         max-width: 32em;
     }
 }
+
+.decl_anchor {
+    visibility: hidden;
+    float: right;
+    margin-top: 5px;
+    margin-right: 5px;
+    text-decoration: none;
+}
+
+dt.d_decl:hover .decl_anchor {
+    visibility: visible;
+}

--- a/js/listanchors.js
+++ b/js/listanchors.js
@@ -13,6 +13,23 @@ function lastName(a) {
     return a.slice(pos + 1);
 }
 
+// adds a anchor link to every documented declaration
+function addAnchors()
+{
+    var items = document.getElementsByClassName('d_decl');
+    if(!items) return;
+    for (var i = 0; i < items.length; i++)
+    {
+        // we link to the first children
+        var a = items[i].querySelector('a');
+        if(!a) continue;
+        var permLink = document.createElement("a");
+        permLink.setAttribute('href', '#' + a.name);
+        permLink.className = "fa fa-anchor decl_anchor";
+        items[i].insertBefore(permLink, items[i].firstChild);
+    }
+}
+
 function listanchors()
 {
     var hideTop = (typeof inhibitQuickIndex !== 'undefined');
@@ -72,4 +89,5 @@ function listanchors()
         var e = document.getElementById(id);
         e.innerHTML = newText;
     }
+    addAnchors();
 }


### PR DESCRIPTION
I was missing anchors at the declarations for a long time. Turns out, while it's pretty difficult to do with DDoc, it's very easy to do so in JS :)

It will add an anchor at the top right.

![image](https://cloud.githubusercontent.com/assets/4370550/14947618/d9c589c8-103e-11e6-989e-da681b4cfc8f.png)