### PR TITLE
fix accidental use of BACKTICK macro

### DIFF
--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -502,7 +502,7 @@ $(P
 
 $(P
     A literal backtick character can be output either as a non-paired $(BACKTICK) on a single
-    line or by using the $(BACKTICK) macro.
+    line or by using the `$(DOLLAR)(BACKTICK)` macro.
 )
 
 ---


### PR DESCRIPTION
The text is supposed to literally say "$(BACKTICK) macro" there, not
"` macro".

Also putting it in backticks for code styling.