### PR TITLE
add comma operator to the deprecated list

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -10,6 +10,7 @@ $(SPEC_S Deprecated Features,
 
     $(TABLE2 Deprecated Features,
         $(THEAD Feature,                                                          Spec,  Dep,    Error,  Gone)
+        $(TROW $(DEPLINK Using the result of a comma expression),                 future, &nbsp;, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK delete),                                                 future, &nbsp;, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK scope for allocating classes on the stack),              future, &nbsp;, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Imaginary and complex types),                            future, &nbsp;, &nbsp;, &nbsp;)
@@ -55,6 +56,61 @@ $(SPEC_S Deprecated Features,
     )
 
 
+$(H3 $(DEPNAME Using the result of a comma expression))
+    $(P The comma operator (`,`) allows executing multiple expressions and
+        discards the result of them except for the last which is returned.
+
+        ---
+        int a = 1;
+        int b = 2;
+        bool ret = a == 2, b == 2; // true
+        ---
+
+        It's also common to use the comma operator in for-loop increment
+        statements to allow multiple expressions.
+
+        ---
+        for (; !a.empty && !b.empty; a.popFront, b.popFront)
+        ---
+    )
+$(H4 Corrective Action)
+    $(P If possible, split the comma operator in two statements. Otherwise use
+        lambdas.
+
+        ---
+        auto result = foo(), bar();
+
+        // split off in two statements
+        foo();
+        auto result = bar();
+
+        // or use lambdas
+        auto result = (){ foo(); return bar();};
+        ---
+    )
+$(H4 Rationale)
+    $(P The comma operator leads to unintended behavior (see below for a selection)
+        Moreover it is not commonly used and it blocks the ability to implement tuples.
+
+        A selection of problems through the accidental use of the comma operator:
+        ---
+        writeln( 6, mixin("7,8"), 9 ); // 6, 8, 9
+
+        template vec(T...)(T args) { ... }
+        vec v = (0, 0, 3); // 3, because vec is variadic
+
+        int b = 2;
+        if (a == 1, b == 2) {
+            // will always be reached
+        }
+
+        void foo(int x) {}
+        foo((++a, b));
+
+        synchronized (lockA, lockB) {}
+        // isn't currently implemented, but still compiles "thanks" to the comma operator
+        ---
+    )
 
 $(H3 $(DEPNAME delete))
     $(P Memory allocated on the GC heap can be freed with $(D delete).


### PR DESCRIPTION
As we are finally getting rid of the comma operator, how about adding it to the "Future" list. Once the [PR](https://github.com/dlang/dmd/pull/5737) is merged, more infos can be added?
Ping @Geod24 @yebblies 