### PR TITLE
Shorten TWiD frontpage text

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -89,8 +89,8 @@ $(DIVC boxes,
             )
             $(P Stay updated with
                 $(LINK2 http://arsdnet.net/this-week-in-d,
-                    <cite>This Week in D</cite>),
-                Adam D. Ruppe's weekly newsletter. $(SPANC twid)
+                    <cite>This Week in D</cite>) -
+                $(SPANC twid)
             )
         )
         $(TOUR graduation-cap, Learn,


### PR DESCRIPTION
At the moment TWiD uses four lines:

![image](https://cloud.githubusercontent.com/assets/4370550/15858489/0a82c9a6-2cc1-11e6-9ed6-effa95b92fff.png)

this shortens it to three lines so that's more similar to the height of the Learn section:

![image](https://cloud.githubusercontent.com/assets/4370550/15858556/70f848a0-2cc1-11e6-835a-acd050944380.png)

Btw Both links redirect (This week in D, "June 5") redirect to the same page - so we could remove one?

CC @adamdruppe 

Btw @adamdruppe now that @CyberShadow's auto-deploy is there, you could think about dropping your custom js ;-)