### PR TITLE
use <div> for DDOC_BLANKLINE

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -789,7 +789,7 @@ h3.download
     font-weight: bold;
 }
 
-div.summary, div.description, div.keyval
+div.summary, div.description, div.keyval, div.blankline
 {
     margin: 1.12em 0;
 }

--- a/std.ddoc
+++ b/std.ddoc
@@ -42,5 +42,5 @@ JOIN_DOT=.$1$(JOIN_DOT $+)
 TAIL=$+
 _=
 
-DDOC_BLANKLINE = $(BR)$(BR)$(LF)
+DDOC_BLANKLINE = $(DIVC blankline)$(LF)
 _=


### PR DESCRIPTION
The old `<br><br>` would result in more whitespace after block elements
than after plain text. A `<div>` doesn't have that problem.

Exemplary before/after shot:

![diff-a-after1](https://cloud.githubusercontent.com/assets/9287500/15656947/eb49105a-26ac-11e6-8852-d0104b86f41c.png)