### PR TITLE
Fix issue 16152 - Fix merging of eponymous template doc comments.

### DIFF
--- a/dpl-docs/dub.selections.json
+++ b/dpl-docs/dub.selections.json
@@ -1,15 +1,13 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"backtrace-d": "~master",
-		"ddox": "0.15.6",
+		"ddox": "0.15.10",
 		"experimental_allocator": "2.70.0-b1",
 		"hyphenate": "1.1.1",
 		"libasync": "0.7.9",
 		"libdparse": "0.6.0",
 		"libev": "5.0.0+4.04",
 		"libevent": "2.0.1+2.0.16",
-		"libhttp2": "0.2.6",
 		"memutils": "0.4.5",
 		"openssl": "1.1.4+1.0.1g",
 		"vibe-d": "0.7.28"


### PR DESCRIPTION
This change avoids discarding the doc comment of either the parent template or the template member when merging eponymous templates to a single declaration.