### PR TITLE
Kill WEB, HTTP and HTTPS macros

### DIFF
--- a/changelog/2.070.0.dd
+++ b/changelog/2.070.0.dd
@@ -50,7 +50,7 @@ $(LI $(LNAME2 core-sys-windows, The `core.sys.windows` package has been
 
     $(P The `core.sys.windows` package now contains a considerably more
         comprehensive set of Windows API bindings. The package has been
-        adapted from $(WEB github.com/smjgordon/bindings, Stewart Gordon's
+        adapted from $(HTTP github.com/smjgordon/bindings, Stewart Gordon's
         bindings), which were originally adapted from the MinGW project.
     )
 )

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -158,8 +158,8 @@ _=
 GEN_DATETIME=$(DATETIME)
 GLINK=$(RELATIVE_LINK2 $0, $(I $0))
 GLINK2=$(DDSUBLINK spec/$1,$2,$(I $2))
-GLOSSARY = $(WEB dlang.org/glossary.html#$0, $0)
-GLOSSARY2 = $(WEB dlang.org/glossary.html#$1, $2)
+GLOSSARY = $(HTTP dlang.org/glossary.html#$0, $0)
+GLOSSARY2 = $(HTTP dlang.org/glossary.html#$1, $2)
 GNAME=<a id="$0">$(SPANC gname, $0)</a>
 GRAMMAR=$(TC pre, bnf notranslate, $0)
 GREEN=$(SPANC green, $0)

--- a/doc.ddoc
+++ b/doc.ddoc
@@ -19,7 +19,7 @@ DUMPOBJ=$(HTTP digitalmars.com/ctg/dumpobj.html, dumpobj)
 SHELL=$(HTTP digitalmars.com/ctg/shell.html, shell)
 _=
 
-AMAZONLINK= $(WEB amazon.com/exec/obidos/ASIN/$1/classicempire, $+)
+AMAZONLINK= $(HTTP amazon.com/exec/obidos/ASIN/$1/classicempire, $+)
 _=
 
 MIDRULE=

--- a/modlist.d
+++ b/modlist.d
@@ -1,8 +1,8 @@
 #!/usr/bin/env rdmd
 /**
  * Copyright: Martin Nowak 2015-.
- * License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors: $(WEB code.dawg.eu, Martin Nowak)
+ * License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors: $(HTTP code.dawg.eu, Martin Nowak)
  */
 import std.algorithm, std.file, std.path, std.stdio, std.string, std.range;
 

--- a/orgs-using-d.dd
+++ b/orgs-using-d.dd
@@ -158,9 +158,9 @@ $(P
 Macros:
     TITLE=Organizations using the D Language
     FA_ICON=<i class="fa fa-$1" aria-hidden="true"></i>
-    FA_HIRING=$(FA_ICON rocket) $(WEB $1, Hiring)
+    FA_HIRING=$(FA_ICON rocket) $(HTTP $1, Hiring)
     FA_GITHUB=$(FA_ICON github) $(HTTPS github.com/$1, Github)
-    FA_TALK=$(FA_ICON youtube-play) $(WEB $1, $2)
+    FA_TALK=$(FA_ICON youtube-play) $(HTTP $1, $2)
     FA_SEPARATOR=&nbsp;
     FA_TESTIMONIAL=$(FA_ICON heart)
     FA_QUOTE=$(FA_ICON quote-left) $0 $(FA_ICON quote-right)

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2251,7 +2251,7 @@ $(H3 $(LNAME2 pseudo-member, Uniform Function Call Syntax (UFCS)))
 
     $(P This provides a way to add functions to a class externally as if they were
     public final member functions, which enables
-    $(WEB www.drdobbs.com/architecture-and-design/component-programming-in-d/240008321,
+    $(HTTP www.drdobbs.com/architecture-and-design/component-programming-in-d/240008321,
     function chaining and component programming).
     )
 


### PR DESCRIPTION
https://github.com/dlang/phobos/pull/4411 (see this for more info)

In the manual cleanup after the usual `sed`'s (see git log) I found a github link to `D-Programming-Language`. 

Also note that this PR doesn't remove the `WEB`, `HTTP` and `HTTPS` macros, but I will submit a follow-up PR once the sister PRs https://github.com/dlang/phobos/pull/4411 and https://github.com/dlang/druntime/pull/1585 are merged.