### PR TITLE
remove deprecated WIKI macro

### DIFF
--- a/32-64-portability.dd
+++ b/32-64-portability.dd
@@ -8,4 +8,3 @@ $(LINK2 https://wiki.dlang.org/Porting_32_Bit_Code_to_64_Bits, https://wiki.dlan
 )
 
 Macros:
-WIKI=Porting_32_Bit_Code_to_64_Bits

--- a/COM.dd
+++ b/COM.dd
@@ -8,4 +8,3 @@ $(LINK2 https://wiki.dlang.org/COM_Programming, https://wiki.dlang.org/COM_Progr
 )
 
 Macros:
-WIKI=COM_Programming

--- a/D1toD2.dd
+++ b/D1toD2.dd
@@ -97,6 +97,5 @@ $(ITEM immutable_string, String Literals are Immutable)
 
 Macros:
 	TITLE=Migrating D1 Code to D2
-	WIKI=D1toD2
 	ITEMR=$(LI $(RELATIVE_LINK2 $1, $+))
 	ITEM=$(HR)$(H3 $(ADEF $1)$+)

--- a/acknowledgements.dd
+++ b/acknowledgements.dd
@@ -49,5 +49,4 @@ $(P
 
 Macros:
 	TITLE=Acknowledgements
-	WIKI=Acknowledgements
 

--- a/ascii-table.dd
+++ b/ascii-table.dd
@@ -27,4 +27,3 @@ $(PRE
 
 Macros:
 	TITLE=ASCII Table
-	WIKI=AsciiTable

--- a/bugstats.php.dd
+++ b/bugstats.php.dd
@@ -47,4 +47,3 @@ Macros:
   DISPLAY=$(TR $(TD $(LINK2 https://issues.dlang.org/buglist.cgi?$2, $1)) $(TD <iframe scrolling="no" frameborder="0" width="4.8em" height="1.4em" style="width:4.8em;height:1.4em;" vspace="0" hspace="0" marginwidth="0" marginheight="0" src="fetch-issue-cnt.php?$2&amp;format=table&amp;action=wrap&amp;ctype=csv"></iframe>))
   GRAPH_HTML_URL=https://issues.dlang.org/reports.cgi?product=D&amp;datasets=NEW&amp;datasets=ASSIGNED&amp;datasets=REOPENED&amp;datasets=RESOLVED
   GRAPH_IMG_URL=https://issues.dlang.org/graphs/mVH75HpydPklNqy3BSv8EvqlAOaP1WacmgYB1CsRbiM.png
-  WIKI=BugStats

--- a/builtin.dd
+++ b/builtin.dd
@@ -173,6 +173,5 @@ $(SECTION2 Please Note,
 
 Macros:
 	TITLE=D Builtin Rationale
-	WIKI=builtins
 	SUBNAV=$(SUBNAV_ARTICLES)
 

--- a/changelog/index.dd
+++ b/changelog/index.dd
@@ -25,4 +25,3 @@ $(UL
 Macros:
 
 TITLE=Change Log: List of All Versions
-WIKI=ChangeLog

--- a/code_coverage.dd
+++ b/code_coverage.dd
@@ -227,5 +227,4 @@ $(LINK2 https://en.wikipedia.org/wiki/Code_coverage, Wikipedia)
 
 Macros:
 	TITLE=Code Coverage Analysis
-	WIKI=Dcover
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/concepts.dd
+++ b/concepts.dd
@@ -242,7 +242,6 @@ $(H2 References)
 
 Macros:
 	TITLE=Template Constraints
-	WIKI=Constraints
 META_KEYWORDS=D Programming Language, constraints, template, concepts, C++
 META_DESCRIPTION=Going beyond type patterns to constrain template instantiations.
 

--- a/const-faq.dd
+++ b/const-faq.dd
@@ -292,7 +292,6 @@ $(ITEM invariant, What is $(I immutable) good for?)
 
 Macros:
 	TITLE=const(FAQ)
-	WIKI=constFAQ
 	ITEMR=$(LI $(RELATIVE_LINK2 $1, $+))
 	ITEM=<hr>$(H3 <a name="$1">$+</a>)
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/cpp0x.dd
+++ b/cpp0x.dd
@@ -732,7 +732,6 @@ enum E : int;
 
 Macros:
 	TITLE=D and C++0x
-	WIKI=Cpp0x
 	DOLLAR=$
 	NDOCS=http://www.open-std.org/jtc1/sc22/wg21/docs/papers/
 	_=

--- a/cppcontracts.dd
+++ b/cppcontracts.dd
@@ -495,6 +495,5 @@ $(H2 References)
 
 Macros:
 	TITLE=D's Contract Programming vs C++'s
-	WIKI=CppDbc
 
 

--- a/cppstrings.dd
+++ b/cppstrings.dd
@@ -579,4 +579,3 @@ int main(int argc, char const *argv[])
 
 Macros:
 	TITLE=D Strings vs C++ Strings
-	WIKI=CPPstrings

--- a/cpptod.dd
+++ b/cpptod.dd
@@ -825,5 +825,4 @@ void test()
 
 Macros:
 	TITLE=Programming in D for C++ Programmers
-	WIKI=CPPtoD
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/ctod.dd
+++ b/ctod.dd
@@ -1611,5 +1611,4 @@ int main()
 
 Macros:
 	TITLE=Programming in D for C Programmers
-	WIKI=ctod
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/d-array-article.dd
+++ b/d-array-article.dd
@@ -246,6 +246,5 @@ Macros:
 	TITLE=D Slices
     STDREF = <a href="phobos/std_$1.html#$2">$(D $2)</a>
     OBJREF = <a href="phobos/object.html#$1">$(D $2)</a>
-    WIKI =
     SUBNAV=$(SUBNAV_ARTICLES)
     _=

--- a/d-floating-point.dd
+++ b/d-floating-point.dd
@@ -347,5 +347,4 @@ Macros:
       SQRT = &radix;
       HALF = &frac12;
 	TITLE=Real Close to the Machine: Floating Point in D
-	WIKI=FloatingPointInD
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -1179,7 +1179,6 @@ make -f posix.mak DMD=~/$(DMDDIR)/$(OS)/bin/dmd
 
 Macros:
     TITLE=DMD Compiler for $(WINDOWS Windows)$(LINUX Linux)$(OSX OSX)$(FREEBSD FreeBSD)
-    WIKI=DCompiler
     BODYCLASS=std dcompiler
     LIB=$(WINDOWS phobos.lib)$(UNIX libphobos2.a)
     DMD_CONF=$(RELATIVE_LINK2 dmd-conf, dmd.conf)

--- a/deprecate.dd
+++ b/deprecate.dd
@@ -735,5 +735,4 @@ Macros:
 	DEPLINK2=$(LINK2 $1.html#$2, $2)
 	DEPNAME=$(LNAME2 $0, $0)
 	TITLE=Deprecated Features
-	WIKI=DeprecatedFeatures
 	STDFILEREF = <a href="phobos/std_$1.html">$(D std.$1)</a>

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -454,7 +454,6 @@ VISUALD = http://rainers.github.io/visuald/visuald/StartPage.html
 _=
 
 WHITE=$(SPANC white, $0)
-WIKI=$(TITLE)
 _=
 
 XREF=$(XREF2 $1, $2, $(D std.$1.$2))

--- a/dll-linux.dd
+++ b/dll-linux.dd
@@ -549,4 +549,3 @@ and the static destructors are called by dlclose().
 
 Macros:
         TITLE=Writing Shared Libraries With D On Linux
-        WIKI=DLLs

--- a/dll.dd
+++ b/dll.dd
@@ -8,4 +8,3 @@ $(LINK2 https://wiki.dlang.org/Win32_DLLs_in_D, https://wiki.dlang.org/Win32_DLL
 )
 
 Macros:
-WIKI=Win32_DLLs_in_D

--- a/download.dd
+++ b/download.dd
@@ -164,7 +164,6 @@ $(LI $(LINK2 http://www.digitalmars.com/download/freecompiler.html, Digital Mars
 
 Macros:
 	TITLE=Downloads
-	WIKI=Downloads
 
     DMDV2=$(LATEST)
 

--- a/dstyle.dd
+++ b/dstyle.dd
@@ -306,5 +306,4 @@ $(P
 
 Macros:
     TITLE=The D Style
-    WIKI=DStyle
 

--- a/exception-safe.dd
+++ b/exception-safe.dd
@@ -440,5 +440,4 @@ $(LINK2 https://www.amazon.com/exec/obidos/ASIN/0321334876/classicempire,
 
 Macros:
 	TITLE=Exception Safety
-	WIKI=ExceptionSafe
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/faq.dd
+++ b/faq.dd
@@ -929,7 +929,6 @@ $(COMMENT
 
 Macros:
 	TITLE=D 2.0 FAQ
-	WIKI=FAQ
 	ITEMR=$(LI $(RELATIVE_LINK2 $1, $+))
 	ITEM=<hr>$(H3 <a name="$1">$+</a>)
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/future.dd
+++ b/future.dd
@@ -15,5 +15,4 @@ $(D_S Future Directions,
 
 Macros:
 	TITLE=Future Directions
-	WIKI=Future
 

--- a/getstarted.dd
+++ b/getstarted.dd
@@ -52,4 +52,3 @@ Getting Started,
 
 Macros:
   TITLE=Getting Started
-  WIKI=The_D_Programming_Language

--- a/glossary.dd
+++ b/glossary.dd
@@ -259,5 +259,4 @@ void test()
 
 Macros:
 	TITLE=Glossary
-	WIKI=Glossary
     D=<span class="d_inlinecode">$0</span>

--- a/gpg_keys.dd
+++ b/gpg_keys.dd
@@ -19,4 +19,3 @@ $(P You can also download them as $(LINK2 d-keyring.gpg,keyring) file.)
 
 Macros:
     TITLE=GPG Keys
-    WIKI=GPG Keys

--- a/gsoc2011.dd
+++ b/gsoc2011.dd
@@ -64,5 +64,4 @@ $(P Good luck!)
 
 Macros:
 	TITLE=GSoC2011
-	WIKI=GSoC2011
     HTMLTAG=<$1>$+</$1>

--- a/gsoc2012-template.dd
+++ b/gsoc2012-template.dd
@@ -65,5 +65,4 @@ $(P Good luck!)
 
 Macros:
 	TITLE=GSoC2012
-	WIKI=GSoC2012
     HTMLTAG=<$1>$+</$1>

--- a/gsoc2012.dd
+++ b/gsoc2012.dd
@@ -62,5 +62,4 @@ timeline) for details.)
 
 Macros:
 	TITLE=GSoC2012
-	WIKI=GSoC2012
     HTMLTAG=<$1>$+</$1>

--- a/gsoc2013-template.dd
+++ b/gsoc2013-template.dd
@@ -65,5 +65,4 @@ $(P Good luck!)
 
 Macros:
 	TITLE=GSoC2013
-	WIKI=GSoC2013
     HTMLTAG=<$1>$+</$1>

--- a/gsoc2013.dd
+++ b/gsoc2013.dd
@@ -62,6 +62,5 @@ timeline) for details.)
 
 Macros:
 	TITLE=GSoC2013
-	WIKI=GSoC2013
     HTMLTAG=<$1>$+</$1>
     HTTP=$(LINK2 http://$1,$+)

--- a/hijack.dd
+++ b/hijack.dd
@@ -565,5 +565,4 @@ $(LI Andrei Alexandrescu)
 
 Macros:
 	TITLE=Hijack
-	WIKI=Hijack
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/howto-promote.dd
+++ b/howto-promote.dd
@@ -93,5 +93,4 @@ $(H3 Promoting the Project)
 
 Macros:
 	TITLE=Promoting D Projects (or Internet Marketing 101)
-	WIKI=PromotingDProjects
 

--- a/htod.dd
+++ b/htod.dd
@@ -230,5 +230,4 @@ $(OL
 
 Macros:
 	TITLE=htod
-	WIKI=htod
 	SUBNAV=$(SUBNAV_TOOLS)

--- a/htomodule.dd
+++ b/htomodule.dd
@@ -8,4 +8,3 @@ $(LINK2 https://wiki.dlang.org/Converting_C_.h_Files_to_D_Modules, https://wiki.
 )
 
 Macros:
-WIKI=Converting_C_.h_Files_to_D_Modules

--- a/index.dd
+++ b/index.dd
@@ -373,7 +373,6 @@ consistency. $(LINK2 spec/memory-safe-d.html, Read more).)
 
 Macros:
     TITLE=Home
-    WIKI=Intro
     TAG=<$1>$+</$1>
     TAG2=<$1 $2>$3</$1>
     D=<span class="d_inlinecode">$0</span>

--- a/intro-to-datetime.dd
+++ b/intro-to-datetime.dd
@@ -791,5 +791,4 @@ Macros:
     TIMEZONE=$(XREF datetime, TimeZone)
     UTC=$(XREF datetime, UTC)
     WINDOWSTZ=$(XREF datetime, WindowsTimeZone)
-    WIKI=
     _=

--- a/lazy-evaluation.dd
+++ b/lazy-evaluation.dd
@@ -309,7 +309,6 @@ $(H2 Acknowledgements)
 
 Macros:
     TITLE=Lazy Evaluation Of Function Arguments
-    WIKI=LazyEvaluation
     SUBNAV=$(SUBNAV_ARTICLES)
 
     NG_digitalmars_D = <a href="http://www.digitalmars.com/pnews/read.php?server=news.digitalmars.com$(AMP)group=digitalmars.D$(AMP)artnum=$0">D/$0</a>

--- a/memory.dd
+++ b/memory.dd
@@ -9,5 +9,4 @@ $(LINK2 https://wiki.dlang.org/Memory_Management, https://wiki.dlang.org/Memory_
 
 Macros:
 	TITLE=Memory Management
-	WIKI=Memory
 

--- a/migrate-to-shared.dd
+++ b/migrate-to-shared.dd
@@ -225,6 +225,5 @@ extern (C)
 
 Macros:
 	TITLE=Migrating to Shared
-	WIKI=Migrating To Shared
 	SUBNAV=$(SUBNAV_ARTICLES)
 

--- a/mixin.dd
+++ b/mixin.dd
@@ -92,5 +92,4 @@ END
 
 Macros:
 	TITLE=Mixins
-	WIKI=Mixins
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/overview.dd
+++ b/overview.dd
@@ -1347,4 +1347,3 @@ So the numbers represented by the array actually go from 3 to (8190 + 8190 + 3),
 
 Macros:
     TITLE=Overview
-    WIKI=Overview

--- a/pretod.dd
+++ b/pretod.dd
@@ -723,7 +723,6 @@ $(H3 <a name="mixins">Template Mixins</a>)
 
 Macros:
 	TITLE=The C Preprocessor vs D
-	WIKI=PreToD
 	CWAY=$(SECTION4 The C Preprocessor Way, $0)
 	DWAY=$(SECTION4 The D Way, $0)
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/rationale.dd
+++ b/rationale.dd
@@ -243,6 +243,5 @@ static if (0 || is(int T)) T x;
 
 Macros:
 	TITLE=Rationale
-	WIKI=Rationale
 	SUBNAV=$(SUBNAV_ARTICLES)
 

--- a/rdmd.dd
+++ b/rdmd.dd
@@ -129,6 +129,5 @@ $(LINK2 http://erdani.org/, Andrei Alexandrescu)
 
 Macros:
 	TITLE=rdmd
-	WIKI=rdmd
 	SUBNAV=$(SUBNAV_TOOLS)
 

--- a/safed.dd
+++ b/safed.dd
@@ -259,5 +259,4 @@ $(P Many thanks go to the rest of the D design team for valuable feedback and co
 
 Macros:
 	TITLE=SafeD
-	WIKI=SafeD
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/sitemap-template.dd
+++ b/sitemap-template.dd
@@ -4,5 +4,4 @@ $(D_S Sitemap, $(LINKS))
 
 Macros:
 	TITLE=Sitemap
-	WIKI=Sitemap
     LINKS=

--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -935,4 +935,3 @@ $(H3 $(LNAME2 codeview, Codeview Debugger Extensions))
 
 Macros:
 	TITLE=Application Binary Interface
-	WIKI=ABI

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -995,5 +995,4 @@ $(H2 $(LNAME2 implicit-conversions, Implicit Conversions))
 
 Macros:
         TITLE=Arrays
-        WIKI=Arrays
         _=

--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -829,4 +829,3 @@ pragma(msg, __traits(getAttributes, typeof(a))); // prints tuple("hello")
 
 Macros:
         TITLE=Attributes
-        WIKI=Attribute

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -1347,6 +1347,5 @@ $(SECTION3 $(LEGACY_LNAME2 ConstClass, const-class, Const, Immutable and Shared 
 
 Macros:
         TITLE=Classes
-        WIKI=Class
         _=
 

--- a/spec/const3.dd
+++ b/spec/const3.dd
@@ -475,7 +475,6 @@ Macros:
 	Y=$(TD $(GREEN Yes))
 	N=$(TD $(RED No))
 	TITLE=Type Qualifiers
-	WIKI=ConstInvariant
 	ERROR = $(RED $(B error))
     META_KEYWORDS=D Programming Language, const, immutable
     META_DESCRIPTION=Comparison of const between the D programming language, C++, and C++0x

--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -260,5 +260,4 @@ $(H2 $(LNAME2 references, References))
 
 Macros:
 	TITLE=Contract Programming
-	WIKI=DBC
 

--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -878,6 +878,5 @@ foo(cast(immutable)&i, &i);
 
 Macros:
     TITLE=Interfacing to C++
-    WIKI=InterfaceToCPP
 
 

--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -1044,6 +1044,5 @@ $(P
 
 Macros:
     TITLE=Documentation Generator
-    WIKI=Ddoc
     _= Remove the following line when 2.067.0 is used to compile the site.
     BACKTIP=`

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -742,7 +742,6 @@ struct S
 
 Macros:
         TITLE=Declarations
-        WIKI=Declaration
         ASSIGNEXPRESSION=$(GLINK2 expression, AssignExpression)
         EXPRESSION=$(GLINK2 expression, Expression)
         VEXPRESSION=$(ASSIGNEXPRESSION)

--- a/spec/entity.dd
+++ b/spec/entity.dd
@@ -288,4 +288,3 @@ $(BR)
 
 Macros:
 	TITLE=Named Character Entities
-	WIKI=Entities

--- a/spec/enum.dd
+++ b/spec/enum.dd
@@ -265,6 +265,5 @@ enum size = __traits(classInstanceSize, Foo);  // evaluated at compile-time
 
 Macros:
 	TITLE=Enums
-	WIKI=Enum
 	CATEGORY_SPEC=$0
 

--- a/spec/errors.dd
+++ b/spec/errors.dd
@@ -208,5 +208,4 @@ $(COMMENT
 
 Macros:
 	TITLE=Errors
-	WIKI=Errors
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2145,7 +2145,6 @@ $(H3 $(LNAME2 associativity, Associativity and Commutativity))
 
 Macros:
         TITLE=Expressions
-        WIKI=Expression
         IDENTIFIER=$(GLINK2 lex, Identifier)
         _=
 

--- a/spec/float.dd
+++ b/spec/float.dd
@@ -183,4 +183,3 @@ $(COMMENT
 
 Macros:
 	TITLE=Floating Point
-	WIKI=Float

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2346,5 +2346,4 @@ $(H3 $(LNAME2 pseudo-member, Uniform Function Call Syntax (UFCS)))
 
 Macros:
         TITLE=Functions
-        WIKI=Function
         ASSIGNEXPRESSION=$(GLINK2 expression, AssignExpression)

--- a/spec/garbage.dd
+++ b/spec/garbage.dd
@@ -446,4 +446,3 @@ $(H2 $(LNAME2 references, References))
 
 Macros:
 	TITLE=Garbage Collection
-	WIKI=Garbage

--- a/spec/grammar.dd
+++ b/spec/grammar.dd
@@ -1822,7 +1822,6 @@ $(GNAME MixinDeclaration):
 
 Macros:
         TITLE=D Grammar
-        WIKI=Grammar
         IDENTIFIER=$(GLINK Identifier)
         EXPRESSION=$(GLINK Expression)
         ASSIGNEXPRESSION=$(GLINK AssignExpression)

--- a/spec/hash-map.dd
+++ b/spec/hash-map.dd
@@ -433,4 +433,3 @@ $(H3 $(LNAME2 aa_example, Associative Array Example: word count))
 
 Macros:
         TITLE=Associative Arrays
-        WIKI=AssociativeArrays

--- a/spec/iasm.dd
+++ b/spec/iasm.dd
@@ -1163,5 +1163,4 @@ getsec
 
 Macros:
         TITLE=Inline Assembler
-        WIKI=IAsm
 

--- a/spec/interface.dd
+++ b/spec/interface.dd
@@ -331,5 +331,4 @@ class Ifoo
 
 Macros:
     TITLE=Interfaces
-    WIKI=Interface
 

--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -363,4 +363,3 @@ Macros:
     TROW3PLUS=$(TR3 $(TD $(D $1)), $(TD $(D $2)), $(TD $(D $3) $4))
 	TD2=$(MULTICOL_CELL 2, $0)
 	TITLE=Interfacing to C
-	WIKI=InterfaceToC

--- a/spec/intro.dd
+++ b/spec/intro.dd
@@ -72,5 +72,4 @@ $(OL
 
 Macros:
 	TITLE=Introduction
-	WIKI=SpecIntro
 

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -1151,5 +1151,4 @@ x;  // this is now line 6 of file foo\bar
 
 Macros:
 	TITLE=Lexical
-	WIKI=Lex
 

--- a/spec/memory-safe-d.dd
+++ b/spec/memory-safe-d.dd
@@ -46,4 +46,3 @@ $(H3 Limitations)
 
 Macros:
 	TITLE=Memory-Safe-D-Spec
-	WIKI=SafeDSpec

--- a/spec/module.dd
+++ b/spec/module.dd
@@ -639,6 +639,5 @@ $(H3 $(LEGACY_LNAME2 PackageModule, package-module, Package Module))
 
 Macros:
 	TITLE=Modules
-	WIKI=Module
 	_=
 

--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -1077,7 +1077,6 @@ $(H2 $(LEGACY_LNAME2 Old-Style, old-style, D1 style operator overloading))
 
 Macros:
 	TITLE=Operator Overloading
-	WIKI=OperatorOverloading
 	ARGUMENTS=$(I b)$(SUBSCRIPT 1), $(I b)$(SUBSCRIPT 2), ... $(I b)$(SUBSCRIPT n)
 	ARGUMENTS2=$(I c)$(SUBSCRIPT 1), $(I c)$(SUBSCRIPT 2), ... $(I c)$(SUBSCRIPT n)
 	SLICE=$(I i)..$(I j)

--- a/spec/portability.dd
+++ b/spec/portability.dd
@@ -116,5 +116,4 @@ $(H2 $(LNAME2 os_specific_code, OS Specific Code))
 
 Macros:
 	TITLE=Portability
-	WIKI=Portability
 

--- a/spec/pragma.dd
+++ b/spec/pragma.dd
@@ -186,5 +186,4 @@ version (DigitalMars)
 
 Macros:
         TITLE=Pragmas
-        WIKI=Pragma
 

--- a/spec/property.dd
+++ b/spec/property.dd
@@ -248,4 +248,3 @@ $(SECTION3 $(LNAME2 classproperties, User Defined Properties),
 
 Macros:
 	TITLE=Properties
-	 WIKI=Property

--- a/spec/simd.dd
+++ b/spec/simd.dd
@@ -251,7 +251,6 @@ $(H3 $(LNAME2 vector_op_intrinsics, Vector Operation Intrinsics))
 
 Macros:
 	TITLE=Vector Extensions
-	WIKI=Float
 	Y=$(TIMES)
 	N=$(NDASH)
 	CORE_SIMD=$(LINK2 $(ROOT_DIR)phobos/core_simd.html, $(D core.simd))

--- a/spec/spec.dd
+++ b/spec/spec.dd
@@ -54,4 +54,3 @@ $(TOC Table of Contents,
 
 Macros:
         TITLE=Table of Contents
-        WIKI=TOC

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1828,7 +1828,6 @@ void main()
 
 Macros:
         TITLE=Statements
-        WIKI=Statement
         EXPRESSION=$(GLINK2 expression, Expression)
         PSSEMI_PSCURLYSCOPE=$(GLINK Statement)
         PSSEMI_PSCURLYSCOPE_LIST=$(GLINK ScopeStatementList)

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -624,7 +624,6 @@ $(H2 $(LNAME2 unions_and_special_memb_funct, Unions and Special Member Functions
 
 Macros:
         TITLE=Structs, Unions
-        WIKI=Struct
         UNCHECK=
         CHECK=$(CHECKMARK)
         _=

--- a/spec/template-mixin.dd
+++ b/spec/template-mixin.dd
@@ -334,7 +334,6 @@ void test()
 
 Macros:
         TITLE=Template Mixins
-        WIKI=Mixin
         TEMPLATEPARAMETERS=$(GLINK2 template, TemplateParameters)
         TEMPLATEARGUMENTS=$(GLINK2 template, TemplateArguments)
         _=

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -1453,5 +1453,4 @@ $(H2 $(LNAME2 limitations, Limitations))
 
 Macros:
         TITLE=Templates
-        WIKI=Template
         _=

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -980,5 +980,4 @@ function: 'test.main', pretty function: 'int test.main(string[] args)'
 
 Macros:
 	TITLE=Traits
-	WIKI=Traits
 	GBLINK=$(RELATIVE_LINK2 $0, $(D $0))

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -342,5 +342,4 @@ $(SECTION3 $(LNAME2 ptrdiff_t, $(D ptrdiff_t)),
 
 Macros:
     TITLE=Types
-    WIKI=Type
 

--- a/spec/unittest.dd
+++ b/spec/unittest.dd
@@ -207,6 +207,5 @@ $(H3 $(LNAME2 versioning, Versioning))
 
 Macros:
 	TITLE=Unit Tests
-	WIKI=UnitTests
 	_=
 

--- a/spec/version.dd
+++ b/spec/version.dd
@@ -582,5 +582,4 @@ void foo()
 
 Macros:
 	TITLE=Conditional Compilation
-	WIKI=Version
 

--- a/template-comparison.dd
+++ b/template-comparison.dd
@@ -880,7 +880,6 @@ template$(LT)class T$(GT) class Foo
 
 Macros:
 	TITLE=Template Comparison
-	WIKI=TemplateComparison
 	NO=<td class="compNo">No</td>
 	NO1=<td class="compNo"><a href="$1">No</a></td>
 	D_CODE = <pre class="d_code2">$0</pre>

--- a/templates-revisited.dd
+++ b/templates-revisited.dd
@@ -1219,5 +1219,4 @@ of Don Clugston, Eric Anderton and Matthew Wilson.
 
 Macros:
 	TITLE=Templates Revisited
-	WIKI=TemplatesRevisited
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/variadic-function-templates.dd
+++ b/variadic-function-templates.dd
@@ -266,5 +266,4 @@ $(H3 References)
 
 Macros:
 	TITLE=Variadic Templates
-	WIKI=VariadicTemplates
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/warnings.dd
+++ b/warnings.dd
@@ -91,5 +91,4 @@ int foo(int i)
 
 Macros:
 	TITLE=Warnings
-	WIKI=Warnings
 	SUBNAV=$(SUBNAV_ARTICLES)

--- a/wc.dd
+++ b/wc.dd
@@ -69,5 +69,4 @@ int main(string[] args)
 
 Macros:
     TITLE=Word Count
-    WIKI=WC
 

--- a/windbg.dd
+++ b/windbg.dd
@@ -178,6 +178,5 @@ $(P and it should now compile and run without error.)
 
 Macros:
 	TITLE=windbg Debugger
-	WIKI=Windbg
     DMDDIR=\dmd2
     _=

--- a/windows.dd
+++ b/windows.dd
@@ -8,4 +8,3 @@ $(LINK2 https://wiki.dlang.org/D_for_Win32, https://wiki.dlang.org/D_for_Win32)
 )
 
 Macros:
-WIKI=D_for_Win32


### PR DESCRIPTION
If this wiki macro is no longer used, let's remove it!

```
sed '/^\s*WIKI=/d' -i **/*.dd
```

dlang.org.ddoc was manually modified.