### PR TITLE
add D Language Foundation page

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -40,7 +40,7 @@ COMMON_SCRIPTS_DLANG =
 _=
 
 CONSOLE=$(TC pre, console notranslate, $0)
-COPYRIGHT=Copyright &copy; 1999-$(YEAR) by Digital Mars $(REG), All Rights Reserved
+COPYRIGHT=Copyright &copy; 1999-$(YEAR) by the $(LINK2 $(ROOT)/foundation.html, D Language Foundation)
 CPPCODE=$(TC pre, cppcode notranslate, $0)
 CPPLISTING=$(CPPCODE $0)
 CROSS=&#x2718;

--- a/foundation.dd
+++ b/foundation.dd
@@ -1,0 +1,64 @@
+Ddoc
+
+$(D_S $(TITLE),
+
+$(H4 The D Language Foundation is an organization devoted to advancing
+     open source technology related to the D programming language.
+)
+$(H3 History)
+
+$(P The D programming language was started by Walter Bright, as a 'better C++'
+and has grown slowly, but steadily, for more than 15 years. Recent improvements
+to the D development process have accelerated development of the language and
+shown the need for a governing organization that overlooks and arranges the
+future development of the D programming language.)
+
+$(H3 Current projects)
+
+The D foundation
+
+$(UL
+
+    $(LI is providing the various resources for the D community
+        (e.g. this website, dmd downloads, the D tour and more))
+    $(LI is an accepted
+        $(HTTPS summerofcode.withgoogle.com/organizations/5078256051027968/,
+        Google Summer of Code organization) and hosts four projects during
+        the summer of 2016.
+    )
+    $(LI is organizing the yearly $(HTTP dconf.org, D conference))
+)
+
+$(H3 Committee)
+
+The officers of the D Language Foundation are:
+
+$(UL
+    $(LI $(HTTP www.walterbright.com, Walter Bright), President)
+    $(LI $(HTTPS erdani.com/index.php/contact, Tudor Andrei Cristian Alexandrescu), Vice President and Treasurer)
+    $(LI $(HTTP http://acehreli.org, Ali Çehreli), Secretary)
+)
+
+$(H3 Becoming a member)
+
+Individual and corporate membership packages will be announced in the future.
+
+$(H3 Sponsoring D)
+
+$(P If you want to help the D Language to advance further and have resources
+    that you can spend, don't hesitate to contact
+    $(HTTPS erdani.com/index.php/contact, Andrei) and
+    $(HTTP www.walterbright.com, Walter).
+    $(BR)
+    Your help is highly appreciated!
+)
+
+$(H3 Official contacts)
+
+$(P The D Language Foundation has been incorporated with the state of Washington, USA.
+    The employer ID is 47-5352856.)
+
+)
+
+Macros:
+	TITLE=The D Language Foundation

--- a/posix.mak
+++ b/posix.mak
@@ -165,8 +165,8 @@ PAGES_ROOT=$(SPEC_ROOT) 32-64-portability acknowledgements articles ascii-table	
 	const-faq cpptod ctarguments ctod \
 	D1toD2 d-array-article d-floating-point deprecate dll dll-linux \
 	dmd-freebsd dmd-linux dmd-osx dmd-windows documentation download dstyle \
-	exception-safe faq forum-template gpg_keys getstarted glossary gsoc2011 \
-	gsoc2012 gsoc2012-template hijack howto-promote htod htomodule index \
+	exception-safe faq forum-template foundation gpg_keys getstarted glossary \
+	gsoc2011 gsoc2012 gsoc2012-template hijack howto-promote htod htomodule index \
 	intro-to-datetime lazy-evaluation memory menu migrate-to-shared mixin	\
 	overview pretod rationale rdmd regular-expression resources safed search \
 	template-comparison templates-revisited tools tuple				\


### PR DESCRIPTION
AFAIK it's already registered and official - e.g. the D foundation is hosting this year's GSoC.

Unfortunately I don't know much about the D foundation (that's the reason why such a page should exist), but I tried to put all the information in here.

Ping @WalterBright @andralex @CyberShadow @MartinNowak 

1) How far are you with applying for non-profit status
2) Do you already have a bank acocunt?
3) Is there more known?

Other pages:

https://www.python.org/psf-landing/
https://www.mozilla.org/en-US/foundation/
http://www.linuxfoundation.org/
http://www.fsf.org/