### PR TITLE
Fix issue 15925 name in changelog

### DIFF
--- a/changelog/2.071.1.dd
+++ b/changelog/2.071.1.dd
@@ -13,7 +13,7 @@ $(LI $(BUGZILLA 15629): [REG2.066.0] wrong code with '-O -inline' but correct wi
 $(LI $(BUGZILLA 15861): [REG 2.069] Wrong double-to-string conversion with -O)
 $(LI $(BUGZILLA 15897): private base class method not seen through derived class)
 $(LI $(BUGZILLA 15898): [REG2.069] Internal error: backend\cgcod.c 1651)
-$(LI $(BUGZILLA 15925): [REG 2.071] Import declaration from mixin templates are ignored)
+$(LI $(BUGZILLA 15925): -transition=[check]imports ignores import declaration from mixin templates)
 $(LI $(BUGZILLA 15961): [REG2.066] ICE with instance field introduced by anonymous struct)
 $(LI $(BUGZILLA 15998): [REG2.067] Segmentation fault on const folding of arrays of static arrays)
 $(LI $(BUGZILLA 16022): [REG2.069] dmd assertion failure due to misplaced comma operator)


### PR DESCRIPTION
The issue was repurposed and the name was confusing to readers:
https://forum.dlang.org/post/nl2bgi$2oim$1@digitalmars.com