### PR TITLE
modernize macros in intro-to-datetime

### DIFF
--- a/intro-to-datetime.dd
+++ b/intro-to-datetime.dd
@@ -64,9 +64,9 @@ $(D_S $(TITLE),
 
     $(P The duration types can actually be found in $(CORE_TIME). They are
         $(DURATION) and $(TICK_DURATION). $(TICK_DURATION) is intended for
-        precision timing and is used primarily with $(XREF datetime, StopWatch)
+        precision timing and is used primarily with $(REF_SHORT StopWatch, std,datetime)
         and the benchmarking functions found in $(STD_DATETIME) - such as
-        $(XREF datetime, benchmark) - and you're unlikely to use it outside of
+        $(REF_SHORT benchmark, std,datetime) - and you're unlikely to use it outside of
         using them. $(DURATION), on the other hand, you're likely to use quite a
         bit.)
 
@@ -78,7 +78,7 @@ $(D_S $(TITLE),
         (the $(D total) function).)
 
     $(P Generally, a $(DURATION) is created in one of two ways: by subtracting
-        two time points or with the $(FULL_CXREF time, dur) function. So, for
+        two time points or with the $(REF dur, core,time) function. So, for
         instance, if you subtracted a time point which represented 17:02 from
         a time point which represented 6:07, you'd get a $(DURATION) which
         represented 10 hours and 55 minutes. Or, if you wanted to create a
@@ -102,7 +102,7 @@ assert(duration.total!"hnsecs"() == 393_000_000_000);
         Phobos which take a duration of time take an actual $(DURATION) rather
         than a naked number (most currently take both, though the versions which
         take a naked number are going to be deprecated). For instance,
-        $(FULL_CXREF thread, sleep) takes a $(DURATION), as does
+        $(REF sleep, core,thread) takes a $(DURATION), as does
         $(FULL_XREF concurrency, receiveTimeout). So, durations are used outside
         of just interacting with $(CORE_TIME) and $(STD_DATETIME).)
 
@@ -115,7 +115,7 @@ assert(duration.total!"hnsecs"() == 393_000_000_000);
         however that very few functions take $(D "nsecs"), because nothing in
         $(STD_DATETIME), and very little in $(CORE_TIME), has precision
         greater than hnsecs (100 ns). Also, a number of functions (such as
-        $(FULL_CXREF time, dur)) do not take $(D "years") or $(D "months"),
+        $(REF dur, core,time)) do not take $(D "years") or $(D "months"),
         because it is not possible to convert between years or months and
         smaller units without a specific date. So, while you can add a
         $(DURATION) to a time point, if you want to add years or months to one,
@@ -176,7 +176,7 @@ assert(tod == dateTime.timeOfDay);
         $(D time_t).)
 
     $(P The one other related type which I should mention at this point is
-        $(FULL_CXREF time, FracSec). It holds fractional seconds, and it is
+        $(REF FracSec, core,time). It holds fractional seconds, and it is
         what you get from a $(DURATION) or $(SYSTIME) when you specifically
         ask for the fractional portion of the time.)
 
@@ -725,13 +725,13 @@ int dateFromNthWeekdayOfMonth(int year, Month month,
                   $(D Clock.currTime()). Its internal time is in UTC
                   regardless.))
         $(TR $(TD $(D DosFileTime))
-             $(TD $(XREF datetime, DosFileTime)))
+             $(TD $(REF_SHORT DosFileTime, std,datetime)))
         $(TR $(TD $(D toDtime))
-             $(TD $(XREF datetime, DosFileTimeToSysTime)))
+             $(TD $(REF_SHORT DosFileTimeToSysTime, std,datetime)))
         $(TR $(TD $(D toDosFileTime))
-             $(TD $(XREF datetime, SysTimeToDosFileTime)))
+             $(TD $(REF_SHORT SysTimeToDosFileTime, std,datetime)))
         $(TR $(TD $(D benchmark))
-             $(TD $(XREF datetime, benchmark)))
+             $(TD $(REF_SHORT benchmark, std,datetime)))
     )
 
     $(P Note that I'm not an expert on what does and doesn't work in
@@ -765,30 +765,28 @@ Macros:
     RED = <span style="color:red">$0</span>
     TITLE = Introduction to std.datetime
 
-    CXREF = <a href="phobos/core_$1.html#$2">$(D $2)</a>
-    FULL_CXREF = <a href="phobos/core_$1.html#$2">$(D core.$1.$2)</a>
-    XREF = <a href="phobos/std_$1.html#$2">$(D $2)</a>
-    CORE_TIME=<a href="phobos/core_time.html">$(D core.time)</a>
-    STD_DATETIME=<a href="phobos/std_datetime.html">$(D std.datetime)</a>
+    REF_SHORT=$(REF_ALTTEXT $(D $1), $1, $+)
+    CORE_TIME=$(MREF core,time)
+    STD_DATETIME=$(MREF std,datetime)
     STD_DATE=$(D std.date)
-    STD_FILE=<a href="phobos/std_file.html">$(D std.file)</a>
+    STD_FILE=$(MREF std,file)
 
-    DATE=$(XREF datetime, Date)
-    DATETIME=$(XREF datetime, DateTime)
-    DURATION=$(CXREF time, Duration)
-    FRACSEC=$(CXREF time, FracSec)
-    INTERVAL=$(XREF datetime, Interval)
-    LOCALTIME=$(XREF datetime, LocalTime)
-    NEGINF_INTERVAL=$(XREF datetime, NegInfInterval)
-    POSINF_INTERVAL=$(XREF datetime, PosInfInterval)
-    POSIXTZ=$(XREF datetime, PosixTimeZone)
-    STOPWATCH=$(XREF datetime, StopWatch)
-    SIMPLETZ=$(XREF datetime, SimpleTimeZone)
+    DATE=$(REF_SHORT Date, std,datetime)
+    DATETIME=$(REF_SHORT DateTime, std,datetime)
+    DURATION=$(REF_SHORT Duration, core,time)
+    FRACSEC=$(REF_SHORT FracSec, core,time)
+    INTERVAL=$(REF_SHORT Interval, std,datetime)
+    LOCALTIME=$(REF_SHORT LocalTime, std,datetime)
+    NEGINF_INTERVAL=$(REF_SHORT NegInfInterval, std,datetime)
+    POSINF_INTERVAL=$(REF_SHORT PosInfInterval, std,datetime)
+    POSIXTZ=$(REF_SHORT PosixTimeZone, std,datetime)
+    STOPWATCH=$(REF_SHORT StopWatch, std,datetime)
+    SIMPLETZ=$(REF_SHORT SimpleTimeZone, std,datetime)
     SUBNAV=$(SUBNAV_ARTICLES)
-    SYSTIME=$(XREF datetime, SysTime)
-    TIMEOFDAY=$(XREF datetime, TimeOfDay)
-    TICK_DURATION=$(CXREF time, TickDuration)
-    TIMEZONE=$(XREF datetime, TimeZone)
-    UTC=$(XREF datetime, UTC)
-    WINDOWSTZ=$(XREF datetime, WindowsTimeZone)
+    SYSTIME=$(REF_SHORT SysTime, std,datetime)
+    TIMEOFDAY=$(REF_SHORT TimeOfDay, std,datetime)
+    TICK_DURATION=$(REF_SHORT TickDuration, core,time)
+    TIMEZONE=$(REF_SHORT TimeZone, std,datetime)
+    UTC=$(REF_SHORT UTC, std,datetime)
+    WINDOWSTZ=$(REF_SHORT WindowsTimeZone, std,datetime)
     _=


### PR DESCRIPTION
Replacing the custom macros XREF and CXREF with a custom REF_SHORT which
has the same syntax as REF and may prove useful generally.

The custom macro FULL_CXREF is replaced with REF.

Replacing raw HTML with MREF in definitions of CORE_TIME, STD_DATETIME, and
STD_FILE.

FULL_XREF does not have a custom definition here. It's going to be replaced
in a repository-wide purge.

sed commands:

XREF -> REF_SHORT:

    arg='\s*([^(),]*)'
    from='\$\(XREF\s'$arg','$arg'\)'
    to='$(REF_SHORT \2, std,\1)'
    sed -i -r "s/$from/$to/g" intro-to-datetime.dd

CXREF -> REF_SHORT:

    arg='\s*([^(),]*)'
    from='\$\(CXREF\s'$arg','$arg'\)'
    to='$(REF_SHORT \2, core,\1)'
    sed -i -r "s/$from/$to/g" intro-to-datetime.dd

FULL_CXREF -> REF:

    arg='\s*([^(),]*)'
    from='\$\(FULL_CXREF\s'$arg','$arg'\)'
    to='$(REF \2, core,\1)'
    sed -i -r "s/$from/$to/g" intro-to-datetime.dd