### PR TITLE
XREF variants -> REF (sed)

### DIFF
--- a/cpptod.dd
+++ b/cpptod.dd
@@ -237,7 +237,7 @@ if (h != HANDLE_INIT)
 $(H4 The D Way)
 
 	No need for idiomatic constructions like the above.
-	You can use $(FULL_XREF typecons, Typedef):
+	You can use $(REF Typedef, std,typecons):
 
 ------
 alias Handle = Typedef!(void*, cast(void*)-1);
@@ -250,9 +250,9 @@ if (h != Handle.init)
     ...
 ------
 
-	Unlike a bare $(D alias), using $(FULL_XREF typecons, Typedef)
+	Unlike a bare $(D alias), using $(REF Typedef, std,typecons)
 	ensures the two types are not considered as equals. Note how a
-	default initializer can be supplied to $(FULL_XREF typecons, Typedef)
+	default initializer can be supplied to $(REF Typedef, std,typecons)
 	as a value of the underlying type.
 
 <hr><!-- -------------------------------------------- -->
@@ -467,7 +467,7 @@ void test()
 
 $(P $(D class)es are typically managed by the garbage collector which doesn't
 lend itself to RAII. If you need deterministic destruction with $(D class)es
-you can use $(FULL_XREF typecons, scoped) (which will also allocate the
+you can use $(REF scoped, std,typecons) (which will also allocate the
 $(D class) on the stack instead of the garbage collector managed heap).)
 
 $(P See also $(GLINK2 statement, ScopeGuardStatement) for a more generalized

--- a/d-array-article.dd
+++ b/d-array-article.dd
@@ -229,7 +229,7 @@ slice.assumeSafeAppend();
 assert(slice.capacity == 7); // force the used data to 2 elements
 ------
 
-$(P If D slices' append performance just isn't up to snuff for your performance requirements, there is another alternative.  The $(FULL_XREF array, Appender) type will append data to an array as fast as possible, without any need to look up metadata from the runtime.  $(STDREF array, Appender) also supports the output range idiom via an append operation (normal slices only support the output range by overwriting their own data).)
+$(P If D slices' append performance just isn't up to snuff for your performance requirements, there is another alternative.  The $(REF Appender, std,array) type will append data to an array as fast as possible, without any need to look up metadata from the runtime.  $(STDREF array, Appender) also supports the output range idiom via an append operation (normal slices only support the output range by overwriting their own data).)
 
 $(H2 Conclusion)
 

--- a/deprecate.dd
+++ b/deprecate.dd
@@ -159,7 +159,7 @@ $(H3 $(DEPNAME scope for allocating classes on the stack))
         ---
     )
 $(H4 Corrective Action)
-    $(P Use $(FULL_XREF typecons, scoped) instead.
+    $(P Use $(REF scoped, std,typecons) instead.
         ---
         class A
         {
@@ -243,7 +243,7 @@ $(H3 $(DEPNAME Floating point NCEG operators))
         (!<>=, <>, <>=, !>, !>=, !<, !<=, !<>) for comparisons involving NaNs.
     )
 $(H4 Corrective Action)
-    $(P Use the normal operators and $(FULL_XREF math, isNaN).
+    $(P Use the normal operators and $(REF isNaN, std,math).
     )
 $(H4 Rationale)
     $(P These operators are too specialized to be a part of the core language.
@@ -349,7 +349,7 @@ $(H3 $(DEPNAME typedef))
         ---
     )
 $(H4 Corrective Action)
-    $(P Replace use of typedef with alias or use $(FULL_XREF typecons, Typedef).
+    $(P Replace use of typedef with alias or use $(REF Typedef, std,typecons).
     )
 $(H4 Rationale)
     $(P typedef is not flexible enough to cover all use cases.  This is better
@@ -478,7 +478,7 @@ $(H3 $(DEPNAME Octal literals))
         ---
     )
 $(H4 Corrective Action)
-    $(P Use the $(FULL_XREF conv, octal) template.
+    $(P Use the $(REF octal, std,conv) template.
         ---
         auto x = octal!123;
         ---

--- a/intro-to-datetime.dd
+++ b/intro-to-datetime.dd
@@ -103,7 +103,7 @@ assert(duration.total!"hnsecs"() == 393_000_000_000);
         than a naked number (most currently take both, though the versions which
         take a naked number are going to be deprecated). For instance,
         $(REF sleep, core,thread) takes a $(DURATION), as does
-        $(FULL_XREF concurrency, receiveTimeout). So, durations are used outside
+        $(REF receiveTimeout, std,concurrency). So, durations are used outside
         of just interacting with $(CORE_TIME) and $(STD_DATETIME).)
 
     $(P One particular thing to note here is how both $(D dur) and $(D total)
@@ -170,7 +170,7 @@ assert(tod == dateTime.timeOfDay);
         them, but you do risk problems with DST when creating a $(SYSTIME) from
         the other 3 time points unless you specifically create the $(SYSTIME)
         with a $(TIMEZONE) which doesn't have DST (such as
-        $(FULL_XREF datetime, UTC)), since when a time zone has DST, one hour of
+        $(REF UTC, std,datetime)), since when a time zone has DST, one hour of
         the year does not exist, and another exists twice. You can also convert
         to and from unix time, which is what you're dealing with in C with
         $(D time_t).)
@@ -253,7 +253,7 @@ assert(stdTime == st.stdTime);
         at all or are dealing with anything which needs to worry about DST,
         you should use $(SYSTIME). Because it keeps its time internally in UTC,
         it avoids problems with DST. And while it does have a time zone
-        component, it defaults to $(FULL_XREF datetime, LocalTime) (which
+        component, it defaults to $(REF LocalTime, std,datetime) (which
         is the time zone type for the local time of the system), so you don't
         generally have to deal directly with time zones if you don't want to.)
 
@@ -499,8 +499,8 @@ setTimes("yourfile.txt", sysTime, sysTime + dur!"msecs"(5));
         use as discussed previously (such as its std time or its ISO string),
         or you're going to have be converting between $(D d_time) and
         $(SYSTIME). At present, the functions
-        $(FULL_XREF datetime, sysTimeToDTime) and
-        $(FULL_XREF datetime, dTimeToSysTime) will do those conversions for you.
+        $(REF sysTimeToDTime, std,datetime) and
+        $(REF dTimeToSysTime, std,datetime) will do those conversions for you.
         So, converting between the two formats is easy. However, because
         $(D d_time) is going away, those functions will be going away. That
         means that you either need to refactor your code so that those functions
@@ -562,12 +562,12 @@ immutable tzWithoutDST = new SimpleTimeZone(utcOffset);
          values between $(STD_DATE) and $(STD_DATETIME).
          $(D std.date.Date)'s $(D weekday) property gives Sunday a value of
          1, but $(D std.date.weekDay) gives Sunday a value of 0.
-         $(FULL_XREF datetime, DayOfWeek) gives Sunday a value of 0. So,
+         $(REF DayOfWeek, std,datetime) gives Sunday a value of 0. So,
          depending on which part of $(STD_DATE) you're dealing with it, it
          may or may not match what $(STD_DATETIME) is doing for the numerical
          values of weekdays. Months have a similar problem.
          $(D std.date.Date)'s $(D month) property gives January a value of
-         1 - which matches what $(FULL_XREF datetime, Month) does - but
+         1 - which matches what $(REF Month, std,datetime) does - but
          $(D std.date.monthFromTime) gives January a value of 0. So,
          just as with the days of the week, you have to be careful with the
          numerical values of the months. Whether $(STD_DATETIME) matches what

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -197,7 +197,7 @@ s[1..3] = s[0..2]; // error, overlapping copy
         )
         
         $(P If overlapping is required, use
-        $(XREF_PACK algorithm,mutation,copy):
+        $(REF copy, std,algorithm,mutation):
         )
 
 ---------

--- a/spec/hash-map.dd
+++ b/spec/hash-map.dd
@@ -228,7 +228,7 @@ $(H3 $(LNAME2 construction_assignement_entries, Construction or Assignment on Se
         ---------
 
         This is designed for efficient memory reuse with some value-semantics
-        structs, eg. $(FULL_XREF bigint,BigInt).
+        structs, eg. $(REF BigInt, std,bigint).
 
         ---------
         import std.bigint;

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -748,7 +748,7 @@ $(GNAME HexLetter):
 
 	$(P C-style octal integer notation was deemed too easy to mix up with decimal notation;
 	it is only fully supported in string literals.
-	D still supports octal integer literals interpreted at compile time through the $(FULL_XREF conv, octal)
+	D still supports octal integer literals interpreted at compile time through the $(REF octal, std,conv)
 	template, as in $(D octal!167).)
 
 	$(P Hexadecimal integers are a sequence of hexadecimal digits preceded

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -717,7 +717,7 @@ $(GNAME TemplateSequenceParameter):
         is declared as a $(I TemplateSequenceParameter),
         it is a match with any trailing template arguments.
         Such a sequence of arguments can be defined using the template
-        $(XREF meta, AliasSeq) and will thus henceforth
+        $(REF AliasSeq, std,meta) and will thus henceforth
         be referred to by that name for clarity.
         An $(I AliasSeq) is not itself a type, value, or symbol.
         It is a compile-time sequence of any mix of types, values or symbols.
@@ -826,7 +826,7 @@ a
             writefln("%d", plus_two(6, 8)); // prints 16
         }
         ----
-        See also: $(FULL_XREF functional, partial)
+        See also: $(REF partial, std,functional)
     )
 
 $(H3 $(LNAME2 variadic_template_specialization, Specialization))


### PR DESCRIPTION
With this, dlang.org doesn't use any macros of the XREF variety anymore.

The definitions stay in place, because the stable docs still use them. Thanks @wilzbach for noticing this. There's a separate pull request to remove the definitions: #1355. It should be possible to pull that after the 2.072 release.