### PR TITLE
Restructure community menu - move successful resources to the top

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -223,14 +223,14 @@ $(DIVID cssmenu, $(UL
 ))
 NAVIGATION_COMMUNITY=
 $(SUBMENU_MANUAL
-    $(SUBMENU_LINK $(ROOT_DIR)bugstats.php, Bug Tracker)
-    $(SUBMENU_LINK https://github.com/dlang, GitHub)
+    $(SUBMENU_LINK https://dlang.org/blog, Blog)
+    $(SUBMENU_LINK $(ROOT_DIR)orgs-using-d.html, Orgs using D)
+    $(SUBMENU_LINK https://twitter.com/search?q=%23dlang, Twitter)
     $(SUBMENU_LINK_DIVIDER https://forum.dlang.org, Forums)
     $(SUBMENU_LINK irc://irc.freenode.net/d, IRC)
     $(SUBMENU_LINK https://wiki.dlang.org, Wiki)
-    $(SUBMENU_LINK_DIVIDER https://dlang.org/blog, Blog)
-    $(SUBMENU_LINK https://twitter.com/search?q=%23dlang, Twitter)
-    $(SUBMENU_LINK $(ROOT_DIR)orgs-using-d.html, Orgs using D)
+    $(SUBMENU_LINK_DIVIDER https://github.com/dlang, GitHub)
+    $(SUBMENU_LINK $(ROOT_DIR)bugstats.php, Issues)
 )
 NAVIGATION_DOCUMENTATION=
 $(SUBMENU_MANUAL


### PR DESCRIPTION
- @p0nce suggested to move the more successful resources at the top (e.g. Blog, Orgs using D)
- I fixed the alphabetical order
- I renamed "Bug Tracker" to "Issues", because 
    - bugs has a very negative connotation
    - it's called issues.dlang.org too
    - it should be last on the list (and with "Issues" we achieve this without breaking the alphabetical order)