### PR TITLE
Reworded statement

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -158,7 +158,7 @@ $(DIVC whyd, $(SECTION2 Why D?,
 $(DIVC section,
 $(DIV, $(SECTION3 $(WHY_D_ICON magic) Convenience,
 
-$(P D allows writing large code fragments without redundantly specifying types,
+$(P D allows you to write large code fragments without redundantly specifying types,
 like dynamic languages do. On the other hand, static inference deduces types and other
 code properties, giving the best of both the static and the
 dynamic worlds. $(EXAMPLE 1,


### PR DESCRIPTION
Reworded the initial statement under the 'Convenience' heading of the 'Why D?' section. The language flows better with the combination of a subject pronoun + verb infinitive, than with just a verb in the present participle form. Addressing the reader directly promotes a sense of inclusion in the action suggested.