### PR TITLE
Update requirements for OS X

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -171,7 +171,7 @@ $(H2 $(LNAME2 files, Files))
     )
 
     $(DT $(D $(DMDDIR)/osx/lib/$(LIB))
-    $(DD D runtime library (copy to $(D /usr/lib/$(LIB))))
+    $(DD D runtime library (copy to $(D /usr/local/lib/$(LIB))))
     )
     )
 
@@ -296,10 +296,10 @@ sudo cp $(DMDDIR)/osx/bin/dmdx.conf /usr/local/bin/$(DMD_CONF)
 )
     )
 
-    $(LI Copy the library to $(D /usr/lib):
+    $(LI Copy the library to $(D /usr/local/lib):
 
 $(CONSOLE
-sudo cp $(DMDDIR)/osx/lib/$(LIB) /usr/lib
+sudo cp $(DMDDIR)/osx/lib/$(LIB) /usr/local/lib
 )
     )
     )

--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -52,9 +52,9 @@ $(H2 $(LNAME2 requirements, Requirements and Downloads))
     $(LI Gnu C compiler (gcc))
     )
     $(OSX
-    $(LI 32 bit x86 Mac OSX operating system)
+    $(LI Mac OS X Lion (10.7) or later)
 
-    $(LI Gnu C compiler (gcc))
+    $(LI Xcode)
     )
     $(FREEBSD
     $(LI 32 bit x86 FreeBSD 7.1 operating system)


### PR DESCRIPTION
Update requirements for OS X now when native TLS is used. Also some minor adjustments to the install instructions making them compatible with El Capitan.