### PR TITLE
add dmd.html

### DIFF
--- a/dmd.dd
+++ b/dmd.dd
@@ -1,0 +1,12 @@
+Ddoc
+
+$(D_S dmd - DMD Compiler,
+
+$(P Documentation for DMD is split up by operating system. Choose one from
+the menu on the left.)
+
+)
+
+Macros:
+    TITLE=DMD Compiler
+    SUBNAV=$(SUBNAV_CLI_REFERENCE)

--- a/posix.mak
+++ b/posix.mak
@@ -165,7 +165,7 @@ PAGES_ROOT=$(SPEC_ROOT) acknowledgements areas-of-d-usage \
 	articles ascii-table bugstats.php builtin \
 	$(CHANGELOG_FILES) code_coverage community comparison concepts \
 	const-faq cpptod ctarguments ctod \
-	D1toD2 d-array-article d-floating-point deprecate dll-linux \
+	D1toD2 d-array-article d-floating-point deprecate dll-linux dmd \
 	dmd-freebsd dmd-linux dmd-osx dmd-windows documentation download dstyle \
 	exception-safe faq forum-template foundation gpg_keys glossary \
 	gsoc2011 gsoc2012 gsoc2012-template hijack howto-promote htod index \


### PR DESCRIPTION
There's a redirect in place that detects the user's operating system and
goes to dmd-{windows,linux,...}.html. The redirect is fine and on the
online dlang.org it completely hides the dmd.html file that's being added
here. The file is needed, because dlang.org is also distributed as a bunch
of .html files as part of the dmd releases.

Not putting links to dmd-windows.html, etc into the file, because they'd
only be forgotten there.