### PR TITLE
Remove the 'Symbol' rule from the grammar.

### DIFF
--- a/spec/grammar.dd
+++ b/spec/grammar.dd
@@ -762,7 +762,6 @@ $(GNAME GotoStatement):
 $(GRAMMAR
 $(GNAME WithStatement):
     $(D with) $(D $(LPAREN)) $(EXPRESSION) $(D $(RPAREN)) $(PSSCOPE)
-    $(D with) $(D $(LPAREN)) $(GLINK Symbol) $(D $(RPAREN)) $(PSSCOPE)
     $(D with) $(D $(LPAREN)) $(GLINK TemplateInstance) $(D $(RPAREN)) $(PSSCOPE)
 )
 
@@ -1480,17 +1479,6 @@ $(GNAME TemplateArgumentList):
 $(GNAME TemplateArgument):
     $(GLINK Type)
     $(ASSIGNEXPRESSION)
-    $(GLINK Symbol)
-
-$(GNAME Symbol):
-    $(GLINK SymbolTail)
-    $(D .) $(GLINK SymbolTail)
-
-$(GNAME SymbolTail):
-    $(I Identifier)
-    $(I Identifier) $(D .) $(I SymbolTail)
-    $(GLINK TemplateInstance)
-    $(GLINK TemplateInstance) $(D .) $(I SymbolTail)
 
 $(GNAME TemplateSingleArgument):
     $(I Identifier)

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -75,17 +75,6 @@ $(GNAME TemplateArgumentList):
 $(GNAME TemplateArgument):
     $(GLINK2 declaration, Type)
     $(ASSIGNEXPRESSION)
-    $(GLINK Symbol)
-
-$(GNAME Symbol):
-    $(GLINK SymbolTail)
-    $(D .) $(GLINK SymbolTail)
-
-$(GNAME SymbolTail):
-    $(I Identifier)
-    $(I Identifier) $(D .) $(I SymbolTail)
-    $(GLINK TemplateInstance)
-    $(GLINK TemplateInstance) $(D .) $(I SymbolTail)
 
 $(GNAME TemplateSingleArgument):
     $(I Identifier)


### PR DESCRIPTION
http://forum.dlang.org/thread/oaqifnqictfdaupaaptn@forum.dlang.org

The `Symbol` rule only appears as an alternative to the `Type`, `AssignExpression`, or `Expression` rules, but the `Symbol` rule is a subset of these other rules. Because of this, the grammar is ambiguous.

The difference between a type, expression, and symbol is something that can only be determined during semantic analysis, and thus should not be part of the parse grammar. 