### PR TITLE
IdentityExpression for floats

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -324,8 +324,8 @@ $(GNAME IdentityExpression):
         $(D is).
     )
 
-    $(P For struct objects, identity is defined as the bits in the
-        struct being identical.
+    $(P For struct objects and floating point values, identity is defined as the
+        bits in the operands being identical.
     )
 
     $(P For static and dynamic arrays, identity is defined as referring


### PR DESCRIPTION
in IdentityExpressions, float types are compared with memcmp. See: [e2ir.c#L2391](https://github.com/dlang/dmd/blob/398719f1725ab86435e604682fbe8f41b91f708f/src/e2ir.c#L2391)