### PR TITLE
remove menu link to review queue and digital mars

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -228,9 +228,7 @@ $(SUBMENU
     irc://irc.freenode.net/d, IRC,
     https://github.com/dlang, D on GitHub,
     https://wiki.dlang.org, Wiki,
-    https://wiki.dlang.org/Review_Queue, Review Queue,
     https://twitter.com/search?q=%23dlang, Twitter,
-    http://digitalmars.com/d/dlinks.html, More Links
 )
 NAVIGATION_DOCUMENTATION=
 $(SUBMENU


### PR DESCRIPTION
The digital mars page was last updated on "Tue May 28 11:53:30 2013" and I hope we can do better.
The review queue is also usually hopelessly outdated and unmaintained. Imho it's besser if we just remove those two links and let the reader explore the wiki.