### PR TITLE
Add tag & stats badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ![D Logo](https://dlang.org/images/dlogo.svg) D Language Website
 ===============================================================
 
+[![GitHub tag](https://img.shields.io/github/tag/dlang/dlang.org.svg?maxAge=86400)](#)
+[![Issue Stats](https://img.shields.io/issuestats/p/github/dlang/dlang.org.svg?maxAge=2592000)](http://www.issuestats.com/github/dlang/dlang.org)
+
 This repository contains the source files for the [D Language
 Website](https://dlang.org), including the language specifications,
 documentation, and some articles.


### PR DESCRIPTION
- The tag badge will automatically show the latest git tag
- The issue stats badge is intended as a positive motivator for contributors.