### PR TITLE
Remove carriage-returns from sitemap

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -249,7 +249,7 @@ $(DOC_OUTPUT_DIR)/sitemap.html : $(ALL_FILES_BUT_SITEMAP) $(DMD)
 	(true $(foreach F, $(TARGETS), \
 	  && echo \
 	    "$F	`sed -n 's/<title>\(.*\) - D Programming Language.*<\/title>/\1/'p $(DOC_OUTPUT_DIR)/$F`")) \
-	  | sort --ignore-case --key=2 | sed 's/^\([^	]*\)	\(.*\)/<a href="\1">\2<\/a><br>/' >> sitemap.dd
+	  | sort --ignore-case --key=2 | sed 's/^\([^	]*\)	\([^\n\r]*\)/<a href="\1">\2<\/a><br>/' >> sitemap.dd
 	$(DMD) -conf= -c -o- -Df$@ $(DDOC) sitemap.dd
 	rm sitemap.dd
 


### PR DESCRIPTION
Somewhere is a carriage-return hidden. The sitemap `sed` puts that into the HTML.
This PR avoids matching the carriage return symbol:

Before:

http://dlang.org/sitemap.html

![image](https://cloud.githubusercontent.com/assets/4370550/15807043/d07c7122-2b52-11e6-8758-0bdedf92ec97.png)

After:

![image](https://cloud.githubusercontent.com/assets/4370550/15807040/c2bfed3e-2b52-11e6-9d05-7735a2064f0d.png)
