### PR TITLE
use fork icon instead of 'wrench' for contribute

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -138,7 +138,7 @@ $(DIVC boxes,
         )
     )
     $(DIVC row,
-        $(TOUR wrench, Contribute,
+        $(TOUR code-fork, Contribute,
             $(P Report any bugs you find to our $(LINK2 $(ROOT_DIR)bugstats.php,
                 bug tracker). If you can fix an issue, make a pull request on
                 $(LINK2 https://github.com/dlang, GitHub).)


### PR DESCRIPTION
As I just studied FontAwesome a bit closer the 'wrench' icon for "Contribute" seemed a bit unlogical, how about using the fork icon?

before:

![image](https://cloud.githubusercontent.com/assets/4370550/16063353/f04f5198-3298-11e6-873f-b1355bebd474.png)

after:

![image](https://cloud.githubusercontent.com/assets/4370550/16063333/e9b19850-3298-11e6-811d-86e6dfedab67.png)


Alternatives could be:

http://fontawesome.io/icon/github/ (it's a brand)
http://fontawesome.io/icon/bug/ (potentially bad, it shows that we have 'bugs')