### PR TITLE
use protocol relative URLs for nightly downloads

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -214,7 +214,7 @@ Macros:
     H3I=<h3 class="download">$0</h3>
     DLSITE=http://downloads.dlang.org/releases/2.x/$(DMDV2)/$0
     B_DLSITE=http://downloads.dlang.org/pre-releases/2.x/$(B_DMDV2)/$0
-    N_DLSITE=http://nightlies.dlang.org/dmd-nightly/$0
+    N_DLSITE=//nightlies.dlang.org/dmd-nightly/$0
     DOWNLOAD =
     $(DIV,
         $(DIVC download_image, $1)


### PR DESCRIPTION
- i.e. use https when dlang.org is loaded via https