### PR TITLE
Add description and dconf talk to frontpage companies

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -386,7 +386,7 @@ $(DIVC frontpage-orgs center,
     $(FRONTPAGE_ORG Weka.IO, http://weka.io, weka.png,
         Software defined storage
     )
-    $(FRONTPAGE_ORG Funkwerk AG, http://remedygames.com, funkwerk.png,
+    $(FRONTPAGE_ORG Funkwerk AG, http://www.funkwerk.com/en, funkwerk.png,
         Passenger information systems
     )
 )

--- a/index.dd
+++ b/index.dd
@@ -378,12 +378,16 @@ consistency. $(LINK2 spec/memory-safe-d.html, Read more).)
 $(DIVC section, $(DIV, $(SECTION3 Industry-proven,
 $(DIVC frontpage-orgs center,
     $(FRONTPAGE_ORG Facebook, https://www.facebook.com, facebook.svg,
+        Online social networking service
     )
     $(FRONTPAGE_ORG Sociomantic, https://www.sociomantic.com, sociomantic.png,
+        Real-time personalized advertising
     )
     $(FRONTPAGE_ORG Weka.IO, http://weka.io, weka.png,
+        Software defined storage
     )
     $(FRONTPAGE_ORG Funkwerk AG, http://remedygames.com, funkwerk.png,
+        Passenger information systems
     )
 )
     <div id="frontpage-orgs-more">
@@ -415,7 +419,7 @@ Macros:
     TOUR=$(DIVC item, $(SECTION4 $(TC i, fa fa-$1 big-icon)$2, $3))
     _=
 	FRONTPAGE_ORG_IMG=$(DIVC frontpage-orgs-img-wrapper vcontainer-box, <img class="vcontainer-element" src="$(ROOT_DIR)images/orgs-using-d/$0" />)
-    FRONTPAGE_ORG=$(DIVC frontpage-orgs-cell dont-highlight-link, $(LINK2 $2, $(FRONTPAGE_ORG_IMG $3)) $(H3 $1) $(P $4))
+    FRONTPAGE_ORG=$(DIVC frontpage-orgs-cell dont-highlight-link, $(LINK2 $2, $(FRONTPAGE_ORG_IMG $3)) $(H3 $1) $(P $(I $4 )))
     _= Single word inline CSS needs to be escaped _=
     C_A=$1:$2;
     EXTRA_HEADERS=$(T style,


### PR DESCRIPTION
as @leandro-lucarella-sociomantic suggested, this PR puts the short description of the companies and their DConf Link onto the frontpage.

before:

![image](https://cloud.githubusercontent.com/assets/4370550/15868163/c88919f8-2ce6-11e6-9f19-a5e9d29e915b.png)

after:

![image](https://cloud.githubusercontent.com/assets/4370550/15868141/ae6ef466-2ce6-11e6-918b-f08154ed0088.png)

Unfortunately imho adding the quote and more links makes it to messy for the frontpage, see:

![2016-06-07-19 24 18](https://cloud.githubusercontent.com/assets/4370550/15868132/a51490e2-2ce6-11e6-9860-478b93a2b868.png)

After experimenting with this, I am not sure anymore whether it's a good idea to add Links
@aG0aep6G @CyberShadow - what do you think?