### PR TITLE
Fix relative links in deprecate page

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -9,40 +9,40 @@ $(SPEC_S Deprecated Features,
     )
 
     $(TABLE2 Deprecated Features,
-        $(THEAD Feature,                                                          Spec,  Dep,    Error,  Gone)
-        $(TROW $(DEPLINK Using the result of a comma expression),                 future, &nbsp;, &nbsp;, &nbsp;)
-        $(TROW $(DEPLINK delete),                                                 future, &nbsp;, &nbsp;, &nbsp;)
-        $(TROW $(DEPLINK scope for allocating classes on the stack),              future, &nbsp;, &nbsp;, &nbsp;)
-        $(TROW $(DEPLINK Imaginary and complex types),                            future, &nbsp;, &nbsp;, &nbsp;)
-        $(TROW $(DEPLINK Implicit catch statement),                               2.072, 2.072,  future, future )
-        $(TROW $(DEPLINK .sort and .reverse properties for arrays),               ?,     2.072;, &nbsp;, &nbsp;)
-        $(TROW $(DEPLINK C-style array pointers),                                 ?,     2.072;, &nbsp;, &nbsp;)
-        $(TROW $(DEPLINK Floating point NCEG operators),                          ?,     2.066,  2.072,  &nbsp;)
-        $(TROW $(DEPLINK clear),                                                  2.060, 2.066,  &nbsp;, 2.068 )
-        $(TROW $(DEPLINK .min property for floating point types),                 N/A,   2.065,  2.067,  2.072 )
-        $(TROW $(DEPLINK Cast T[] to integral type),                              ?,     2.060,  &nbsp;, 2.061 )
-        $(TROW $(DEPLINK Base Class Protection),                                  2.058, 2.058,  2.067,  2.072 )
-        $(TROW $(DEPLINK Windows 3.x and Windows 9x support),                     2.058, N/A,    N/A,    2.058 )
-        $(TROW $(DEPLINK typedef),                                                2.057, 2.057,  2.067,  2.072 )
-        $(TROW $(DEPLINK Using * to dereference arrays),                          ?,     2.057,  2.067,  (never) )
-        $(TROW $(DEPLINK invariant as an alias for immutable),                    2.057, 2.057,  2.064,  2.066 )
-        $(TROW $(DEPLINK Non-final switch statements without a default case),     2.054, 2.054,  2.068,  (never) )
-        $(TROW $(DEPLINK Hiding base class functions),                            2.054, 2.054,  2.068,  (never) )
-        $(TROW $(DEPLINK Octal literals),                                         2.054, 2.053,  2.067,  (never) )
-        $(TROW $(DEPLINK C-style function pointers),                              ?,     2.050,  2.067,  (never) )
-        $(TROW $(DEPLINK Using length in index expressions),                      ?,     2.041,  &nbsp;, 2.061 )
-        $(TROW $(DEPLINK Escape string literals),                                 ?,     2.026,  2.061,  2.067 )
-        $(TROW $(DEPLINK volatile),                                               2.013, 2.013,  2.067,  2.072)
-        $(TROW $(DEPLINK HTML source files),                                      ?,     2.013,  N/A,    2.061 )
-        $(TROW $(DEPLINK Overriding without override),                            ?,     2.004,  2.072,  (never) )
-        $(TROW $(DEPLINK Lower case 'l' suffix for integer literals),             ?,     1.054,  0.174,  (never) )
-        $(TROW $(DEPLINK Variable shadowing inside functions),                    ?,     0.161,  &nbsp;, 2.061 )
-        $(TROW $(DEPLINK Upper case 'I' suffix for imaginary literals),           ?,     0.154,  2.061,  (never) )
-        $(TROW $(DEPLINK if (v; e)),                                              ?,     0.149,  2.061,  2.068 )
-        $(TROW $(DEPLINK Removing an item from an associative array with delete), ?,     0.127,  2.061,  2.067 )
-        $(TROW $(DEPLINK .offset property),                                       ?,     0.107,  2.061,  2.067 )
-        $(TROW $(DEPLINK .size property),                                         ?,     0.107,  0.107,  2.061 )
-        $(TROW $(DEPLINK .typeinfo property),                                     ?,     0.093,  2.061,  2.067 )
+        $(THEAD Feature,                                                                                    Spec,  Dep,    Error,  Gone)
+        $(TROW $(DEPLINK result-of-a-comma-expression, Using the result of a comma expression),             future, &nbsp;, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK delete, delete),                                                                   future, &nbsp;, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK scope-allocating-classes, scope for allocating classes on the stack),              future, &nbsp;, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK imaginary-complex-types, Imaginary and complex types),                             future, &nbsp;, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK implicit-catch, Implicit catch statement),                                         2.072, 2.072,  future, future )
+        $(TROW $(DEPLINK sort-reverse-properties, .sort and .reverse properties for arrays),                ?,     2.072;, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK c-style-pointers, C-style array pointers),                                         ?,     2.072;, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK fp-nceg-operators, Floating point NCEG operators),                                 ?,     2.066,  2.072,  &nbsp;)
+        $(TROW $(DEPLINK clear, clear),                                                                     2.060, 2.066,  &nbsp;, 2.068 )
+        $(TROW $(DEPLINK fp-min-property, .min property for floating point types),                          N/A,   2.065,  2.067,  2.072 )
+        $(TROW $(DEPLINK cast-integral-type, Cast T[] to integral type),                                    ?,     2.060,  &nbsp;, 2.061 )
+        $(TROW $(DEPLINK base-class-protection, Base Class Protection),                                     2.058, 2.058,  2.067,  2.072 )
+        $(TROW $(DEPLINK windows-3x-9x-support, Windows 3.x and Windows 9x support),                        2.058, N/A,    N/A,    2.058 )
+        $(TROW $(DEPLINK typedef, typedef),                                                                 2.057, 2.057,  2.067,  2.072 )
+        $(TROW $(DEPLINK star-dereferencing-arrays, Using * to dereference arrays),                         ?,     2.057,  2.067,  (never) )
+        $(TROW $(DEPLINK invariant-alias-immutable, invariant as an alias for immutable),                   2.057, 2.057,  2.064,  2.066 )
+        $(TROW $(DEPLINK non-final-without-default, Non-final switch statements without a default case),    2.054, 2.054,  2.068,  (never) )
+        $(TROW $(DEPLINK hiding-base-class, Hiding base class functions),                                   2.054, 2.054,  2.068,  (never) )
+        $(TROW $(DEPLINK octal-literals, Octal literals),                                                   2.054, 2.053,  2.067,  (never) )
+        $(TROW $(DEPLINK c-style-function-pointer, C-style function pointers),                              ?,     2.050,  2.067,  (never) )
+        $(TROW $(DEPLINK length-in-index-exp, Using length in index expressions),                           ?,     2.041,  &nbsp;, 2.061 )
+        $(TROW $(DEPLINK escape-string-literals, Escape string literals),                                   ?,     2.026,  2.061,  2.067 )
+        $(TROW $(DEPLINK volatile, volatile),                                                               2.013, 2.013,  2.067,  2.072)
+        $(TROW $(DEPLINK html-source-files, HTML source files),                                             ?,     2.013,  N/A,    2.061 )
+        $(TROW $(DEPLINK overriding-without-override, Overriding without override),                         ?,     2.004,  2.072,  (never) )
+        $(TROW $(DEPLINK lowercase-l-for-integers, Lower case 'l' suffix for integer literals),             ?,     1.054,  0.174,  (never) )
+        $(TROW $(DEPLINK variable-shadowing-functions, Variable shadowing inside functions),                ?,     0.161,  &nbsp;, 2.061 )
+        $(TROW $(DEPLINK uppercase-suffix-for-imaginary, Upper case 'I' suffix for imaginary literals),     ?,     0.154,  2.061,  (never) )
+        $(TROW $(DEPLINK variable-delcaration-in-if-without-auto, if (v; e)),                               ?,     0.149,  2.061,  2.068 )
+        $(TROW $(DEPLINK delete-assoc-array, Removing an item from an associative array with delete),       ?,     0.127,  2.061,  2.067 )
+        $(TROW $(DEPLINK offset-property, .offset property),                                                ?,     0.107,  2.061,  2.067 )
+        $(TROW $(DEPLINK size-property, .size property),                                                    ?,     0.107,  0.107,  2.061 )
+        $(TROW $(DEPLINK typeinfo-property, .typeinfo property),                                            ?,     0.093,  2.061,  2.067 )
     )
 
     $(DL
@@ -57,7 +57,7 @@ $(SPEC_S Deprecated Features,
     )
 
 
-$(H3 $(DEPNAME Using the result of a comma expression))
+$(H3 $(DEPNAME Using the result of a comma expression, result-of-a-comma-expression))
     $(P The comma operator (`,`) allows executing multiple expressions and
         discards the result of them except for the last which is returned.
 
@@ -113,7 +113,7 @@ $(H4 Rationale)
         ---
     )
 
-$(H3 $(DEPNAME delete))
+$(H3 $(DEPNAME delete, delete))
     $(P Memory allocated on the GC heap can be freed with $(D delete).
         ---
         auto a = new Class();
@@ -139,7 +139,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME scope for allocating classes on the stack))
+$(H3 $(DEPNAME scope for allocating classes on the stack, scope-allocating-classes))
     $(P The $(D scope) keyword can be used to allocate class objects on the stack:
         ---
         class A
@@ -187,7 +187,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Imaginary and complex types))
+$(H3 $(DEPNAME Imaginary and complex types, imaginary-complex-types))
     $(P D currently supports imaginary and complex versions of all floating point types.
         ---
         float a = 2;
@@ -204,7 +204,7 @@ $(H4 Rationale)
     )
 
 
-$(H3 $(DEPNAME Implicit catch statement))
+$(H3 $(DEPNAME Implicit catch statement, implicit-catch))
     $(P One can catch everything by using $(D catch) without specifying a type.)
         ---
         int[] arr = new int[](10);
@@ -231,7 +231,7 @@ $(H4 Rationale)
     )
 
 
-$(H3 $(DEPNAME .sort and .reverse properties for arrays))
+$(H3 $(DEPNAME .sort and .reverse properties for arrays, sort-reverse-properties))
     $(P D arrays can be manipulated using these built-in properties.
         ---
         int[] x = [2, 3, 1];
@@ -247,7 +247,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME C-style array pointers))
+$(H3 $(DEPNAME C-style array pointers, c-style-pointers))
     $(P C-style array pointers can be used in D.
         ---
         alias float *arrayptr[10][15];
@@ -265,7 +265,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Floating point NCEG operators))
+$(H3 $(DEPNAME Floating point NCEG operators, fp-nceg-operators))
     $(P D currently supports the NCEG floating point operators
         (!<>=, <>, <>=, !>, !>=, !<, !<=, !<>) for comparisons involving NaNs.
     )
@@ -278,7 +278,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME clear))
+$(H3 $(DEPNAME clear, clear))
     $(P Call an object's destructor.
         ---
         auto a = new Class();
@@ -300,7 +300,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME .min property for floating point types))
+$(H3 $(DEPNAME .min property for floating point types, fp-min-property))
     $(P Floating point types have the .min property to access the smallest value.
         ---
         enum m = real.min;
@@ -319,7 +319,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Cast T[] to integral type))
+$(H3 $(DEPNAME Cast T[] to integral type, cast-integral-type))
     $(P At some point in time you could do:
         ---
         ulong u = cast(ulong)[1,2];
@@ -336,7 +336,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Base Class Protection))
+$(H3 $(DEPNAME Base Class Protection, base-class-protection))
     $(P Base class protections are things like:
         ---
         class A : $(D protected) B
@@ -356,7 +356,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Windows 3.x and Windows 9x support))
+$(H3 $(DEPNAME Windows 3.x and Windows 9x support, windows-3x-9x-support))
     $(P There is some code in Phobos for Windows 3.x/9x support.
     )
 $(H4 Corrective Action)
@@ -368,7 +368,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME typedef))
+$(H3 $(DEPNAME typedef, typedef))
     $(P typedef can be used to construct a strongly-typed alias of a type.
         ---
         typedef int myint;
@@ -385,7 +385,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Using * to dereference arrays))
+$(H3 $(DEPNAME Using * to dereference arrays, star-dereferencing-arrays))
     $(P D array variables can be dereferenced to get the first element, much like pointers.
         ---
         int[] arr = [1, 2, 3];
@@ -405,7 +405,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME invariant as an alias for immutable))
+$(H3 $(DEPNAME invariant as an alias for immutable, invariant-alias-immutable))
     $(P The invariant storage class and type modifier is an alias for immutable.
         ---
         static assert(is(invariant(int) == immutable(int)));
@@ -422,7 +422,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Non-final switch statements without a default case))
+$(H3 $(DEPNAME Non-final switch statements without a default case, non-final-without-default))
     $(P Switch statements can be declared without a default case, and the
         compiler automatically adds one.
         ---
@@ -459,7 +459,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Hiding base class functions))
+$(H3 $(DEPNAME Hiding base class functions, hiding-base-class))
     $(P Declaration functions in a derived class that can be called with the
         same arguments as a function in a base class, but do not override that
         function causes the base class function to be hidden.
@@ -497,7 +497,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Octal literals))
+$(H3 $(DEPNAME Octal literals, octal-literals))
     $(P Octal literals can be used to enter literals in base 8.
         ---
         // deprecated code
@@ -516,7 +516,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME C-style function pointers))
+$(H3 $(DEPNAME C-style function pointers, c-style-function-pointer))
     $(P C-style function pointers can be used in D.
         ---
         alias void(*fptr)(int, long);
@@ -534,7 +534,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Using length in index expressions))
+$(H3 $(DEPNAME Using length in index expressions, length-in-index-exp))
     $(P When used inside an indexing or slicing expression, length is rewritten to
         be the length of the array being sliced.
         ---
@@ -552,7 +552,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Escape string literals))
+$(H3 $(DEPNAME Escape string literals, escape-string-literals))
     $(P Escape string literals can be used to describe characters using escape sequences.
         ---
         // deprecated code
@@ -571,7 +571,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME volatile))
+$(H3 $(DEPNAME volatile, volatile))
     $(P volatile can be used to mark statement, in order to prevent some
         compiler optimizations.
         ---
@@ -590,7 +590,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME HTML source files))
+$(H3 $(DEPNAME HTML source files, html-source-files))
     $(P The D compiler can parse html files by ignoring everything not contained
         in &lt;code&gt;&lt;/code&gt; tags.
         ---
@@ -610,7 +610,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Overriding without override))
+$(H3 $(DEPNAME Overriding without override, overriding-without-override))
     $(P Virtual functions can currently override a function in a base class
         without the 'override' attribute.
         ---
@@ -645,7 +645,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Lower case 'l' suffix for integer literals))
+$(H3 $(DEPNAME Lower case 'l' suffix for integer literals, lowercase-l-for-integers))
     $(P Lower case 'l' is an alternative suffix to denote 64 bit integer literals.
         ---
         // deprecated code
@@ -669,7 +669,7 @@ $(H4 Note)
 
 
 
-$(H3 $(DEPNAME Variable shadowing inside functions))
+$(H3 $(DEPNAME Variable shadowing inside functions, variable-shadowing-functions))
     $(P Variable shadowing is when a variable in an inner scope has the same
         name as a variable in an enclosing scope.
         ---
@@ -694,7 +694,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Upper case 'I' suffix for imaginary literals))
+$(H3 $(DEPNAME Upper case 'I' suffix for imaginary literals, uppercase-suffix-for-imaginary))
     $(P The 'I' suffix can be used to denote imaginary floating point values.
         ---
         // deprecated code
@@ -713,7 +713,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME if (v; e)))
+$(H3 $(DEPNAME if (v; e, variable-delcaration-in-if-without-auto)))
     $(P This syntax can be used to declare a variable in an if statement condition.
         ---
         if (v; calculateAndReturnPointer()) { ... }
@@ -731,7 +731,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME Removing an item from an associative array with delete))
+$(H3 $(DEPNAME Removing an item from an associative array with delete, delete-assoc-array))
     $(P delete can be used to remove an item from an associative array.
         ---
         int[int] aa = [1 : 2];
@@ -753,7 +753,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME .offset property))
+$(H3 $(DEPNAME .offset property, offset-property))
     $(P The .offset property can be used to get member offset information.
         ---
         struct S { int a, b; }
@@ -773,7 +773,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME .size property))
+$(H3 $(DEPNAME .size property, size-property))
     $(P The .size property can be used to get type size information
         ---
         struct S { int a, b; }
@@ -793,7 +793,7 @@ $(H4 Rationale)
 
 
 
-$(H3 $(DEPNAME .typeinfo property))
+$(H3 $(DEPNAME .typeinfo property, typeinfo-property))
     $(P The .typeinfo property can be used to get the associated TypeInfo class.
         ---
         T.typeinfo
@@ -814,8 +814,8 @@ $(H4 Rationale)
 )
 
 Macros:
-	DEPLINK=$(RELATIVE_LINK2 $0, $0)
+	DEPLINK=$(RELATIVE_LINK2 $1, $2)
 	DEPLINK2=$(LINK2 $1.html#$2, $2)
-	DEPNAME=$(LNAME2 $0, $0)
+	DEPNAME=$(LNAME2 $2, $1)
 	TITLE=Deprecated Features
 	STDFILEREF = <a href="phobos/std_$1.html">$(D std.$1)</a>


### PR DESCRIPTION
I was now annoyed a couple of times by the lack to be able to link directly to a deprecation page (or only with manually replacing spaces with `%20`, so here is a fix for it.

It's a shame DDoc doesn't allow function execution / CTFE :/