### PR TITLE
fix issue 16186 - [Programming in D for C Programmers] Backticks shou…

### DIFF
--- a/ctod.dd
+++ b/ctod.dd
@@ -949,7 +949,7 @@ $(H4 The D Way)
 
     D has both C-style string literals which can use escaping,
     and WYSIWYG (what you see is what you get) raw strings
-    usable with the $(B `foo`) and $(B r"bar") syntax:
+    usable with the `$(BACKTICK)foo$(BACKTICK)` and `r"bar"` syntax:
 
 ----------------------------
 string file = r"c:\root\file.c";  // c:\root\file.c


### PR DESCRIPTION
…ld be escaped in explanation of raw string syntax

Also changing $(B ...) with backticks for proper code styling.

https://issues.dlang.org/show_bug.cgi?id=16186