### PR TITLE
DDOX: don't exclude std.format

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -453,7 +453,7 @@ docs.json : ${DMD_REL} ${DRUNTIME_DIR}-${LATEST} \
 	find ${DRUNTIME_DIR}-${LATEST}/src -name '*.d' | \
 	  sed -e /unittest.d/d -e /gcstub/d > .release-files.txt
 	find ${PHOBOS_DIR}-${LATEST} -name '*.d' | \
-	  sed -e /unittest.d/d -e /format/d -e /windows/d >> .release-files.txt
+	  sed -e /unittest.d/d -e /windows/d >> .release-files.txt
 	${DMD_REL} -c -o- -version=CoreDdoc -version=StdDdoc -Df.release-dummy.html \
 	  -Xfdocs.json -I${PHOBOS_DIR}-${LATEST} @.release-files.txt
 	${DPL_DOCS} filter docs.json --min-protection=Protected \
@@ -464,7 +464,7 @@ docs-prerelease.json : ${DMD} ${DRUNTIME_DIR} \
 		${PHOBOS_DIR} | dpl-docs
 	find ${DRUNTIME_DIR}/src -name '*.d' | sed -e '/gcstub/d' \
 	  -e /unittest/d > .prerelease-files.txt
-	find ${PHOBOS_DIR} -name '*.d' | sed -e /unittest.d/d -e /format/d \
+	find ${PHOBOS_DIR} -name '*.d' | sed -e /unittest.d/d \
 	  -e /windows/d >> .prerelease-files.txt
 	${DMD} -c -o- -version=CoreDdoc -version=StdDdoc -Df.prerelease-dummy.html \
 	  -Xfdocs-prerelease.json -I${PHOBOS_DIR} @.prerelease-files.txt


### PR DESCRIPTION
It had been excluded because of ["random compiler errors"](https://github.com/dlang/dlang.org/pull/267#issuecomment-21374478). That doesn't seem to be an issue anymore. Works for me at least.