### PR TITLE
show list of contributors per module

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1463,7 +1463,7 @@ body#Menu #content li.expand-container ul
 
 div#copyright
 {
-    margin-top: 5em;
+    margin-top: 1.5em;
     text-align: center;
 }
 
@@ -1478,6 +1478,10 @@ div#copyright
     color: #555;
 }
 
+#contributors-github img
+{
+    padding-right: 5px;
+}
 
 /* These are for the changelogs */
 div.version

--- a/js/show_contributors.js
+++ b/js/show_contributors.js
@@ -1,0 +1,45 @@
+/**
+Shows a list of the contributors to a Phobos module
+It queries the backend contribs.dlang.io
+Backend source: https://github.com/wilzbach/phobos-contribs
+
+License:   http://boost.org/LICENSE_1_0.txt, Boost License 1.0
+
+Authors:   Sebastian Wilzbach
+*/
+
+// find out whether the current page is a module or package
+function isPackage()
+{
+    return $('.tip.smallprint a[href*="package.d"]').length > 0;
+}
+
+$(document).ready(function()
+{
+    // only for std at the moment
+    if (!$('body').hasClass("std"))
+        return;
+
+    // for index modules (package.d), we want to display all contributors of the package
+    var modulePath = document.body.id.replace(/[.]/g, '/');
+    if (!isPackage())
+       modulePath += '.d';
+
+    $.getJSON( "https://contribs.dlang.io/contributors/file/dlang/phobos?file=" + modulePath, function(contributors) {
+
+        var posToInsert = $('#copyright');
+        var contentNode = $("<div id='contributors-github'></div>");
+
+        var totalContributors = contributors.length;
+        contentNode.append("<h3>" + totalContributors + " Contributors</h3>");
+
+        // list contributors with github avatar
+        $.each(contributors, function(i, contributor){
+            var contributorDiv = '<a href=' + contributor.html_url +' target="_blank">';
+            contributorDiv += '<img src="'+ contributor.avatar_url +'&size=40" height="40" width=40" alt="' + contributor.login + '"/>';
+            contributorDiv += "</a>";
+            contentNode.append(contributorDiv);
+        });
+        contentNode.insertBefore(posToInsert);
+    });
+});

--- a/posix.mak
+++ b/posix.mak
@@ -133,7 +133,8 @@ IMAGES=favicon.ico $(addprefix images/, \
 	$(addsuffix .jpg, tdpl))
 
 JAVASCRIPT=$(addsuffix .js, $(addprefix js/, \
-	codemirror-compressed dlang ddox listanchors run run-main-website jquery-1.7.2.min))
+	codemirror-compressed dlang ddox listanchors run run-main-website \
+	show_contributors jquery-1.7.2.min))
 
 STYLES=$(addsuffix .css, $(addprefix css/, \
 	style print codemirror ddox))

--- a/std.ddoc
+++ b/std.ddoc
@@ -6,6 +6,7 @@ SEARCHDEFAULT_PHOBOS = selected
 BODY_PREFIX = $(DIVCID quickindex, quickindex, )
 LAYOUT_SUFFIX =
 $(SCRIPTLOAD ../js/listanchors.js)
+$(SCRIPTLOAD ../js/show_contributors.js)
 $(SCRIPT jQuery(document).ready(listanchors);)
 LAYOUT_TITLE=$(H1 $(D $(TITLE)))
 _=


### PR DESCRIPTION
This adds a list of all contributors to a module at the end of the documentation.

![image](https://cloud.githubusercontent.com/assets/4370550/15455038/0a46851c-2051-11e6-8a8c-eb05b8773ac1.png)

The [backend](https://github.com/wilzbach/phobos-contribs) queries the Github API for commits to that file / folder and reduces this to Github user + their avatars. Every query is cached for 24h.
That being said yes - the backend could maintain [it's own git repo](https://github.com/wilzbach/phobos-contribs/issues/1) and map the commits to Github avatars, but so far this approach is also working.

The contributor avatars are sorted alphabetically and only enabled for "std" modules.