### PR TITLE
clarify what happens with overlarge shifts

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -514,8 +514,9 @@ $(GNAME ShiftExpression):
         $(D >)$(D >)$(D >) is an unsigned right shift.
     )
 
-    $(P It's illegal to shift by the same or more bits than the size of the
-        quantity being shifted:
+    $(P If the quantity is shifted by the same or more bits than the size of the
+	quantity, it is implementation defined whether a diagnostic is issued
+	or the resulting value is unspecified.
 
         -------------
         int c;


### PR DESCRIPTION
Saying it is "illegal" implies it must always be diagnosed.
