### PR TITLE
[don't merge before 2.072] Remove last standing WEB macro

### DIFF
--- a/html.ddoc
+++ b/html.ddoc
@@ -65,7 +65,6 @@ LINK = $(A $0, $0)
 LINK2 = $(A $1, $+)
 HTTP = $(LINK2 http://$1,$2)
 HTTPS = $(LINK2 https://$1,$2)
-WEB = $(HTTP $1,$2)
 _=
 
 _=Colors

--- a/std_consolidated.ddoc
+++ b/std_consolidated.ddoc
@@ -44,7 +44,6 @@ LESS = &lt;
 GREATER = &gt;
 HTTP = $(LINK2 http://$1,$2)
 HTTPS = $(LINK2 https://$1,$2)
-WEB = $(HTTP $1,$2)
 LUCKY = $(HTTP
 google.com/search?btnI=I%27m+Feeling+Lucky&amp;ie=UTF-8&amp;oe=UTF-8&amp;q=$0,$0)
 D = <font face="Courier"><b>$0</b></font>


### PR DESCRIPTION
removes the last bit of the `WEB` macro - shouldn't be pulled before 2.072