### PR TITLE
Add icons to 'Why D'

### DIFF
--- a/areas-of-d-usage.dd
+++ b/areas-of-d-usage.dd
@@ -29,7 +29,7 @@ $(DIVC page-contents quickindex,
 )
 
 $(DIVC start-icons,
-    $(START_ICONS_ENTRY Industry, building, industry)
+    $(START_ICONS_ENTRY Industry, industry, industry)
     $(START_ICONS_ENTRY Systems Programming, gears, systems-programming)
     $(START_ICONS_ENTRY Research, flask, cutting-edge)
     $(START_ICONS_ENTRY Academia, graduation-cap, academia)
@@ -45,7 +45,7 @@ $(DIV,
 
 $(DIV style="clear:both")
 
-$(SECTION2 $(LNAME2 industry, Industry), $(SECTION_FA_ICON building)
+$(SECTION2 $(LNAME2 industry, Industry), $(SECTION_FA_ICON industry)
 
 $(DIVC area-section2,
     $(P

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -94,7 +94,7 @@ $(DIVC container,
 )
 $(COMMON_SCRIPTS)
 $(LAYOUT_SUFFIX)
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
 </body>
 </html>
 _=

--- a/index.dd
+++ b/index.dd
@@ -156,7 +156,7 @@ $(DIVC boxes,
 $(DIVC whyd, $(SECTION2 Why D?,
 
 $(DIVC section,
-$(DIV, $(SECTION3 Convenience,
+$(DIV, $(SECTION3 $(WHY_D_ICON magic) Convenience,
 
 $(P D allows writing large code fragments without redundantly specifying types,
 like dynamic languages do. On the other hand, static inference deduces types and other
@@ -239,7 +239,7 @@ void main()
 
 )))
 
-$(DIVC section, $(DIV, $(SECTION3 Power,
+$(DIVC section, $(DIV, $(SECTION3 $(WHY_D_ICON rocket) Power,
 
 $(P The best paradigm is to not impose something at the expense of others.
 D offers classic polymorphism, value semantics, functional
@@ -309,7 +309,7 @@ Read more).)
 
 )))
 
-$(DIVC section, $(DIV, $(SECTION3 Efficiency,
+$(DIVC section, $(DIV, $(SECTION3 $(WHY_D_ICON bolt) Efficiency,
 
 $(P D compiles naturally to efficient native code.)
 
@@ -375,7 +375,7 @@ consistency. $(LINK2 spec/memory-safe-d.html, Read more).)
 
 )))
 
-$(DIVC section, $(DIV, $(SECTION3 Industry-proven,
+$(DIVC section, $(DIV, $(SECTION3 $(WHY_D_ICON industry) Industry-proven,
 $(DIVC frontpage-orgs center,
     $(FRONTPAGE_ORG Facebook, https://www.facebook.com, facebook.svg,
         Online social networking service
@@ -420,12 +420,16 @@ Macros:
     LAYOUT_TITLE=
     TOUR=$(DIVC item, $(SECTION4 $(LINK2 $1, $(TC i, fa fa-$2 big-icon)$3), $4))
     TOUR=$(DIVC item, $(SECTION4 $(TC i, fa fa-$1 big-icon)$2, $3))
+    WHY_D_ICON=$(TC i, fa fa-$1 why-d-icon)
     _=
 	FRONTPAGE_ORG_IMG=$(DIVC frontpage-orgs-img-wrapper vcontainer-box, <img class="vcontainer-element" src="$(ROOT_DIR)images/orgs-using-d/$0" />)
     FRONTPAGE_ORG=$(DIVC frontpage-orgs-cell dont-highlight-link, $(LINK2 $2, $(FRONTPAGE_ORG_IMG $3)) $(H3 $1) $(P $(I $4 )))
     _= Single word inline CSS needs to be escaped _=
     C_A=$1:$2;
     EXTRA_HEADERS=$(T style,
+        .why-d-icon {
+            padding-right: 0.2em;
+        }
         .frontpage-orgs h3 {
            $(C_A margin, 0.4em)
            margin-left: 0;


### PR DESCRIPTION
FontAwesome is amazing, so how about using it at a very important part of our frontpage?

before:

![image](https://cloud.githubusercontent.com/assets/4370550/16063137/0a111720-3298-11e6-8901-d7c6ce95b816.png)

after: 

![image](https://cloud.githubusercontent.com/assets/4370550/16063114/f972c2a6-3297-11e6-8731-2ba8d5007ebf.png)

(screenshots are taken at 50%)