### PR TITLE
Make opAssign return ref

### DIFF
--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -532,10 +532,10 @@ $(H2 $(LEGACY_LNAME2 Assignment, assignment, Assignment Operator Overloading))
     struct S
     {
         // identiy assignment, allowed.
-        void $(CODE_HIGHLIGHT opAssign)(S rhs);
+        ref S $(CODE_HIGHLIGHT opAssign)(S rhs);
 
         // not identity assignment, also allowed.
-        void $(CODE_HIGHLIGHT opAssign)(int);
+        ref S $(CODE_HIGHLIGHT opAssign)(int);
     }
     S s;
     s = S();      // Rewritten to s.opAssign(S());


### PR DESCRIPTION
Assignment should return the assigned object and not be void. The example is misleading.