### PR TITLE
Update community section on frontpage

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -95,12 +95,13 @@ $(DIVC boxes,
         )
         $(TOUR comments, Community,
             $(P Discuss D on the $(LINK2 https://forum.dlang.org/, forums), join
-                the $(LINK2 irc://irc.freenode.net/d, IRC channel), or follow
-                us on $(LINK2 https://twitter.com/D_Programming, Twitter).)
+                the $(LINK2 irc://irc.freenode.net/d, IRC channel), read our
+                $(LINK2 https://dlang.org/blog, official Blog), or follow us
+                on $(LINK2 https://twitter.com/D_Programming, Twitter).)
             $(P Browse the $(LINK2 https://wiki.dlang.org, wiki) where among
                 other things you can find the
-                $(LINK2 https://wiki.dlang.org/Review_Queue, review queue) for
-                major additions to the D project.)
+                $(LINK2 https://wiki.dlang.org/Vision/2016H1, high-level vision)
+                of the D foundation.)
         )
     )
     $(DIVC row,


### PR DESCRIPTION
1) adds a link to the official dlang blog CC @mdparker 
2) removes the link to the empty/outdated review queue

The best replacement I could find for 2) were the DIPs, better ideas are welcome.