### PR TITLE
default opEquals does not compare object contents

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -284,9 +284,11 @@ $(GNAME EqualExpression):
     )
 
     $(P For class objects, the $(D ==) and $(D !=)
-        operators compare the
-        contents of the objects. Therefore, comparing against
-        $(D null) is invalid, as $(D null) has no contents.
+        operators are intended to compare the contents of the objects,
+        however an appropriate $(D opEquals) override must be defined for this to work.
+        The default $(D opEquals) provided by the root $(D Object) class is
+        equivalent to the $(D is) operator.
+        Comparing against $(D null) is invalid, as $(D null) has no contents.
         Use the $(D is) and $(D !is) operators instead.
 
         ---


### PR DESCRIPTION
this documents the behaviour more clearly, addressing issue 10549