### PR TITLE
use <span id="foo"> for anchors instead of <a name="foo">

### DIFF
--- a/html.ddoc
+++ b/html.ddoc
@@ -4,7 +4,7 @@ here for completeness. Macros defer wherever possible to style classes.
 _=Simple tags, ordered alphabetically
 
 A = <a href="$1">$+</a>
-ADEF = <a name="$0"></a>
+ADEF = <span id="$0"></span>
 AHTTP = <a href="http://$1">$+</a>
 AHTTPS = <a class="https" href="https://$1">$+</a>
 ALOCAL = <a href="#$1">$+</a>


### PR DESCRIPTION
The old method would mess with surrounding links.

Hit recently in <https://github.com/dlang/phobos/pull/4410>.