### PR TITLE
Remove 'New Library Reference' from menu

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -236,7 +236,6 @@ NAVIGATION_DOCUMENTATION=
 $(SUBMENU_MANUAL
     $(SUBMENU_LINK $(ROOT_DIR)spec/spec.html, Language Reference)
     $(SUBMENU_LINK $(ROOT_DIR)phobos/index.html, Library Reference)
-    $(SUBMENU_LINK $(ROOT_DIR)library/index.html, Library Reference Preview)
     $(SUBMENU_LINK $(ROOT_DIR)dmd.html, Command-line Reference)
     $(SUBMENU_LINK_DIVIDER $(ROOT_DIR)comparison.html, Feature Overview)
     $(SUBMENU_LINK $(ROOT_DIR)articles.html, Articles)

--- a/std_navbar-prerelease.ddoc
+++ b/std_navbar-prerelease.ddoc
@@ -3,7 +3,10 @@ $(SUBNAV_TEMPLATE
     $(DIVC head,
         $(H2 Library Reference)
         $(P $(SPANC smallprint, pre-release version $(SPANC separator, $(BR))
-            $(LINK2 ../phobos/index.html, switch to version $(LATEST))))
+            switch to $(LINK2 ../phobos/index.html, $(LATEST)). $(BR)
+            $(LINK2 ../library-prerelease/index.html, preview) beta library reference.
+            )
+        )
         $(P $(LINK2 index.html, overview))
     )
     $(UL $(MODULE_MENU))

--- a/std_navbar-release.ddoc
+++ b/std_navbar-release.ddoc
@@ -3,8 +3,11 @@ $(SUBNAV_TEMPLATE
     $(DIVC head,
         $(H2 Library Reference)
         $(P $(SPANC smallprint, version $(LATEST) $(SPANC separator, $(BR))
-            $(LINK2 ../phobos-prerelease/index.html, switch to pre-release
-                version)))
+            switch to
+            $(LINK2 ../phobos-prerelease/index.html, pre-release). $(BR)
+            $(LINK2 ../library/index.html, preview) beta library reference.
+            )
+        )
         $(P $(LINK2 index.html, overview))
     )
     $(UL $(MODULE_MENU))


### PR DESCRIPTION
Imho it's very confusing to have "Library Reference" and Library Reference Preview" - how about linking it directly from the docs?

stable:

![image](https://cloud.githubusercontent.com/assets/4370550/15981719/f78cf504-2f79-11e6-8152-ca42cad8484c.png)

pre-release:

![image](https://cloud.githubusercontent.com/assets/4370550/15981691/803e20ea-2f79-11e6-8914-77752d4b7833.png)

(for pre-release I thought people are familar with D and know about the difference between ddoc and ddox)