### PR TITLE
Fix broken link to rdmd

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -30,19 +30,19 @@ RewriteRule ^changelog(.html)?$ changelog/index.html [R=301,L]
 
 # OS detection for CLI manual
 RewriteCond %{HTTP_USER_AGENT} Windows
-RewriteRule dmd.html dmd-windows.html [R]
+RewriteRule /dmd.html dmd-windows.html [R]
 
 RewriteCond %{HTTP_USER_AGENT} Mac
-RewriteRule dmd.html dmd-osx.html [R]
+RewriteRule /dmd.html dmd-osx.html [R]
 
 RewriteCond %{HTTP_USER_AGENT} Linux
-RewriteRule dmd.html dmd-linux.html [R]
+RewriteRule /dmd.html dmd-linux.html [R]
 
 RewriteCond %{HTTP_USER_AGENT} FreeBSD
-RewriteRule dmd.html dmd-freebsd.html [R]
+RewriteRule /dmd.html dmd-freebsd.html [R]
 
 # soft-fail to windows
-RewriteRule dmd.html dmd-windows.html [L,R]
+RewriteRule /dmd.html dmd-windows.html [L,R]
 
 # legacy URLs of /spec/ pages
 RewriteRule ^(spec|intro|lex|grammar|module|declaration|type|property|\


### PR DESCRIPTION
It seems that we broke the link to http://dlang.org/rdmd.html, should be fixed with this.