### PR TITLE
add whitespace in selective imports to dstyle

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -294,6 +294,8 @@ else if (…)
     …
 }
 -------------------------------
+    $(LI Selective imports should have a space before and after the colon (`:`) like
+    `import std.range : zip`)
  )
 
 $(P


### PR DESCRIPTION
Having a space before and after the colon for selective imports seems to be an informal rule and has been critized in many PR's. 
I personally prefer `import std.range: zip` instead of `std.range : zip`, but the point is to make it a rule and standardize it, so we can automatically check it & no further time is wasted about such nitpicks.