### PR TITLE
Fix runable examples when running dlang via https

### DIFF
--- a/js/run.js
+++ b/js/run.js
@@ -491,7 +491,7 @@ $(document).ready(function()
            
             $.ajax({
                 type: 'POST',
-                url: "http://dpaste.dzfl.pl/request/",
+                url: "//dpaste.dzfl.pl/request/",
                 dataType: "json",
                 data: 
                 {


### PR DESCRIPTION
Currently if you try to evaluate code examples on the https://dlang.org the xhr request goes via plain http to dpaste - causing fails on some browsers like safari

DPaste supports https.