### PR TITLE
add link to kostya's benchmarks

### DIFF
--- a/areas-of-d-usage.dd
+++ b/areas-of-d-usage.dd
@@ -67,7 +67,7 @@ $(DIVC area-section2,
         $(LINK2 $(ROOT_DIR)spec/errors.html, error handling) aid in
         shipping a bug-free product.
         If at the end of the day $(LINK2 $(ROOT_DIR)overview.html#performance, performance)
-        matters $(MDASH) D has you covered!
+        matters $(MDASH) D has you $(LINK2 https://github.com/kostya/benchmarks, covered)!
         You can tune your code with tools starting from
         $(LINK2 https://dlang.org/spec/version.html, conditional compilation) over
         $(LINK2 https://dlang.org/spec/simd.html, SIMD vector optimizations) to
@@ -183,7 +183,7 @@ $(AREA_SECTION3 $(LNAME2 numerical, Numerical computing), $(ARTICLE_FA_ICON calc
     Unlike NumPy, D does not become slow for computations not covered by preexisting libraries,
     and does not force its user to escape into another language.
     Additionally, due to its compile-time introspection capabilities, D enables
-    further optimizations for superior performance. See Andrei's talk
+    further optimizations for $(LINK2 https://github.com/kostya/benchmarks, superior performance). See Andrei's talk
     $(HTTPS www.youtube.com/watch?v=AxnotgLql0k, Fastware) on this topic.
 
     D's standard library includes support for $(LINK2 $(ROOT_DIR)phobos/std_experimental_ndslice.html, multidimensional arrays),


### PR DESCRIPTION
Thanks to @ZombineDev's work D's performances is quite for [Kostya's benchmark](https://github.com/kostya/benchmarks) and as people love such benchmarks I thought it's probably a good idea to add it to a popular place.

![image](https://cloud.githubusercontent.com/assets/4370550/16540652/6ccbaa4c-406c-11e6-8cfc-f005e33b7cad.png)