### PR TITLE
Documentation menu: add divider + rename DMD manual

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -233,13 +233,13 @@ $(SUBMENU_MANUAL
     $(SUBMENU_LINK $(ROOT_DIR)orgs-using-d.html, Orgs using D)
 )
 NAVIGATION_DOCUMENTATION=
-$(SUBMENU
-    $(ROOT_DIR)spec/spec.html, Language Reference,
-    $(ROOT_DIR)phobos/index.html, Library Reference,
-    $(ROOT_DIR)library/index.html, NEW Library Reference Preview,
-    $(ROOT_DIR)comparison.html, Feature Overview,
-    $(ROOT_DIR)dmd-windows.html, DMD Manual,
-    $(ROOT_DIR)articles.html, Articles
+$(SUBMENU_MANUAL
+    $(SUBMENU_LINK $(ROOT_DIR)spec/spec.html, Language Reference)
+    $(SUBMENU_LINK $(ROOT_DIR)phobos/index.html, Library Reference)
+    $(SUBMENU_LINK $(ROOT_DIR)library/index.html, Library Reference Preview)
+    $(SUBMENU_LINK $(ROOT_DIR)dmd-windows.html, Command-line Reference)
+    $(SUBMENU_LINK_DIVIDER $(ROOT_DIR)comparison.html, Feature Overview)
+    $(SUBMENU_LINK $(ROOT_DIR)articles.html, Articles)
 )
 NAVIGATION_RESOURCES=
 $(SUBMENU


### PR DESCRIPTION
- rename DMD Manual to Command-line Reference (it currently links to DMD for Windows, there will be a follow-up fixing that)
- add divider after Command-line Reference
- removed "New" from Library Reference Preview (afaik it's more than two years old - there will be a follow-up to remove that entirely in favor of displaying a button within the documentation)

![image](https://cloud.githubusercontent.com/assets/4370550/15981296/a0a0c88e-2f73-11e6-9088-b799f702eba0.png)