### PR TITLE
Add Official D Blog to menu

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -224,6 +224,7 @@ $(DIVID cssmenu, $(UL
 NAVIGATION_COMMUNITY=
 $(SUBMENU
     $(ROOT_DIR)bugstats.php, Bug Tracker,
+    https://dlang.org/blog, Blog,
     https://forum.dlang.org, Forums,
     irc://irc.freenode.net/d, IRC,
     https://github.com/dlang, D on GitHub,


### PR DESCRIPTION
Is there any special sorting mechanism of the menu? Should I sort the links alphabetically?

Ping @JackStouffer @mdparker

Btw
1) the font-size for the menu on http://dlang.org/blog/ should be `15px` and your menu seems to be outdated (e.g. #1303 is missing)
2) have you tried the blog on your phone yet? The D menu doesn't seem to be responsive anymore :/