### PR TITLE
Rebrand Bug Tracker to Issue Tracker

### DIFF
--- a/bugstats.php.dd
+++ b/bugstats.php.dd
@@ -1,6 +1,6 @@
 Ddoc
 
-$(D_S Bug tracker,
+$(D_S Issue tracker,
 
 $(P
     We use $(B Bugzilla) to track the issues for the D programming language.
@@ -9,20 +9,20 @@ $(P
 )
 
 $(P
-    You can browse through the existing bugs for D projects $(LINK2 https://issues.dlang.org/describecomponents.cgi?product=D, $(B here)).
+    You can browse through the existing issues for D projects $(LINK2 https://issues.dlang.org/describecomponents.cgi?product=D, $(B here)).
 )
 
 $(P
-    If you want to search for a specific bug, you can use the $(LINK2 https://issues.dlang.org/query.cgi?format=specific, $(B search page)).
+    If you want to search for a specific issue, you can use the $(LINK2 https://issues.dlang.org/query.cgi?format=specific, $(B search page)).
 )
 
 $(P
-    And if you want to file a new bug, you can use $(LINK2 https://issues.dlang.org/enter_bug.cgi?product=D, $(B this page)).
+    And if you want to file a new issue, you can use $(LINK2 https://issues.dlang.org/enter_bug.cgi?product=D, $(B this page)).
 )
 
-$(H3 Bug Tracker Statistics)
+$(H3 Issue Tracker Statistics)
 
-$(BOOKTABLE $(SECTION3 Current bugs <font size="-1">$(LINK2 https://issues.dlang.org/enter_bug.cgi?product=D,[report new bug])$(LINK2 https://issues.dlang.org/query.cgi,[search])</font>),
+$(BOOKTABLE $(SECTION3 Current issues<font size="-1">$(LINK2 https://issues.dlang.org/enter_bug.cgi?product=D,[report new bug])$(LINK2 https://issues.dlang.org/query.cgi,[search])</font>),
 $(DISPLAY Regression, y_axis_field=bug_severity&amp;query_format=report-table&amp;product=D&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;bug_severity=regression)
 $(DISPLAY Blocker, y_axis_field=bug_severity&amp;query_format=report-table&amp;product=D&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;bug_severity=blocker)
 $(DISPLAY Critical, y_axis_field=bug_severity&amp;query_format=report-table&amp;product=D&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;bug_severity=critical)
@@ -41,7 +41,7 @@ $(P <center>$(LINK2 $(GRAPH_HTML_URL), <img border="1" src="$(GRAPH_IMG_URL)">)<
 )
 
 Macros:
-  TITLE=The D Bug Tracker
+  TITLE=The D Issue Tracker
   PHP=<?php $0 ?>
   BOOKTABLE = <center><table cellspacing="0" cellpadding="5" class="book"><caption>$1</caption>$2</table></center>
   DISPLAY=$(TR $(TD $(LINK2 https://issues.dlang.org/buglist.cgi?$2, $1)) $(TD <iframe scrolling="no" frameborder="0" width="4.8em" height="1.4em" style="width:4.8em;height:1.4em;" vspace="0" hspace="0" marginwidth="0" marginheight="0" src="fetch-issue-cnt.php?$2&amp;format=table&amp;action=wrap&amp;ctype=csv"></iframe>))


### PR DESCRIPTION
As mentioned in #1406, "Bug" has a very negative connotation. Moreover about half of our "bugs" are actually enhancement requests, so I propose the rebranding to "Issues" on such a publicly visible site.

Does anyone know how I can rename the chart?