### PR TITLE
Upgrade to DDOX 0.15.4 - Fixes the DDOX part of issue 14608.

### DIFF
--- a/dpl-docs/dub.selections.json
+++ b/dpl-docs/dub.selections.json
@@ -2,7 +2,7 @@
 	"fileVersion": 1,
 	"versions": {
 		"backtrace-d": "~master",
-		"ddox": "0.15.2",
+		"ddox": "0.15.4",
 		"experimental_allocator": "2.70.0-b1",
 		"hyphenate": "1.1.1",
 		"libasync": "0.7.9",


### PR DESCRIPTION
- Removes per-enum-member pages and instead displays the full enum member documentation inside of a single table
- Adds template arguments and constraints display for composite types and enums