### PR TITLE
Change Visual Studio 10 link to MSDN docs

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -613,7 +613,7 @@ dmd -cov -unittest myprog.d
       $(SWITCH $(SWNAME -m64),
         Compile a 64 bit executable.
         The generated object code is in MS-COFF and is meant to be used with the
-        $(LINK2 https://www.amazon.com/gp/product/B0038KTO8S/ref=as_li_qf_sp_asin_il_tl?ie=UTF8$(AMP)camp=1789$(AMP)creative=9325$(AMP)creativeASIN=B0038KTO8S$(AMP)linkCode=as2$(AMP)tag=classicempire, Microsoft Visual Studio 10)
+        $(LINK2 https://msdn.microsoft.com/en-us/library/dd831853(v=vs.100).aspx, Microsoft Visual Studio 10)
         or later compiler.
       )
     )


### PR DESCRIPTION
Changed links that redirected to Amazon with official Microsoft MSDN documentation
https://msdn.microsoft.com/en-us/library/dd831853(v=vs.100).aspx