### PR TITLE
ignore 'scope' for parameters with no indirections

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1053,7 +1053,8 @@ int foo(in int x, out int y, ref int z, int q);
 
     $(TROW $(D ref),   parameter is passed by reference)
     $(TROW $(D scope), references in the parameter
-    cannot be escaped (e.g. assigned to a global variable))
+    cannot be escaped (e.g. assigned to a global variable).
+    Ignored for parameters with no references)
     $(TROW $(D lazy), argument is evaluated by the called function and not by the caller)
         $(TROW $(D const), argument is implicitly converted to a const type)
     $(TROW $(D immutable), argument is implicitly converted to an immutable type)


### PR DESCRIPTION
Because scope has no meaning apart from indirections.

Implementation:
https://github.com/dlang/dmd/pull/5897