### PR TITLE
FAQ: D frontend is not C++ anymore

### DIFF
--- a/faq.dd
+++ b/faq.dd
@@ -78,7 +78,6 @@ $(H2 General D FAQ)
 	$(ITEMR omf, Can I link in C object files created with another compiler?)
 	$(ITEMR regexp_literals, Why not support regular expression literals
 		with the /foo/g syntax?)
-	$(ITEMR dogfood, Why is the D front end written in C++ rather than D?)
 	$(ITEMR cpp_to_D, Why aren't all Digital Mars programs translated to D?)
 	$(ITEMR foreach, When should I use a foreach loop rather than a for?)
 	$(ITEMR cpp_interface, Why doesn't D have an interface to C++ as well as C?)
@@ -538,20 +537,6 @@ $(ITEM regexp_literals, Why not support regular expression literals
 	would add 3 more. This would proliferate through much of the compiler,
 	debugger info, and library, and is not worth it.)
 
-	)
-
-$(ITEM dogfood, Why is the D front end written in C++ rather than D?)
-
-	$(P The front end is in C++ in order to interface to the existing gcc
-	and dmd back ends.
-	It's also meant to be easily interfaced to other existing back ends,
-	which are likely written in C++.
-	The D implementation of
-	$(LINK2 http://www.digitalmars.com/dscript/index.html, DMDScript),
-	which performs better than the
-	$(LINK2 http://www.digitalmars.com/dscript/cppscript.html, C++ version),
-	shows that there is no problem
-	writing a professional quality compiler in 100% D.
 	)
 
 $(ITEM cpp_to_D, Why aren't all Digital Mars programs translated to D?)


### PR DESCRIPTION
>Why is the D front end written in C++ rather than D?

This shouldn't be frequently asked any more, since it's no longer true.

Also why is this entry named "dogfood" ?