### PR TITLE
remove class {de,}allocators from the D spec

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -66,8 +66,6 @@ $(UL
             $(LI $(GLINK SharedStaticDestructor)s)
             $(LI $(RELATIVE_LINK2 invariants, Class Invariants))
             $(LI $(DDSUBLINK spec/unittest, unittest, Unit Tests))
-            $(LI $(RELATIVE_LINK2 allocators, Class Allocators))
-            $(LI $(RELATIVE_LINK2 deallocators, Class Deallocators))
             $(LI $(RELATIVE_LINK2 alias-this, Alias This))
         )
         )
@@ -848,130 +846,6 @@ $(GNAME Invariant):
     Class invariants are used to specify characteristics of a class that always
     must be true (except while executing a member function).
     They are described in $(GLINK2 contracts, Invariants).
-
-$(H3 $(LNAME2 allocators, Class Allocators))
-$(B Note): Class allocators are deprecated in D2.
-$(GRAMMAR
-$(GNAME Allocator):
-    $(D new) $(GLINK2 function, Parameters) $(D ;)
-    $(D new) $(GLINK2 function, Parameters) $(GLINK2 function, FunctionBody)
-)
-
-        A class member function of the form:
-
-------
-new(uint size)
-{
-    ...
-}
-------
-
-        is called a class allocator.
-        The class allocator can have any number of parameters, provided
-        the first one is of type uint.
-        Any number can be defined for a class, the correct one is
-        determined by the usual function overloading rules.
-        When a new expression:
-
-------
-new Foo;
-------
-
-        is executed, and Foo is a class that has
-        an allocator, the allocator is called with the first argument
-        set to the size in bytes of the memory to be allocated for the
-        instance.
-        The allocator must allocate the memory and return it as a
-        $(D void*).
-        If the allocator fails, it must not return a $(D null), but
-        must throw an exception.
-        If there is more than one parameter to the allocator, the
-        additional arguments are specified within parentheses after
-        the $(D new) in the $(I NewExpression):
-
-------
-class Foo
-{
-    this(char[] a) { ... }
-
-    new(uint size, int x, int y)
-    {
-        ...
-    }
-}
-
-...
-
-new(1,2) Foo(a);        // calls new(Foo.sizeof,1,2)
-------
-
-        $(P Derived classes inherit any allocator from their base class,
-        if one is not specified.
-        )
-
-        $(P The class allocator is not called if the instance is created
-        on the stack.
-        )
-
-        $(P See also
-        $(DDSUBLINK memory, newdelete, Explicit Class Instance Allocation).
-        )
-
-$(H3 $(LNAME2 deallocators, Class Deallocators))
-$(B Note): Class deallocators and the delete operator are deprecated in D2.
-Use the $(D destroy) function to finalize an object by calling its destructor.
-The memory of the object is $(B not) immediately deallocated, instead the GC
-will collect the memory of the object at an undetermined point after finalization:
-
-------
-class Foo { int x; this() { x = 1; } }
-Foo foo = new Foo;
-destroy(foo);
-assert(foo.x == int.init);  // object is still accessible
-------
-
-$(GRAMMAR
-$(GNAME Deallocator):
-    $(D delete) $(GLINK2 function, Parameters) $(D ;)
-    $(D delete) $(GLINK2 function, Parameters) $(GLINK2 function, FunctionBody)
-)
-
-        A class member function of the form:
-
-------
-delete(void *p)
-{
-    ...
-}
-------
-
-        is called a class deallocator.
-        The deallocator must have exactly one parameter of type $(D void*).
-        Only one can be specified for a class.
-        When a delete expression:
-
-------
-delete f;
-------
-
-        $(P is executed, and f is a reference to a class instance that has
-        a deallocator, the deallocator is called with a pointer to the
-        class instance after the destructor (if any) for the class is
-        called. It is the responsibility of the deallocator to free
-        the memory.
-        )
-
-        $(P Derived classes inherit any deallocator from their base class,
-        if one is not specified.
-        )
-
-        $(P The class allocator is not called if the instance is created
-        on the stack.
-        )
-
-        $(P See also
-        $(DDSUBLINK memory, newdelete, Explicit Class Instance Allocation).
-        )
 
 $(H3 $(LEGACY_LNAME2 AliasThis, alias-this, Alias This))
 


### PR DESCRIPTION
> Class allocators are deprecated in D2.
> Class deallocators are deprecated in D2.

I couldn't find it on the [deprecation page](https://dlang.org/deprecate.html), so I assume it's a pretty old deprecation that went undocumented.

I don't know whether there was a ny rationale in keeping it in the spec. I guess initially to ease the migration?
If that's the case we could still move them to the deprecation page, but imho the spec should be up-to-date and not mention stuff from D1.