### PR TITLE
redirect tools to D wiki

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -245,7 +245,7 @@ NAVIGATION_RESOURCES=
 $(SUBMENU_MANUAL
     $(SUBMENU_LINK https://wiki.dlang.org/Books, Books)
     $(SUBMENU_LINK https://wiki.dlang.org/Tutorials, Tutorials)
-    $(SUBMENU_LINK_DIVIDER $(ROOT_DIR)tools.html, D-Specific Tools)
+    $(SUBMENU_LINK_DIVIDER https://wiki.dlang.org/Development_tools, Tools)
     $(SUBMENU_LINK https://wiki.dlang.org/Editors, Editors)
     $(SUBMENU_LINK https://wiki.dlang.org/IDEs, IDEs)
     $(SUBMENU_LINK $(VISUALD), Visual D)


### PR DESCRIPTION
short follow-up to #1365 as this could be a bit controversial.

- changes the link for "Tools" to the D wiki
- renames them to "Tools" as they are no longer "D-specific"