### PR TITLE
Use secure HTTP for the Dlang Tour

### DIFF
--- a/areas-of-d-usage.dd
+++ b/areas-of-d-usage.dd
@@ -239,7 +239,7 @@ $(AREA_SECTION3 $(LNAME2 teaching, Teaching), $(ARTICLE_FA_ICON graduation-cap),
         advantages of $(I static) type checking.
     )
     $(P Last but not least, there are $(LINK2 http://ddili.org/ders/d.en/index.html,
-        books) and $(LINK2 http://tour.dlang.org/, tutorials) freely available online
+        books) and $(LINK2 https://tour.dlang.org/, tutorials) freely available online
         which can be used as resources.
     )
 ))

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -211,7 +211,7 @@ _=
 
 NAVIGATION=
 $(DIVID cssmenu, $(UL
-    $(MENU http://tour.dlang.org, Learn)
+    $(MENU https://tour.dlang.org, Learn)
     $(MENU_W_SUBMENU_LINK $(ROOT_DIR)documentation.html, Documentation)
       $(NAVIGATION_DOCUMENTATION)
     $(MENU $(ROOT_DIR)download.html, Downloads)

--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -41,7 +41,7 @@ html(lang='en-US')
           #cssmenu
             ul
               li
-                a(href="http://tour.dlang.org")
+                a(href="https://tour.dlang.org")
                   span Learn
               li.expand-container
                 a.expand-toggle(href="#{root_dir}documentation.html")

--- a/index.dd
+++ b/index.dd
@@ -94,7 +94,7 @@ $(DIVC boxes,
             )
         )
         $(TOUR graduation-cap, Learn,
-            $(P Take the $(LINK2 http://tour.dlang.org,
+            $(P Take the $(LINK2 https://tour.dlang.org,
                 Tour), explore
                 $(LINK2 $(ROOT_DIR)overview.html, major features) in D,
                 quick start with $(LINK2 $(ROOT_DIR)ctod.html, C) or


### PR DESCRIPTION
:tada: the tour supports now secure HTTP - how about redirecting to it by default?

CC @stonemaster

https://github.com/stonemaster/dlang-tour/issues/45
