### PR TITLE
Push down reference to XOmB

### DIFF
--- a/areas-of-d-usage.dd
+++ b/areas-of-d-usage.dd
@@ -146,8 +146,8 @@ $(AREA_SECTION3 $(LNAME2 operating_systems, Operating systems), $(ARTICLE_FA_ICO
         project have proven so. To name a few:
 
         $(UL
-            $(LI $(HTTPS github.com/xomboverlord/xomb/tree/unborn, XOmB) - Exokernel operating system)
             $(LI $(HTTPS github.com/Vild/PowerNex, PowerNex) - A kernel written in D)
+            $(LI $(HTTPS github.com/xomboverlord/xomb/tree/unborn, XOmB) - Exokernel operating system)
             $(LI $(HTTPS github.com/Rikarin/Trinix, Trinix) - Hybrid operating system for x64 PC)
         )
     )


### PR DESCRIPTION
from @yannick:

> i would remove (or push down) XOmB. its bad if the first link is a very outdated project (yes there is a branch that had some activity this year, but still).
powernex is much more interesting since its under active development.

XOmB still has a lot of Github stars, so I went for pushing it down.