### PR TITLE
Fix issue 16141 - Organizations page should have a menu item

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -224,6 +224,20 @@ body > .container
     padding-bottom: 0.6em;
 }
 
+
+#top #cssmenu > ul > li .menu-divider
+{
+    border-top: 1px solid #943029;
+}
+
+#top #cssmenu > ul > li .menu-divider:before
+{
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    display: block;
+    height: 1px;
+    content: '';
+}
+
 /* search box */
 
 #top .search-container.expand-container .expand-toggle

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -222,14 +222,15 @@ $(DIVID cssmenu, $(UL
       $(NAVIGATION_RESOURCES)
 ))
 NAVIGATION_COMMUNITY=
-$(SUBMENU
-    $(ROOT_DIR)bugstats.php, Bug Tracker,
-    https://dlang.org/blog, Blog,
-    https://forum.dlang.org, Forums,
-    irc://irc.freenode.net/d, IRC,
-    https://github.com/dlang, D on GitHub,
-    https://wiki.dlang.org, Wiki,
-    https://twitter.com/search?q=%23dlang, Twitter,
+$(SUBMENU_MANUAL
+    $(SUBMENU_LINK $(ROOT_DIR)bugstats.php, Bug Tracker)
+    $(SUBMENU_LINK https://github.com/dlang, GitHub)
+    $(SUBMENU_LINK_DIVIDER https://forum.dlang.org, Forums)
+    $(SUBMENU_LINK irc://irc.freenode.net/d, IRC)
+    $(SUBMENU_LINK https://wiki.dlang.org, Wiki)
+    $(SUBMENU_LINK_DIVIDER https://dlang.org/blog, Blog)
+    $(SUBMENU_LINK https://twitter.com/search?q=%23dlang, Twitter)
+    $(SUBMENU_LINK $(ROOT_DIR)orgs-using-d.html, Orgs using D)
 )
 NAVIGATION_DOCUMENTATION=
 $(SUBMENU
@@ -391,6 +392,9 @@ STATIC=$(ROOT_DIR)$1
 SUBMENU=<ul class='expand-content'>$(SUBMENU2 $1,$+)</ul></li>
 SUBMENU2=<li><a href='$1'>$2</a></li>$(SUBMENU3 $+)
 SUBMENU3=$(SUBMENU2 $+)
+SUBMENU_MANUAL=<ul class='expand-content'>$1 $+</ul></li>
+SUBMENU_LINK=<li><a href='$1'>$2</a></li>
+SUBMENU_LINK_DIVIDER=<li class="menu-divider"><a href='$1'>$2</a></li>
 _=
 
 SUBNAV=


### PR DESCRIPTION
Thanks @qznc for pointing this out. We have to be a bit careful about not adding too much to the menu, but I recently purged to items from the menu, so I guess we are good.
Moreover I took the liberty to sort this alphabetically (it's easier to parse for the human eye).

Btw there are many other great pages that are currently hard to find, see e.g. http://dlang.org/sitemap.html

