### PR TITLE
Menu: Sort resources alphabetically

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -242,17 +242,17 @@ $(SUBMENU
     $(ROOT_DIR)articles.html, Articles
 )
 NAVIGATION_RESOURCES=
-$(SUBMENU
-    $(ROOT_DIR)tools.html, D-Specific Tools,
-    $(VISUALD), Visual D,
-    https://wiki.dlang.org/Editors, Editors,
-    https://wiki.dlang.org/IDEs, IDEs,
-    https://wiki.dlang.org/Tutorials, Tutorials,
-    https://wiki.dlang.org/Books, Books,
-    $(ROOT_DIR)dstyle.html, The D Style,
-    $(ROOT_DIR)glossary.html, Glossary,
-    $(ROOT_DIR)acknowledgements.html, Acknowledgments,
-    $(ROOT_DIR)sitemap.html, Sitemap
+$(SUBMENU_MANUAL
+    $(SUBMENU_LINK https://wiki.dlang.org/Books, Books)
+    $(SUBMENU_LINK https://wiki.dlang.org/Tutorials, Tutorials)
+    $(SUBMENU_LINK_DIVIDER $(ROOT_DIR)tools.html, D-Specific Tools)
+    $(SUBMENU_LINK https://wiki.dlang.org/Editors, Editors)
+    $(SUBMENU_LINK https://wiki.dlang.org/IDEs, IDEs)
+    $(SUBMENU_LINK $(VISUALD), Visual D)
+    $(SUBMENU_LINK_DIVIDER $(ROOT_DIR)acknowledgements.html, Acknowledgments)
+    $(SUBMENU_LINK $(ROOT_DIR)dstyle.html, D Style)
+    $(SUBMENU_LINK $(ROOT_DIR)glossary.html, Glossary)
+    $(SUBMENU_LINK $(ROOT_DIR)sitemap.html, Sitemap)
 )
 _=
 


### PR DESCRIPTION
follow-up to #1358

- I removed "The" because it seemed rather foreign to the prevalent style (e.g. it isn't"The Sitemap") and it destroy the point of sorting
- there was a bit of grouping, but this shows us that "Acknowledgment", "Sitemap" don't fit entirely into this menu?