### PR TITLE
Fix HTML link to "Nested Functions" section.

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1558,7 +1558,7 @@ void main()
 }
 ---
 
-$(H3 $(LNAME2 variadicnested, Nested Functions))
+$(H3 $(LNAME2 nested, Nested Functions))
 
         $(P Functions may be nested within other functions:)
 


### PR DESCRIPTION
This should fix the link from the contents mini-menu at the top.