### PR TITLE
remove wrong `P` around `LI`s

### DIFF
--- a/changelog/2.062.dd
+++ b/changelog/2.062.dd
@@ -73,7 +73,6 @@ $(BR)$(BIG List of all bug fixes and enhancements:)
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 9174): regression$(LPAREN)2.057$(RPAREN) ice$(LPAREN)cast.c$(RPAREN) with ternary operator and alias this)
 $(LI $(BUGZILLA 9244): union containing pointers not allowed)
 $(LI $(BUGZILLA 9258): opAssign with base class triggers "identity assignment operator overload" error)
@@ -101,13 +100,11 @@ $(LI $(BUGZILLA 9436): enum cannot be forward referenced with cyclic imports and
 $(LI $(BUGZILLA 9496): [REG 2.061 -> 2.062 alpha] "this[1 .. $]" passes wrong "this" to "opDollar")
 $(LI $(BUGZILLA 9514): "template instance … is not an alias")
 $(LI $(BUGZILLA 9525): [CTFE] Cannot convert $(AMP)S to const$(LPAREN)S*$(RPAREN) at compile time)
-)
 
 )
 
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 1369): Unable to find 'this' in __traits$(LPAREN)getMember$(RPAREN))
 $(LI $(BUGZILLA 1730): Bogus error message calling a non-const struct method on a const struct reference)
 $(LI $(BUGZILLA 1841): Closure detection doesn't work when variable is used in a nested function)
@@ -207,13 +204,11 @@ $(LI $(BUGZILLA 9461): Ability to break typesystem with `inout`)
 $(LI $(BUGZILLA 9479): _error_ in error message of type inference of a delegate literal)
 $(LI $(BUGZILLA 9484): Syntax error in JSON output)
 $(LI $(BUGZILLA 9510): core.bitop.bsr undefined)
-)
 
 )
 
 $(BUGSTITLE DMD Compiler enhancements,
 
-$(P
 $(LI $(BUGZILLA 2630): ddoc should be able to document unittests)
 $(LI $(BUGZILLA 3404): JSON output should retain original alias names)
 $(LI $(BUGZILLA 4194): Attributes included in JSON output)
@@ -224,24 +219,20 @@ $(LI $(BUGZILLA 8105): Implement "in ref")
 $(LI $(BUGZILLA 8128): unittest blocks should be allowed in interfaces)
 $(LI $(BUGZILLA 9389): ignore -Hd if -Hf is present)
 $(LI $(BUGZILLA 9463): make @safe "non-escapable")
-)
 
 )
 
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 9355): [security] SSL certificate signature verification disabled in std.net.curl)
 $(LI $(BUGZILLA 9444): Regression $(LPAREN)2.059$(RPAREN): shell doesn't throw on error.)
 $(LI $(BUGZILLA 9457): isSorted$(LPAREN)string$(RPAREN) doesn't work)
 $(LI $(BUGZILLA 9523): std.conv.to will no longer convert enums to themselves)
-)
 
 )
 
 $(BUGSTITLE Phobos bugs,
 
-$(P
 $(LI $(BUGZILLA 5065): writefln$(LPAREN)"%f"  of a Tuple prints a result)
 $(LI $(BUGZILLA 5265): std.array.back does not work correctly for wchar-based arrays)
 $(LI $(BUGZILLA 5726): boyerMooreFinder hangs when finding)
@@ -272,13 +263,11 @@ $(LI $(BUGZILLA 9288): Parameter$(LPAREN)Identifier|DefaultValue$(RPAREN)Tuple r
 $(LI $(BUGZILLA 9299): std.algorithm.minPos of const$(LPAREN)int$(RPAREN)[])
 $(LI $(BUGZILLA 9317): ParameterStorageClassTuple reports errors for inout function)
 $(LI $(BUGZILLA 9336): Writeln is unable to print address of shared variable)
-)
 
 )
 
 $(BUGSTITLE Phobos enhancements,
 
-$(P
 $(LI $(BUGZILLA 4287): opOpAssign!$(LPAREN)"~="$(RPAREN) for std.array.Appender)
 $(LI $(BUGZILLA 4813): trait for getting at access modifiers)
 $(LI $(BUGZILLA 5666): std.array.replace compile error $(LPAREN)string and immutable string$(RPAREN))
@@ -287,33 +276,27 @@ $(LI $(BUGZILLA 7896): Sequence slicing)
 $(LI $(BUGZILLA 8143): Safe std.conv.to enum conversion)
 $(LI $(BUGZILLA 9337): There's no Duration.max)
 $(LI $(BUGZILLA 9339): std.random.uniform!Enum should return random enum member)
-)
 
 )
 
 $(BUGSTITLE Druntime bugs,
 
-$(P
 $(LI $(BUGZILLA 4793): Runtime.loadLibrary cannot load dll using MBS paths.)
 $(LI $(BUGZILLA 5375): Detection of cyclic module imports provides error findings on console, instead of exception msg)
 $(LI $(BUGZILLA 8132): LPTSTR always aliases to LPSTR)
 $(LI $(BUGZILLA 9373): Add deprecation message to all empty deprecation statements)
-)
 
 )
 
 $(BUGSTITLE Website regressions,
 
-$(P
 $(LI $(BUGZILLA 9467): Operator Overloading anchors are broken)
 $(LI $(BUGZILLA 9492): [2.052 beta] Stylesheet not found for off-line HTML docs)
-)
 
 )
 
 $(BUGSTITLE Website bugs,
 
-$(P
 $(LI $(BUGZILLA 5513): Erroneous example in std.algorithm)
 $(LI $(BUGZILLA 7304): Online docs incorrect with regards to covariant arrays)
 $(LI $(BUGZILLA 7345): interfaceToC.html missing on left-hand side)
@@ -324,15 +307,12 @@ $(LI $(BUGZILLA 9321): Dead link to HTML5 standard in language specification)
 $(LI $(BUGZILLA 9394): ABI for static arrays is outdated)
 $(LI $(BUGZILLA 9446): ".keys" missing from properties table at https://dlang.org/hash-map.html)
 $(LI $(BUGZILLA 9503): [grammar] template declaration/instance must take one or more arguments?)
-)
 
 )
 
 $(BUGSTITLE Website enhancements,
 
-$(P
 $(LI $(BUGZILLA 9302): Document extern properly)
-)
 )
 
 )

--- a/changelog/2.063.dd
+++ b/changelog/2.063.dd
@@ -1274,7 +1274,6 @@ $(BR)$(BIG $(LNAME2 list2063, List of all bug fixes and enhancements in D 2.063:
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 9130): Wrong codegen for compile time constructed struct)
 $(LI $(BUGZILLA 9258): opAssign with base class triggers "identity assignment operator overload" error)
 $(LI $(BUGZILLA 9526): ICE when compiling project with unittests)
@@ -1338,10 +1337,8 @@ $(LI $(BUGZILLA 10160): No line number "cannot modify struct ... with immutable 
 $(LI $(BUGZILLA 10166): XXX is not a template)
 $(LI $(BUGZILLA 10178): Compiler segfault with zero-length tuple comparison)
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 1520): TypeInfo_Const.opEquals is incorrect)
 $(LI $(BUGZILLA 1804): Severe GC leaks with repetitive array allocations)
 $(LI $(BUGZILLA 2356): array literal as non static initializer generates horribly inefficient code.)
@@ -1505,10 +1502,8 @@ $(LI $(BUGZILLA 10115): More @disabled holes)
 $(LI $(BUGZILLA 10171): Unexpected error "cannot infer type from overloaded function symbol")
 $(LI $(BUGZILLA 10180): offsetof doesn't work through function call alias this)
 )
-)
 $(BUGSTITLE DMD Compiler enhancements,
 
-$(P
 $(LI $(BUGZILLA 3449): const and invariant struct members do not behave according to spec)
 $(LI $(BUGZILLA 3502): Fix for dropped Mac OS X 10.5)
 $(LI $(BUGZILLA 3673): inheritance + if clause = no go)
@@ -1551,18 +1546,14 @@ $(LI $(BUGZILLA 10109): add -transition compiler switch to aid in dealing with b
 $(LI $(BUGZILLA 10150): Prefix method 'this' qualifiers should be just ignored anytime)
 $(LI $(BUGZILLA 10179): Tuple assignment should not cause "has no effect" error even if the length is zero)
 )
-)
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 9122): std.concurrency send$(LPAREN)$(RPAREN) fails with multiple arrays)
 $(LI $(BUGZILLA 9742): std.math.floor returns 0 for any value x > -1 and x $(LESS) 0)
 $(LI $(BUGZILLA 10122): `Appender` doesn't work with disabled default construction)
 )
-)
 $(BUGSTITLE Phobos bugs,
 
-$(P
 $(LI $(BUGZILLA 3795): Problem with phobos std.variant)
 $(LI $(BUGZILLA 4729): std.algorithm: strange iota behaviour)
 $(LI $(BUGZILLA 4798): std.algorithm.map unusable for ranges with const elements)
@@ -1599,10 +1590,8 @@ $(LI $(BUGZILLA 10116): stdio.File.byLine repeats last line forever, readln$(LPA
 $(LI $(BUGZILLA 10167): Wrong Document Comment on std.format.d$(LPAREN)181$(RPAREN))
 $(LI $(BUGZILLA 10182): std.bitmanip unit test has pointless/unused foreach loop)
 )
-)
 $(BUGSTITLE Phobos enhancements,
 
-$(P
 $(LI $(BUGZILLA 4787): std.algorithm.bisectRight$(LPAREN)$(RPAREN))
 $(LI $(BUGZILLA 4921): Synopsis code in std.variant documentation throws an assertion error)
 $(LI $(BUGZILLA 5013): std.typecons.Tuple should have constructor for static arrays)
@@ -1621,36 +1610,27 @@ $(LI $(BUGZILLA 9814): Add std.traits.isNestedFunction)
 $(LI $(BUGZILLA 9839): std.traits.Select should be able to select symbols)
 $(LI $(BUGZILLA 9888): Allow passing a generator to std.random.uniform for enums)
 )
-)
 $(BUGSTITLE Druntime bugs,
 
-$(P
 $(LI $(BUGZILLA 4307): spawn$(LPAREN)$(RPAREN)'ed thread doesn't terminate)
 $(LI $(BUGZILLA 6024): Document that Windows 2000 SP4 is no longer supported)
 $(LI $(BUGZILLA 10057): [2.063 beta] Module info overwritten in shared phobos.)
 $(LI $(BUGZILLA 10081): Incorrect char array comparison)
 )
-)
 $(BUGSTITLE Optlink bugs,
 
-$(P
 $(LI $(BUGZILLA 6144): Unexpected OPTLINK Termination at EIP=00428DA3)
-)
 )
 $(BUGSTITLE Installer bugs,
 
-$(P
 $(LI $(BUGZILLA 9343): Problem installing dmd-2.061-0.fedora.x86_64.rpm on Fedora 18)
-)
 )
 $(BUGSTITLE Website bugs,
 
-$(P
 $(LI $(BUGZILLA 4847): std.algorithm.topN documentation)
 $(LI $(BUGZILLA 9544): D logo image is broken on non-root-level pages)
 $(LI $(BUGZILLA 9609): Ddoc tags for std.string.icmp seem wrong)
 $(LI $(BUGZILLA 10036): missing core.atomic docs on dlang.org)
-)
 ))
 $(CHANGELOG_NAV 2.062,2.064)
 

--- a/changelog/2.064.dd
+++ b/changelog/2.064.dd
@@ -888,7 +888,6 @@ $(BR)$(BIG $(LNAME2 list2064, List of all bug fixes and enhancements in D 2.064:
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 6014): rt_finalize Segmentation fault , dmd 2.053 on linux $(AMP) freebsd)
 $(LI $(BUGZILLA 10074): segfault in dmd)
 $(LI $(BUGZILLA 10197): [REG2.063] Cannot cast overloaded template property result)
@@ -987,11 +986,9 @@ $(LI $(BUGZILLA 11265): Segfault while calling instance method of class defined 
 $(LI $(BUGZILLA 11267): Resulting executable sizes varies a lot)
 $(LI $(BUGZILLA 11271): [REG 2.063] auto ref opAssign + destructor + struct literal fails)
 )
-)
 
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 952): Strange "Error:" prefix on some warning messages)
 $(LI $(BUGZILLA 1982): [CTFE] Problems with compile-time null)
 $(LI $(BUGZILLA 2407): function pointer as an enum's base type doesn't work)
@@ -1231,11 +1228,9 @@ $(LI $(BUGZILLA 11164): wrong dependencies generated when compiling with -main)
 $(LI $(BUGZILLA 11182): dmd crashes on compiling regex)
 $(LI $(BUGZILLA 11187): A small transitive const bug on struct copying)
 )
-)
 
 $(BUGSTITLE DMD Compiler enhancements,
 
-$(P
 $(LI $(BUGZILLA 658): struct pointers in with$(LPAREN)$(RPAREN))
 $(LI $(BUGZILLA 767): compiler shall print dependencies and pragma$(LPAREN)lib$(RPAREN))
 $(LI $(BUGZILLA 5943): Power expression optimisation for 2^^unsigned)
@@ -1254,11 +1249,9 @@ $(LI $(BUGZILLA 10991): Implement trait to get vptr index of a method.)
 $(LI $(BUGZILLA 11088): Diagnostics for enum member overflows should improve)
 $(LI $(BUGZILLA 11257): Allow whole implicit conversion if one or more overlapped field could.)
 )
-)
 
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 10218): std.typecons.opAssign is not CTFEable)
 $(LI $(BUGZILLA 10268): [REG2.063] std.typecons.Nullable!JSONValue - error instantiating)
 $(LI $(BUGZILLA 10355): fullyQualifiedName doesn't work with enums)
@@ -1274,11 +1267,9 @@ $(LI $(BUGZILLA 11057): [REG2.064dev] New std.uni has icmp$(LPAREN)$(RPAREN) par
 $(LI $(BUGZILLA 11165): std.typecons._d_toObject conflicts with std.signals._d_toObject)
 $(LI $(BUGZILLA 11283): [REG 2.064] assert in std/windows/syserror.d)
 )
-)
 
 $(BUGSTITLE Phobos bugs,
 
-$(P
 $(LI $(BUGZILLA 2717): alloca$(LPAREN)0$(RPAREN) leaves stack unaligned on OSX)
 $(LI $(BUGZILLA 4575): Uses of deprecated delete statement in D2 Phobos)
 $(LI $(BUGZILLA 5224): std.algorithm.remove!$(LPAREN)SwapStrategy.unstable$(RPAREN) doesn't work)
@@ -1357,11 +1348,9 @@ $(LI $(BUGZILLA 11194): std.container.Array.reserve calls opAssign on uninitiali
 $(LI $(BUGZILLA 11222): std.string.isNumeric accepts a "+")
 $(LI $(BUGZILLA 11232): Windows sysErrorString only supports ASCII)
 )
-)
 
 $(BUGSTITLE Phobos enhancements,
 
-$(P
 $(LI $(BUGZILLA 4120): bigint implicit cast too bool)
 $(LI $(BUGZILLA 4124): toString$(LPAREN)$(RPAREN) for BitArray)
 $(LI $(BUGZILLA 4850): std.conv.to isn't pure)
@@ -1380,18 +1369,14 @@ $(LI $(BUGZILLA 10909): std.conv.to!$(LPAREN)bool$(RPAREN)$(LPAREN)int$(RPAREN):
 $(LI $(BUGZILLA 11020): Add function for getting the current executable path)
 $(LI $(BUGZILLA 11123): std.getopt should support functions)
 )
-)
 
 $(BUGSTITLE Druntime regressions,
 
-$(P
 $(LI $(BUGZILLA 10976): thread_joinAll after main exit performed too late)
-)
 )
 
 $(BUGSTITLE Druntime bugs,
 
-$(P
 $(LI $(BUGZILLA 6210): Associative array with array key often cannot be equated.)
 $(LI $(BUGZILLA 6372): data loss due to possible bug in garbage collector)
 $(LI $(BUGZILLA 7741): getHash inconsistent for const$(LPAREN)char$(RPAREN)[] vs. char[] and string)
@@ -1409,25 +1394,19 @@ $(LI $(BUGZILLA 10711): shared phobos library should not depend on _Dmain)
 $(LI $(BUGZILLA 10720): ICE with is$(LPAREN)aaOfNonCopyableStruct.nonExistingField$(RPAREN))
 $(LI $(BUGZILLA 10894): Numerous DDoc parameter warnings in druntime $(LPAREN)as found by 10236$(RPAREN))
 )
-)
 
 $(BUGSTITLE Druntime enhancements,
 
-$(P
 $(LI $(BUGZILLA 9190): Vector operations are not optimized for x86_64 architecture)
-)
 )
 
 $(BUGSTITLE Installer bugs,
 
-$(P
 $(LI $(BUGZILLA 10062): installers should use CDN)
-)
 )
 
 $(BUGSTITLE Website bugs,
 
-$(P
 $(LI $(BUGZILLA 9533): CHM generation crashes)
 $(LI $(BUGZILLA 10031): Link to old wiki on dlang.org)
 $(LI $(BUGZILLA 10230): Duplicated buttons for runnable examples)
@@ -1438,7 +1417,6 @@ $(LI $(BUGZILLA 10605): Lambda grammar is not sufficient)
 $(LI $(BUGZILLA 10885): [std.range] refRange is missing from module description tables)
 $(LI $(BUGZILLA 11001): Need documentation for __traits$(LPAREN)getVirtualIndex$(RPAREN))
 $(LI $(BUGZILLA 11036): Document that .stringof should not be used for code generation)
-)
 )
 
 )

--- a/changelog/2.065.0.dd
+++ b/changelog/2.065.0.dd
@@ -519,7 +519,6 @@ $(BR)$(BIG $(LNAME2 list2065, List of all bug fixes and enhancements in D 2.065:
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 7782): [ICE] With wrong import syntax)
 $(LI $(BUGZILLA 9107): Value Range Analysis with uint and byte)
 $(LI $(BUGZILLA 9639): Recursive template instanciation segfault dmd)
@@ -595,10 +594,8 @@ $(LI $(BUGZILLA 12144): [REG DMD2.064] Unresolved xopEquals when referenced by d
 $(LI $(BUGZILLA 12158): ICE with .init of nonexisting selective import)
 $(LI $(BUGZILLA 12160): UDA related regressions)
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 235): goto $(AMP) scope: cannot goto forward into different try block level)
 $(LI $(BUGZILLA 275): Undefined identifier in instances of templates with forward mixins)
 $(LI $(BUGZILLA 602): Compiler allows a goto statement to skip an initalization)
@@ -785,10 +782,8 @@ $(LI $(BUGZILLA 12040): Compiler segfault with circular reference in variable ty
 $(LI $(BUGZILLA 12051): Wrong code with ?: resulting in char on x86-64)
 $(LI $(BUGZILLA 12095): Wrong code with -O -inline)
 )
-)
 $(BUGSTITLE DMD Compiler enhancements,
 
-$(P
 $(LI $(BUGZILLA 3597): Need single source for parser and documentation grammar.)
 $(LI $(BUGZILLA 5109): some advise)
 $(LI $(BUGZILLA 5746): Make std.range.iota strongly pure)
@@ -805,10 +800,8 @@ $(LI $(BUGZILLA 11711): Add __traits$(LPAREN)getAliasThis$(RPAREN))
 $(LI $(BUGZILLA 11759): Poor error message trying to use lowercase L in literal suffix.)
 $(LI $(BUGZILLA 11840): Show all errors of undefined identifier used in a line)
 )
-)
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 1832): reading/writing an archive causes data loss; std.zip horribly broken)
 $(LI $(BUGZILLA 11309): std.concurrency: OwnerTerminated message doesn't work)
 $(LI $(BUGZILLA 11512): Can't build Phobos docs with win32 makefile)
@@ -832,10 +825,8 @@ $(LI $(BUGZILLA 12098): libcurl bad argument on handle null)
 $(LI $(BUGZILLA 12135): [AA] Format tail after associative array value is treated as separator if explicit separator is empty)
 $(LI $(BUGZILLA 12168): [REG2.065a] Add ref to array$(LPAREN)$(RPAREN) and object$(LPAREN)$(RPAREN) of JSONValue getters to add new element)
 )
-)
 $(BUGSTITLE Phobos bugs,
 
-$(P
 $(LI $(BUGZILLA 1804): Severe GC leaks with repetitive array allocations)
 $(LI $(BUGZILLA 2162): Access violation when threads run closures)
 $(LI $(BUGZILLA 4301): BigInt * const$(LPAREN)BigInt$(RPAREN) doesn't work well)
@@ -884,10 +875,8 @@ $(LI $(BUGZILLA 11879): missing default User-Agent in std.net.curl)
 $(LI $(BUGZILLA 11884): std.container.Array lacks a constructor from an input range)
 $(LI $(BUGZILLA 12069): ctRegex is 3x slower then R-T ?)
 )
-)
 $(BUGSTITLE Phobos enhancements,
 
-$(P
 $(LI $(BUGZILLA 3868): It would be nice to have a function which read a file lazily using a range)
 $(LI $(BUGZILLA 4859): Another File.byChunk$(LPAREN)$(RPAREN))
 $(LI $(BUGZILLA 4909): Two suggestions for std.algorithm.schwartzSort$(LPAREN)$(RPAREN))
@@ -899,16 +888,12 @@ $(LI $(BUGZILLA 11770): std.regex.Captures should be convertible to bool)
 $(LI $(BUGZILLA 11789): No setAttributes to complement getAttributes)
 $(LI $(BUGZILLA 11798): std.algorithm.all with no predicate too)
 )
-)
 $(BUGSTITLE Druntime regressions,
 
-$(P
 $(LI $(BUGZILLA 11478): shared library on osx: worked in 2.062, fails in 2.063.2, still fails in 2.064)
-)
 )
 $(BUGSTITLE Druntime bugs,
 
-$(P
 $(LI $(BUGZILLA 3454): Inconsistent flag setting in GC.realloc$(LPAREN)$(RPAREN))
 $(LI $(BUGZILLA 4809): Stack trace when throwing exception misses location of the throw statement)
 $(LI $(BUGZILLA 7508): float4 values aren't stored on initialisation)
@@ -916,44 +901,32 @@ $(LI $(BUGZILLA 8301): Access violation when a big array is allocated)
 $(LI $(BUGZILLA 10701): [GC] segfault in GC)
 $(LI $(BUGZILLA 11806): Freeze in GC.collect$(LPAREN)$(RPAREN) in in-contracts when multithreading is used)
 )
-)
 $(BUGSTITLE Optlink regressions,
 
-$(P
 $(LI $(BUGZILLA 11559): Optlink crash with more than 2048 modules generated and debug info)
-)
 )
 $(BUGSTITLE Optlink bugs,
 
-$(P
 $(LI $(BUGZILLA 2837): OPTLINK and LARGEADDRESSAWARE)
 $(LI $(BUGZILLA 3956): linker removes underscore from all exported symbols of a module but the first)
 $(LI $(BUGZILLA 6673): Map file contains broken lines on every 16,384 bytes)
 $(LI $(BUGZILLA 7634): optlink creates bad debug info for a large number of modules)
 )
-)
 $(BUGSTITLE Installer bugs,
 
-$(P
 $(LI $(BUGZILLA 10246): Windows installer still downloads from ftp.digitalmars.com)
 $(LI $(BUGZILLA 11799): Incompatible argument types in create_dmd_release)
 )
-)
 $(BUGSTITLE Installer enhancements,
 
-$(P
 $(LI $(BUGZILLA 10153): Beta releases should all have unique names)
-)
 )
 $(BUGSTITLE Website regressions,
 
-$(P
 $(LI $(BUGZILLA 11449): Jump lists of phobos are in wrong order)
-)
 )
 $(BUGSTITLE Website bugs,
 
-$(P
 $(LI $(BUGZILLA 5388): SList.insertFront has complexity O$(LPAREN)log$(LPAREN)n$(RPAREN)$(RPAREN))
 $(LI $(BUGZILLA 9734): setIntersection accepts only 2 ranges, but documentation says otherwise)
 $(LI $(BUGZILLA 10205): 'deprecated' '$(LPAREN)' assignExpression '$(RPAREN)' grammar is not documented)
@@ -964,13 +937,10 @@ $(LI $(BUGZILLA 11398): Language spec does not allow new eponymous template synt
 $(LI $(BUGZILLA 11579): dlang.org repo can't be built without git)
 $(LI $(BUGZILLA 11762): std.regex macro is not displayed/expanded properly)
 )
-)
 $(BUGSTITLE Website enhancements,
 
-$(P
 $(LI $(BUGZILLA 11676): Add a link to D Wiki Sidebar to take users back to DLang.org)
 $(LI $(BUGZILLA 12087): Add Readme to dlang.org repository that explains how to contribute)
-)
 )
 
 )

--- a/changelog/2.066.0.dd
+++ b/changelog/2.066.0.dd
@@ -483,7 +483,6 @@ $(BR)$(BIG $(LNAME2 list2066, List of all bug fixes and enhancements in D 2.066:
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 5105): Member function template cannot be synchronized)
 $(LI $(BUGZILLA 9449): Static arrays of 128bit types segfault on initialization. Incorrect calling of memset128ii.)
 $(LI $(BUGZILLA 11777): [ICE] dmd memory corruption as `Scope::pop` `free`s `fieldinit` used also in `enclosing`)
@@ -588,10 +587,8 @@ $(LI $(BUGZILLA 13252): ParameterDefaultValueTuple affects other instantiations)
 $(LI $(BUGZILLA 13259): [ICE] 'v.result' on line 191 in file 'todt.c')
 $(LI $(BUGZILLA 13284): [dmd 2.066-rc2] Cannot match shared classes at receive)
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 648): DDoc: unable to document mixin statement)
 $(LI $(BUGZILLA 846): Error 42: Symbol Undefined "$(LESS)mangle_of_class_template$(GREATER)__arrayZ")
 $(LI $(BUGZILLA 1659): template alias parameters are chosen over all but exact matches.)
@@ -828,10 +825,8 @@ $(LI $(BUGZILLA 13260): [D1] ICE accessing non-existent aggregate member)
 $(LI $(BUGZILLA 13273): ddoc can't handle \r in unittests and ESCAPES properly)
 $(LI $(BUGZILLA 13275): Wrong di header generation on if and foreach statements)
 )
-)
 $(BUGSTITLE DMD Compiler enhancements,
 
-$(P
 $(LI $(BUGZILLA 1553): foreach_reverse is allowed for delegates)
 $(LI $(BUGZILLA 1673): Implement the isTemplate trait)
 $(LI $(BUGZILLA 1952): Support a unit test handler)
@@ -872,10 +867,8 @@ $(LI $(BUGZILLA 13138): add peek/poke as compiler intrinsics)
 $(LI $(BUGZILLA 13277): The base class in the JSON output is always unqualified)
 $(LI $(BUGZILLA 13281): Print type suffix of real/complex literals in pragma$(LPAREN)msg$(RPAREN) and error diagnostic)
 )
-)
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 12332): std.json API broken without notice)
 $(LI $(BUGZILLA 12375): Writeln of a char plus a fixed size array of chars)
 $(LI $(BUGZILLA 12394): Regression: std.regex unittests take agonizingly long to run - like hours on OSX)
@@ -889,10 +882,8 @@ $(LI $(BUGZILLA 13076): [dmd 2.066-b2] DList clearing of empty list)
 $(LI $(BUGZILLA 13098): std.path functions no longer works with DirEntry)
 $(LI $(BUGZILLA 13181): install target broken)
 )
-)
 $(BUGSTITLE Phobos bugs,
 
-$(P
 $(LI $(BUGZILLA 1452): std.cstream doc incorrect - imports of stream and stdio are not public)
 $(LI $(BUGZILLA 1726): std.stream FileMode documentation problems)
 $(LI $(BUGZILLA 3054): multithreading GC problem. And Stdio not multithreading safe)
@@ -1004,10 +995,8 @@ $(LI $(BUGZILLA 13214): array.opSlice one element falsy empty)
 $(LI $(BUGZILLA 13258): std.process file closing logic is incorrect)
 $(LI $(BUGZILLA 13263): phobos/posix.mak has incorrect dependencies)
 )
-)
 $(BUGSTITLE Phobos enhancements,
 
-$(P
 $(LI $(BUGZILLA 3780): getopt improvements by Igor Lesik)
 $(LI $(BUGZILLA 4725): std.algorithm.sum$(LPAREN)$(RPAREN))
 $(LI $(BUGZILLA 4999): Add Kenji Hara's adaptTo$(LPAREN)$(RPAREN) to Phobos)
@@ -1050,10 +1039,8 @@ $(LI $(BUGZILLA 13022): std.complex lacks a function returning the squared modul
 $(LI $(BUGZILLA 13042): std.net.curl.SMTP doesn't send emails with libcurl-7.34.0 or newer)
 $(LI $(BUGZILLA 13159): std.socket.getAddress allocates once per DNS lookup hit)
 )
-)
 $(BUGSTITLE Druntime regressions,
 
-$(P
 $(LI $(BUGZILLA 12220): [REG2.066a] hash.get$(LPAREN)$(RPAREN) does not accept proper parameters)
 $(LI $(BUGZILLA 12427): Regression $(LPAREN)2.066 git-head$(RPAREN): Building druntime fails with -debug=PRINTF)
 $(LI $(BUGZILLA 12710): Bad @nogc requirement for Windows callbacks)
@@ -1064,10 +1051,8 @@ $(LI $(BUGZILLA 13084): ModuleInfo.opApply delegate expects immutable parameter)
 $(LI $(BUGZILLA 13111): GC.realloc returns invalid memory for large reallocation)
 $(LI $(BUGZILLA 13148): ModuleInfo fields are unnecessary changed to const)
 )
-)
 $(BUGSTITLE Druntime bugs,
 
-$(P
 $(LI $(BUGZILLA 4323): std.demangle incorrectly handles template floating point numbers)
 $(LI $(BUGZILLA 5892): Lazy evaluation of stack trace when exception is thrown)
 $(LI $(BUGZILLA 7954): x86_64 Windows fibers do not save nonvolatile XMM registers)
@@ -1086,10 +1071,8 @@ $(LI $(BUGZILLA 12975): posix.mak should use isainfo on Solaris systems to deter
 $(LI $(BUGZILLA 13057): posix getopt variables in core/sys/posix/unistd.d should be marked __gshared)
 $(LI $(BUGZILLA 13073): Wrong uint/int array comparison)
 )
-)
 $(BUGSTITLE Druntime enhancements,
 
-$(P
 $(LI $(BUGZILLA 8409): Proposal: implement arr.dup in library)
 $(LI $(BUGZILLA 12964): dev_t is incorrectly defined in runtime for Solaris systems)
 $(LI $(BUGZILLA 12976): ModuleInfo should be immutable on Solaris)
@@ -1100,33 +1083,25 @@ $(LI $(BUGZILLA 13144): Add fenv support for Solaris)
 $(LI $(BUGZILLA 13145): Need LC_ locale values for Solaris)
 $(LI $(BUGZILLA 13146): Add missing function definitions from stdlib.h on Solaris)
 )
-)
 $(BUGSTITLE Installer regressions,
 
-$(P
 $(LI $(BUGZILLA 13004): /? option to cl.exe results in ICE)
 $(LI $(BUGZILLA 13047): cannot stat `./icons/16/dmd-source.png`: No such file or directory)
 $(LI $(BUGZILLA 13210): libphobos2.so not being built)
 $(LI $(BUGZILLA 13233): Windows installer: downloading external installers $(LPAREN)Visual D/dmc$(RPAREN) does not work)
 )
-)
 $(BUGSTITLE Installer bugs,
 
-$(P
 $(LI $(BUGZILLA 3319): DInstaller overwrites the %PATH% variable)
 $(LI $(BUGZILLA 5732): Windows installer creates incorrect target for Start menu link)
 $(LI $(BUGZILLA 13149): released libphobos2.a is build with PIC code)
 )
-)
 $(BUGSTITLE Website regressions,
 
-$(P
 $(LI $(BUGZILLA 12813): Parser is confused between float and UFC syntax)
-)
 )
 $(BUGSTITLE Website bugs,
 
-$(P
 $(LI $(BUGZILLA 1497): Add a link to the DWiki debuggers page)
 $(LI $(BUGZILLA 1574): DDoc documentation lacks macro examples)
 $(LI $(BUGZILLA 3093): Object.factory has incomplete documentation)
@@ -1163,14 +1138,11 @@ $(LI $(BUGZILLA 12623): Special lexing case not mentioned in language spec)
 $(LI $(BUGZILLA 12740): DMD accepts invalid version syntax)
 $(LI $(BUGZILLA 13012): Open bugs chart is missing from https://dlang.org/bugstats.php)
 )
-)
 $(BUGSTITLE Website enhancements,
 
-$(P
 $(LI $(BUGZILLA 8103): Use case-insensitive sorting for Jump-to lists in the documentation)
 $(LI $(BUGZILLA 12783): Adding 'Third Party Libraries' link to the navigation sidebar)
 $(LI $(BUGZILLA 12858): Document opEquals usage in AAs)
-)
 )
 
 )

--- a/changelog/2.066.1.dd
+++ b/changelog/2.066.1.dd
@@ -8,7 +8,6 @@ $(BR)$(BIG List of all bug fixes in D 2.066.1.)
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 11312): [REG2.063] Avoid auto-dereference for UFCS functions)
 $(LI $(BUGZILLA 11946): need 'this' to access member when passing field to template parameter)
 $(LI $(BUGZILLA 13294): [IFTI] IFTI fails or works incorrectly for function with const and mutable `ref` parameters of most types)
@@ -31,10 +30,8 @@ $(LI $(BUGZILLA 13476): [REG2.065] Writing stubs for dynamically loaded function
 $(LI $(BUGZILLA 13478): [REG2.066] Templates not emitted when also referenced in speculative contexts)
 $(LI $(BUGZILLA 13504): ICE$(LPAREN)backend/cgelem.c 2418$(RPAREN) with "-O -cov")
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 13235): Wrong code on mutually recursive tuple type)
 $(LI $(BUGZILLA 13204): recursive alias declaration)
 $(LI $(BUGZILLA 13333): Incorrect error ungagging during the resolution of forward references)
@@ -43,43 +40,30 @@ $(LI $(BUGZILLA 13383): wrong code with -O with ints, longs and bitwise operatio
 $(LI $(BUGZILLA 13413): dmd does not follow symlink when searching for dmd.conf)
 $(LI $(BUGZILLA 13323): UDA applied to import statement causes compilation to fail without error)
 )
-)
 $(BUGSTITLE DMD Compiler enhancements,
 
-$(P
 $(LI $(BUGZILLA 12567): Modules can't be marked as deprecated)
-)
 )
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 13618): removing deprecated std.metastrings module breaks code)
-)
 )
 $(BUGSTITLE Phobos bugs,
 
-$(P
 $(LI $(BUGZILLA 13313): std.datetime fails unittests on Windows)
-)
 )
 $(BUGSTITLE Druntime regressions,
 
-$(P
 $(LI $(BUGZILLA 13399): va_arg is nothrow yet may throw)
-)
 )
 $(BUGSTITLE Druntime bugs,
 
-$(P
 $(LI $(BUGZILLA 13377): core/sys/posix/syslog.d is in druntime/src but not in druntime/src/import)
 $(LI $(BUGZILLA 13414): Static destructors not called correctly with dynamic loading)
 )
-)
 $(BUGSTITLE Installer regressions,
 
-$(P
 $(LI $(BUGZILLA 13233): Windows installer: downloading external installers $(LPAREN)Visual D/dmc$(RPAREN) does not work)
-)
 )
 )
 $(CHANGELOG_NAV 2.066.0,2.067.0)

--- a/changelog/2.067.0.dd
+++ b/changelog/2.067.0.dd
@@ -270,7 +270,6 @@ $(BR)$(BIG $(LNAME2 list2067, List of all bug fixes and enhancements in D 2.067:
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 4890): GC.collect$(LPAREN)$(RPAREN) deadlocks multithreaded program.)
 $(LI $(BUGZILLA 12381): [REG2.065] [ICE] An internal error in e2ir.c while casting array ops)
 $(LI $(BUGZILLA 12422): [REG2.055] Templated nested function is inferred as `pure` even if it calls impure functions)
@@ -354,10 +353,8 @@ $(LI $(BUGZILLA 14301): [2.067-rc1] Private symbols of module conflicts with pub
 $(LI $(BUGZILLA 14304): [REG2.067a] ICE with static immutable variable CTFE)
 $(LI $(BUGZILLA 14317): [REG2.066] ICE $(LPAREN)cgcod.c 1767$(RPAREN) when compiing with -profile -O -inline)
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 1625): CTFE: cannot evaluate function when return type includes a union)
 $(LI $(BUGZILLA 1829): Inline assembler cannot get label addresses)
 $(LI $(BUGZILLA 2644): Unresolved template reference)
@@ -541,10 +538,8 @@ $(LI $(BUGZILLA 14306): Wrong codegen with -inline for generic lambdas)
 $(LI $(BUGZILLA 14311): Win32 COFF: bad symbols/relocation entries for global data accesses)
 $(LI $(BUGZILLA 14313): [ld.gold] gdb: wrong value of shared variables)
 )
-)
 $(BUGSTITLE DMD Compiler enhancements,
 
-$(P
 $(LI $(BUGZILLA 1317): Document suggested means of overlapping array copy)
 $(LI $(BUGZILLA 2498): make foreach work for any callable symbol)
 $(LI $(BUGZILLA 2529): 'package' access qualifier should allow access to sub-packages)
@@ -574,10 +569,8 @@ $(LI $(BUGZILLA 14156): buffer overflow in LibELF)
 $(LI $(BUGZILLA 14211): Compiler should devirtualize calls to members of final class)
 $(LI $(BUGZILLA 14338): Implement DIP25 Sealed References)
 )
-)
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 13241): [REG2.067a] writeln no longer flushes stdout)
 $(LI $(BUGZILLA 13257): [REG2.067a] Deprecation message when using std.getopt with string[] parameter)
 $(LI $(BUGZILLA 13300): pure function 'std.array.Appender!$(LPAREN)T[]$(RPAREN).Appender.ensureAddable' cannot call impure function 'test.T.__fieldPostBlit')
@@ -603,10 +596,8 @@ $(LI $(BUGZILLA 14233): [REG2.067b2] Can't build Algebraic!$(LPAREN)This[]$(RPAR
 $(LI $(BUGZILLA 14253): [REG2.067b3] std.traits.ParameterStorageClassTuple gives compiler errors when encountering 'return' functions)
 $(LI $(BUGZILLA 14300): [2.067-rc1] DList casting to base type is broken)
 )
-)
 $(BUGSTITLE Phobos bugs,
 
-$(P
 $(LI $(BUGZILLA 649): concatenation hangs in threaded program)
 $(LI $(BUGZILLA 3141): osx syntax problem with touch)
 $(LI $(BUGZILLA 5036): Remove caching from ranges)
@@ -679,10 +670,8 @@ $(LI $(BUGZILLA 14223): TimSort algorithm is incorrect)
 $(LI $(BUGZILLA 14231): findRoot fails with trivial bounds)
 $(LI $(BUGZILLA 14297): [2.067-rc1] Broken links in phobos/index.html)
 )
-)
 $(BUGSTITLE Phobos enhancements,
 
-$(P
 $(LI $(BUGZILLA 2138): Allow more than 65535 files in Zip archives)
 $(LI $(BUGZILLA 2181): Constant-time std.gc.removeRange)
 $(LI $(BUGZILLA 4493): Add sorting capability to toJSON)
@@ -721,10 +710,8 @@ $(LI $(BUGZILLA 13909): A problem with immutable zip + assocArray)
 $(LI $(BUGZILLA 14110): std.file.read cannot read files open for writing)
 $(LI $(BUGZILLA 14183): Updates to groupBy)
 )
-)
 $(BUGSTITLE Druntime regressions,
 
-$(P
 $(LI $(BUGZILLA 13748): benchmark druntime/benchmark/aabench/string.d fails)
 $(LI $(BUGZILLA 13809): dup no longer works with types with postblit and destructors)
 $(LI $(BUGZILLA 14134): Free of large array does not work)
@@ -732,10 +719,8 @@ $(LI $(BUGZILLA 14192): Access Violation when assigning to shared AA)
 $(LI $(BUGZILLA 14225): [REG2.067a] GDB: error reading variable $(LPAREN)string + dup$(RPAREN))
 $(LI $(BUGZILLA 14291): Druntime master no longer builds)
 )
-)
 $(BUGSTITLE Druntime bugs,
 
-$(P
 $(LI $(BUGZILLA 5629): core.time unittest disabled)
 $(LI $(BUGZILLA 8960): DMD tester: Unable to set thread priority)
 $(LI $(BUGZILLA 13052): TypeInfo.getHash should return same hash for different floating point zeros.)
@@ -750,10 +735,8 @@ $(LI $(BUGZILLA 14157): fabsf fabsl for CRuntime_Microsoft)
 $(LI $(BUGZILLA 14247): string within demangled symbol name should be made escape)
 $(LI $(BUGZILLA 14303): rt.util.container.array.Array unittest contains invalid code)
 )
-)
 $(BUGSTITLE Druntime enhancements,
 
-$(P
 $(LI $(BUGZILLA 9119): [AA] Forward range addition to associative arrays.)
 $(LI $(BUGZILLA 11216): Make synchronized statement `nothrow`)
 $(LI $(BUGZILLA 13401): code cleanup: removing c-style array declarations in druntime)
@@ -762,29 +745,21 @@ $(LI $(BUGZILLA 13725): onInvalidMemoryOperationError et al should not be inline
 $(LI $(BUGZILLA 13755): core.sys.linux.stdio, std.stdio.File: fopencookie, fmemopen missing)
 $(LI $(BUGZILLA 14007): shmctl with IPC_STAT returns wrong number of attachments. shmid_ds is defined wrong.)
 )
-)
 $(BUGSTITLE Optlink bugs,
 
-$(P
 $(LI $(BUGZILLA 4831): Optlink rejects paths with invalid characters based on HPFS filesystem instead of NTFS)
-)
 )
 $(BUGSTITLE Installer bugs,
 
-$(P
 $(LI $(BUGZILLA 9392): Misleading text about required OS version)
-)
 )
 $(BUGSTITLE Website regressions,
 
-$(P
 $(LI $(BUGZILLA 14258): SIGSEGV in dpldocs)
 $(LI $(BUGZILLA 14280): Links to command line tools have disappeared from navigation)
 )
-)
 $(BUGSTITLE Website bugs,
 
-$(P
 $(LI $(BUGZILLA 8307): inconsistent treatment of auto functions)
 $(LI $(BUGZILLA 9118): typo in github tools repo)
 $(LI $(BUGZILLA 9535): incomplete documentation for std.range.recurrence and std.range.sequence)
@@ -824,10 +799,8 @@ $(LI $(BUGZILLA 14121): Wiki: "Create account" page completely broken!)
 $(LI $(BUGZILLA 14135): std.uuid.randomUUID breaks @safety)
 $(LI $(BUGZILLA 14153): std.format page displaying incorrectly)
 )
-)
 $(BUGSTITLE Website enhancements,
 
-$(P
 $(LI $(BUGZILLA 4954): Clarify documentation of foreach with delegates.)
 $(LI $(BUGZILLA 6251): D spec should warn about using foreach_reverse on a delegate)
 $(LI $(BUGZILLA 9469): Keywords list could use linkage; more-humane documentation)
@@ -835,7 +808,6 @@ $(LI $(BUGZILLA 10154): Betas should be posted on dlang.org)
 $(LI $(BUGZILLA 10164): std.string.column examples and documentation)
 $(LI $(BUGZILLA 13325): __vector not documented in language specification)
 $(LI $(BUGZILLA 14011): Canonical links help message should clarify that 'thread' is invalid)
-)
 )
 
 )

--- a/changelog/2.067.1.dd
+++ b/changelog/2.067.1.dd
@@ -8,7 +8,6 @@ $(BR)$(BIG List of all bug fixes and enhancements in D 2.067.1:)
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 14344): [REG2.067] Wrong opBinary call in construction)
 $(LI $(BUGZILLA 14376): [REG2.064] false positive "Error: one path skips field")
 $(LI $(BUGZILLA 14395): [REG2.067] Typesafe variadic function call collapsed if being used for default value)
@@ -17,30 +16,21 @@ $(LI $(BUGZILLA 14440): [REG2.067] [CTFE] Wrong values set in a matrix construct
 $(LI $(BUGZILLA 14443): [REG2.067.0] Incorrect double freeing of reference counted struct)
 $(LI $(BUGZILLA 14463): [REG2.067] DMD crashes compiling module level immutable struct that takes an array in ctor)
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 14375): static assert leads to __traits$(LPAREN)allMembers$(RPAREN) retuning an extra empty entry)
-)
 )
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 14396): [REG2.066] compile error std.conv.parse!int with input range)
-)
 )
 $(BUGSTITLE Druntime regressions,
 
-$(P
 $(LI $(BUGZILLA 14467): arr.capacity sometimes erroneously returns 0)
-)
 )
 $(BUGSTITLE Website bugs,
 
-$(P
 $(LI $(BUGZILLA 14329): [2.067] offline doc - menu broken due to missing jquery-1.7.2.min.js)
-)
 )
 
 )

--- a/changelog/2.068.0.dd
+++ b/changelog/2.068.0.dd
@@ -331,7 +331,6 @@ $(BR)$(BIG $(LNAME2 list2068, List of all bug fixes and enhancements in D 2.068:
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 9279): [REG2.055/2.063] Static array return value implicitly converted to immutable dynamic array)
 $(LI $(BUGZILLA 12984): [REG2.068a] ICE on forward reference of derived class from other instantiated class)
 $(LI $(BUGZILLA 13816): [REG2.066.0] The compiler crashes with recursive tuple expansion)
@@ -375,10 +374,8 @@ $(LI $(BUGZILLA 14851): [REG2.068.0-b2] Cannot assign array operation result to 
 $(LI $(BUGZILLA 14853): [REG2.066] DMD segfaults with the cast from mutable struct new to shared)
 $(LI $(BUGZILLA 14890): [REG 2.068.0-rc1] Can not construct a RedBlackTree of Tuples)
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 1759): Closures and With Statements)
 $(LI $(BUGZILLA 2803): template + default argument = doesn't work)
 $(LI $(BUGZILLA 3869): Unreasonable error without line number: "recursive template expansion")
@@ -433,29 +430,23 @@ $(LI $(BUGZILLA 14629): Type system breaking and wrong code bugs in casting refe
 $(LI $(BUGZILLA 14649): ICE on invalid array operation with string literals)
 $(LI $(BUGZILLA 14656): "auto" of "auto ref" spills over to other function)
 )
-)
 $(BUGSTITLE DMD Compiler enhancements,
 
-$(P
 $(LI $(BUGZILLA 9914): Do attribute inference for auto functions)
 $(LI $(BUGZILLA 11003): Improve .di generation)
 $(LI $(BUGZILLA 14465): CTFE exception stacktrace shows location of Exception constructor)
 $(LI $(BUGZILLA 14547): Ddoc should prefer new Variable Template syntax)
 )
-)
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 14712): GIT HEAD : std.net.curl regressions)
 $(LI $(BUGZILLA 14748): Removing std.stdio import causes 2x increase in "Hello, world" program binary filesize)
 $(LI $(BUGZILLA 14765): [Reg2.068.0] Rangified functions no longer accept types that implicitly cast to string)
 $(LI $(BUGZILLA 14842): [REG 2.068-b2] approxEqual does not work with integers)
 $(LI $(BUGZILLA 14881): [REG] posix.mak omits package.d files when building zip file)
 )
-)
 $(BUGSTITLE Phobos bugs,
 
-$(P
 $(LI $(BUGZILLA 12702): [FixIncluded] std.container.RedBlackTree's in operator is not const)
 $(LI $(BUGZILLA 13534): std.variant can violate memory safety)
 $(LI $(BUGZILLA 14282): executeShell should use sh and ignore the SHELL env variable)
@@ -468,10 +459,8 @@ $(LI $(BUGZILLA 14544): isForwardRange failed to recognise valid forward range)
 $(LI $(BUGZILLA 14575): compile error with std.range.refRange when front/back isn't implicitly convertible from const to mutable)
 $(LI $(BUGZILLA 14585): destructor called on garbage in std.variant)
 )
-)
 $(BUGSTITLE Phobos enhancements,
 
-$(P
 $(LI $(BUGZILLA 14194): nothrow emplace for classes needed)
 $(LI $(BUGZILLA 14288): std.windows.registry should use std.windows.syserror)
 $(LI $(BUGZILLA 14289): WindowsException should not attempt to parse code 0)
@@ -482,18 +471,14 @@ $(LI $(BUGZILLA 14535): std.net.curl.CurlException should include status line)
 $(LI $(BUGZILLA 14548): std.stdio.File should have sync$(LPAREN)$(RPAREN) method $(LPAREN)fsync/FlushFileBuffers wrapper$(RPAREN))
 $(LI $(BUGZILLA 14586): can't get an immutable value from a const std.variant.Variant)
 )
-)
 $(BUGSTITLE Druntime regressions,
 
-$(P
 $(LI $(BUGZILLA 14626): [REG2.066] byValue doesn't work with inout AA)
 $(LI $(BUGZILLA 14746): [REG2.068a] Behavior change with struct destructor and alias this)
 $(LI $(BUGZILLA 14863): CLOCK_BOOTTIME should be optional to support <2.6.39 kernels)
 )
-)
 $(BUGSTITLE Druntime bugs,
 
-$(P
 $(LI $(BUGZILLA 6607): critical_.d and critical.c use double check locking the wrong way)
 $(LI $(BUGZILLA 12289): incorrect core.stdc.stdio.fpos_t alias)
 $(LI $(BUGZILLA 14350): Unit test failures are not displayed in Windows GUI programs)
@@ -504,17 +489,13 @@ $(LI $(BUGZILLA 14476): core.thread unit tests failing on FreeBSD 9+)
 $(LI $(BUGZILLA 14511): Profiler does not work with multithreaded programs)
 $(LI $(BUGZILLA 14565): dmd -profile produces garbled output for long-running CPU-intensive processes)
 )
-)
 $(BUGSTITLE Druntime enhancements,
 
-$(P
 $(LI $(BUGZILLA 12891): add atomicFetchAdd and atomicFetchSub to core.atomic)
 $(LI $(BUGZILLA 14385): AA should use open addressing hash)
 )
-)
 $(BUGSTITLE dlang.org bugs,
 
-$(P
 $(LI $(BUGZILLA 12803): __traits$(LPAREN)getFunctionAttributes$(RPAREN) is not documented)
 $(LI $(BUGZILLA 13527): ddoc website documentation does not match the current built-in symbols)
 $(LI $(BUGZILLA 14079): Variable templates' documentation not generated.)
@@ -522,20 +503,15 @@ $(LI $(BUGZILLA 14080): No mention of documented unittests on ddoc's page)
 $(LI $(BUGZILLA 14326): syntax highlighting of dpl-docs no longer works)
 $(LI $(BUGZILLA 14418): D-style Variadic Function example does not compile)
 )
-)
 $(BUGSTITLE Tools bugs,
 
-$(P
 $(LI $(BUGZILLA 13758): RDMD renames directory if -ofNAME is the name of a directory)
 $(LI $(BUGZILLA 14259): rdmd: --build-only / -of / -od incompatible with --dry-run)
 )
-)
 $(BUGSTITLE Installer bugs,
 
-$(P
 $(LI $(BUGZILLA 14801): OS X installer not compatible with OS X 10.11)
 $(LI $(BUGZILLA 14864): windows uninstall during installation pops up spurious warning)
-)
 )
 
 )

--- a/changelog/2.068.1.dd
+++ b/changelog/2.068.1.dd
@@ -42,7 +42,6 @@ $(BR)$(BIG $(LNAME2 list2068_1, List of all bug fixes and enhancements in D 2.06
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 14431): [REG 2.067.0] huge slowdown of compilation speed)
 $(LI $(BUGZILLA 14621): [REG2.066] ICE: Assertion failure: 'global.gaggedErrors || global.errors' on line 752 in file 'statement.c')
 $(LI $(BUGZILLA 14781): [REG2.067] impure delegate to pure function context should be able to modify context)
@@ -60,10 +59,8 @@ $(LI $(BUGZILLA 14986): [REG2.068.1-b2] Assertion failed: $(LPAREN)id->dyncast$(
 $(LI $(BUGZILLA 15002): [REG2.064] ICE with invalid static variable initializer while CTFE)
 $(LI $(BUGZILLA 15017): [REG2.068.1-b2] assigning a Variant to be value in a hashmap)
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 14624): The array operator overloading fallback is not correct)
 $(LI $(BUGZILLA 14625): opIndex$(LPAREN)$(RPAREN) doesn't work on foreach container iteration)
 $(LI $(BUGZILLA 14696): destructor for temporary called before statement is complete with conditional operator)
@@ -71,27 +68,20 @@ $(LI $(BUGZILLA 14708): destructor for temporary not called during stack unwindi
 $(LI $(BUGZILLA 14889): ICE: Assertion `o->dyncast$(LPAREN)$(RPAREN) == DYNCAST_DSYMBOL' failed.)
 $(LI $(BUGZILLA 14900): 2.068.0 change log example does not compile)
 )
-)
 $(BUGSTITLE DMD Compiler enhancements,
 
-$(P
 $(LI $(BUGZILLA 13889): mscoff32 libs not available)
 $(LI $(BUGZILLA 14951): Win64: Invalid C++ mangling for __gshared pointer variables)
 )
-)
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 14904): [REG2.067.0] bad error message in reduce: 'Incompatible function/seed/element')
 $(LI $(BUGZILLA 14920): [REG2.067.0] SList.insertAfter on uninitialized list triggers assertion in _first)
 $(LI $(BUGZILLA 14980): [REG2.068] getAddressInfo$(LPAREN)null$(RPAREN) broken)
 )
-)
 $(BUGSTITLE Installer bugs,
 
-$(P
 $(LI $(BUGZILLA 14897): shared linux libraries from zip package don't work)
-)
 )
 
 )

--- a/changelog/2.068.2.dd
+++ b/changelog/2.068.2.dd
@@ -14,11 +14,9 @@ $(BR)$(BIG List of all bug fixes and enhancements in D 2.068.2:)
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 15021): [REG2.068.1] linker error with speculative instantiation and -inline)
 $(LI $(BUGZILLA 15030): [REG2.068.1] ICE with recursive delegate, -unittest, and std.range)
 $(LI $(BUGZILLA 15044): [REG2.068.0] destroy might leak memory)
-)
 )
 
 )

--- a/changelog/2.069.0.dd
+++ b/changelog/2.069.0.dd
@@ -229,7 +229,6 @@ $(BR)$(BIG $(LNAME2 bugfix-list, List of all bug fixes and enhancements in D 2.0
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 13720): [REG2.067] Adding trivial destructor to std.datetime causes Internal error: ..\ztc\cgelem.c 2418)
 $(LI $(BUGZILLA 14430): [REG2.060] Null parameter is detected as non-null.)
 $(LI $(BUGZILLA 14572): cannot build dmd from source anymore: 'g++ -m64: No such file or directory')
@@ -269,10 +268,8 @@ $(LI $(BUGZILLA 15251): [REG2.069.0-rc1] std.datetime bug with -inline)
 $(LI $(BUGZILLA 15253): [REG2.069.0-rc1] inliner prevent  compilation)
 $(LI $(BUGZILLA 15272): [2.069-rc2,inline] nothing written to output when -inline is set)
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 1747): class to base interface static cast is incorrect in some cases)
 $(LI $(BUGZILLA 2013): interface to interface dynamic cast is incorrect in some cases)
 $(LI $(BUGZILLA 2091): D2 final cannot be applied to variable)
@@ -325,19 +322,15 @@ $(LI $(BUGZILLA 15080): extern$(LPAREN)C++$(RPAREN) classes have wrong static da
 $(LI $(BUGZILLA 15089): Marks wrong line as where error occurs.)
 $(LI $(BUGZILLA 15127): Parser assertion on wrong code)
 )
-)
 $(BUGSTITLE DMD Compiler enhancements,
 
-$(P
 $(LI $(BUGZILLA 12421): Allow simpler syntax for lambda template declarations)
 $(LI $(BUGZILLA 14717): Ddoc macro recursion limit too low)
 $(LI $(BUGZILLA 14755): Could -profile=gc also give the number of allocations that led to X bytes being allocated?)
 $(LI $(BUGZILLA 14975): DMD refuses to inline even trivial struct constructors)
 )
-)
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 14564): [REG2.067] dmd -property -unittest combination causes compiler error)
 $(LI $(BUGZILLA 14685): [REG2.067] Silent incorrect behavior with enforce and custom exception)
 $(LI $(BUGZILLA 14712): GIT HEAD : std.net.curl regressions)
@@ -346,10 +339,8 @@ $(LI $(BUGZILLA 14881): [REG] posix.mak omits package.d files when building zip 
 $(LI $(BUGZILLA 15027): rangified functions no longer work with alias this'ed strings $(LPAREN)e.g. DirEntry$(RPAREN))
 $(LI $(BUGZILLA 15039): Algebraic cannot store a Typedef along with Typedef'ed type)
 )
-)
 $(BUGSTITLE Phobos bugs,
 
-$(P
 $(LI $(BUGZILLA 10895): incorrect std.array.join behavior with array of string-like class using alias this)
 $(LI $(BUGZILLA 13650): std.algorithm.copy doesn't work with char/wchar)
 $(LI $(BUGZILLA 13856): std.stdio.readln stomps arrays)
@@ -374,10 +365,8 @@ $(LI $(BUGZILLA 15115): std.typetuple link to std.meta is 404)
 $(LI $(BUGZILLA 15187): dispose for allocators is broken)
 $(LI $(BUGZILLA 15188): `deallocate` cause memory leaks)
 )
-)
 $(BUGSTITLE Phobos enhancements,
 
-$(P
 $(LI $(BUGZILLA 5945): redBlackTree printing)
 $(LI $(BUGZILLA 12752): std.algorithm.isPermutation)
 $(LI $(BUGZILLA 12966): Merge the heapsort code in std with the binary heap in std.range)
@@ -390,20 +379,16 @@ $(LI $(BUGZILLA 14877): std.net.curl needs PATCH http method)
 $(LI $(BUGZILLA 14938): std.net.curl tests should use localhost or stub any networking)
 $(LI $(BUGZILLA 14940): Can't call logger with more complex objects)
 )
-)
 $(BUGSTITLE Druntime regressions,
 
-$(P
 $(LI $(BUGZILLA 14750): druntime/test/coverage was added to druntime, but not to the MANIFEST - zip file broken again)
 $(LI $(BUGZILLA 14882): [REG] MANIFEST is missing test/common.mak)
 $(LI $(BUGZILLA 14990): No rule to make target `src/core/sys/windows/stdio_msvc12.d', needed by 'druntime.zip'.)
 $(LI $(BUGZILLA 14993): Allocating in a destructor segfaults instead of throwing InvalidMemoryOperationError)
 $(LI $(BUGZILLA 15012): Druntime Makefile whitelists compilers)
 )
-)
 $(BUGSTITLE Druntime bugs,
 
-$(P
 $(LI $(BUGZILLA 11414): druntime should run debug unittest)
 $(LI $(BUGZILLA 14327): Unhandled exception from writeln$(LPAREN)$(RPAREN) in C++/D application)
 $(LI $(BUGZILLA 14663): shared library test - link_linkdep - segfaults on FreeBSD 10)
@@ -414,63 +399,46 @@ $(LI $(BUGZILLA 15009): Object.destroy calls unnecessary postblits for destructi
 $(LI $(BUGZILLA 15036): SimpleDllMain assumes various symbols are available unqualified)
 $(LI $(BUGZILLA 15104): Switching fibers in finally blocks breaks EH)
 )
-)
 $(BUGSTITLE Druntime enhancements,
 
-$(P
 $(LI $(BUGZILLA 15076): Get ID of current thread)
 $(LI $(BUGZILLA 15137): core.time: Support Duration/Duration and Duration%Duration)
 )
-)
 $(BUGSTITLE dlang.org regressions,
 
-$(P
 $(LI $(BUGZILLA 15046): [REG2.068] isForwardRange documentation is documenting issue 14544)
-)
 )
 $(BUGSTITLE dlang.org bugs,
 
-$(P
 $(LI $(BUGZILLA 12072): Regex article needs update)
 $(LI $(BUGZILLA 14579): [SPEC] No specification on modifiers in TypeDelegate symbols)
 $(LI $(BUGZILLA 14695): [dlang.org] std.uuid Is Not Listed On The Index Page)
 $(LI $(BUGZILLA 14879): tuple documentation broken link)
 $(LI $(BUGZILLA 15095): Malformed URL in documentation link)
 )
-)
 $(BUGSTITLE dlang.org enhancements,
 
-$(P
 $(LI $(BUGZILLA 14328): The terms "lvalue" and "rvalue" should be added to the glossary)
 $(LI $(BUGZILLA 14522): Postfix array declaration examples should be removed from arrays.html)
 $(LI $(BUGZILLA 14808): phobos sidebar "D Lib" link is back to homepage)
 $(LI $(BUGZILLA 14933): specifications for the pragma$(LPAREN)mangle$(RPAREN) are vague)
 )
-)
 $(BUGSTITLE Tools bugs,
 
-$(P
 $(LI $(BUGZILLA 15031): rdmd should force rebuild when --compiler changes)
-)
 )
 $(BUGSTITLE Tools enhancements,
 
-$(P
 $(LI $(BUGZILLA 14715): Add README.md to the tools Repository)
-)
 )
 $(BUGSTITLE Installer bugs,
 
-$(P
 $(LI $(BUGZILLA 13234): Windows installer: when updating, uninstaller reports wrong installation directory)
 $(LI $(BUGZILLA 14801): OS X installer not compatible with OS X 10.11)
 )
-)
 $(BUGSTITLE Installer enhancements,
 
-$(P
 $(LI $(BUGZILLA 14714): Add README.md to the Installer Repository)
-)
 )
 
 )

--- a/changelog/2.069.1.dd
+++ b/changelog/2.069.1.dd
@@ -8,9 +8,7 @@ $(BR)$(BIG List of all bug fixes and enhancements in D $(VER):)
 
 $(BUGSTITLE Installer regressions,
 
-$(P
 $(LI $(BUGZILLA 15284): dmd installer hangs when updating installed windows version)
-)
 )
 
 )

--- a/changelog/2.069.2.dd
+++ b/changelog/2.069.2.dd
@@ -8,28 +8,20 @@ $(BR)$(BIG List of all bug fixes and enhancements in D $(VER):)
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 15292): [REG2.068.0] Segmentation fault with self-referencing struct / inout / alias this)
 $(LI $(BUGZILLA 15296): [REG2.069] cannot inline simple function that calls use non-inlinable statements)
 )
-)
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 15293): [REG2.069.0] std.stdio.readln$(LPAREN)buffer$(RPAREN) messes up buffer's capacity)
-)
 )
 $(BUGSTITLE Phobos bugs,
 
-$(P
 $(LI $(BUGZILLA 15281): std\experimental\allocator\package.d not included in build script)
-)
 )
 $(BUGSTITLE Druntime regressions,
 
-$(P
 $(LI $(BUGZILLA 15334): [REG 2.069] OS X core.time ticksPerSecond calculation is incorrect)
-)
 )
 
 )

--- a/changelog/2.070.0.dd
+++ b/changelog/2.070.0.dd
@@ -84,7 +84,6 @@ $(BR)$(BIG $(LNAME2 bugfix-list, List of all bug fixes and enhancements in D $(V
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 13009): [REG2.064] inout overload conflicts with non-inout when used via alias this)
 $(LI $(BUGZILLA 14782): Internal error: backend/cod1.c)
 $(LI $(BUGZILLA 15369): [REG master] id.d$(LPAREN)369$(RPAREN): Error: Outside Unicode code space)
@@ -92,10 +91,8 @@ $(LI $(BUGZILLA 15430): amdMmx hangs up)
 $(LI $(BUGZILLA 15500): default construction disabled for struct constructor with default arguments)
 $(LI $(BUGZILLA 15550): [Reg 2.070.0-b1] compile error while testing template constraint)
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 3438): struct ctor with defaulted parameters should be rejected)
 $(LI $(BUGZILLA 3913): Bad error message with wrong enum)
 $(LI $(BUGZILLA 4350): $(LPAREN)mixin$(RPAREN) mixed in template identifier is not accessible by "with" statement)
@@ -125,26 +122,20 @@ $(LI $(BUGZILLA 15403): [internal] FileExp represents ImportExpression, the AST 
 $(LI $(BUGZILLA 15404): [internal] DotIdExp$(LPAREN)TOKdot$(RPAREN) and DotExp$(LPAREN)TOKdotexp$(RPAREN))
 $(LI $(BUGZILLA 15417): Wrong parameter passing for variadic nested functions within aggregate)
 )
-)
 $(BUGSTITLE DMD Compiler enhancements,
 
-$(P
 $(LI $(BUGZILLA 12421): Allow simpler syntax for lambda template declarations)
 $(LI $(BUGZILLA 15015): Win64: interop with C/C++ fails if function return value is a struct of size 8)
 $(LI $(BUGZILLA 15186): Emit better diagnostic for C++ member lookup operators)
 $(LI $(BUGZILLA 15464): Template parameter-dependent attributes)
 )
-)
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 14861): Error in stdio.d in LockingTextReader.readFront$(LPAREN)$(RPAREN))
 $(LI $(BUGZILLA 15319): [REG2.069] module map is in file std/map.d which cannot be read)
 )
-)
 $(BUGSTITLE Phobos bugs,
 
-$(P
 $(LI $(BUGZILLA 3764): Remove Phobos workarounds for fixed bugs)
 $(LI $(BUGZILLA 14786): The built-in exponentiation operator ^^ sometimes returns a value with the wrong sign.)
 $(LI $(BUGZILLA 15187): dispose for allocators is broken)
@@ -157,10 +148,8 @@ $(LI $(BUGZILLA 15409): Mallocator cant be used in @nogc code)
 $(LI $(BUGZILLA 15420): topN$(LPAREN)Range, Range$(RPAREN) does not respect its less predicate)
 $(LI $(BUGZILLA 15429): [std.stdio] Broken link in documentation)
 )
-)
 $(BUGSTITLE Phobos enhancements,
 
-$(P
 $(LI $(BUGZILLA 12987): topN should return the top portion of the range)
 $(LI $(BUGZILLA 15128): "IP_ADD_MEMBERSHIP" error in winsock2.d)
 $(LI $(BUGZILLA 15146): std.file.dirEntries$(LPAREN)""$(RPAREN) only works on Windows)
@@ -170,49 +159,36 @@ $(LI $(BUGZILLA 15212): BigInt should implement opCast!long and opCast!int)
 $(LI $(BUGZILLA 15320): static assert$(LPAREN)__traits$(LPAREN)compiles, xyz$(RPAREN)$(RPAREN) considered harmful in unittests)
 $(LI $(BUGZILLA 15385): Apply Andersson91 idea to SortedRange.contains)
 )
-)
 $(BUGSTITLE Druntime bugs,
 
-$(P
 $(LI $(BUGZILLA 15270): use TLS to store Thread.getThis $(LPAREN)pthread_getspecific causes heavy lock contention$(RPAREN))
 $(LI $(BUGZILLA 15367): array of delegates comparison fails)
 )
-)
 $(BUGSTITLE Druntime enhancements,
 
-$(P
 $(LI $(BUGZILLA 15053): Runtime.cArgs not @nogc)
 $(LI $(BUGZILLA 15268): possible deadlock for Thread.getAll/Thread.opApply w/ GC.collect)
 )
-)
 $(BUGSTITLE dlang.org bugs,
 
-$(P
 $(LI $(BUGZILLA 8846): Specs for Inline Assembler don't include cmpxchg16b)
 $(LI $(BUGZILLA 15250): Grammar does not contain rules for multiple slices in an index expression)
 )
-)
 $(BUGSTITLE dlang.org enhancements,
 
-$(P
 $(LI $(BUGZILLA 13624): Parts of the Overview page is very out of date)
 $(LI $(BUGZILLA 15078): GC documentation should reflect 2.067 changes)
 )
-)
 $(BUGSTITLE Tools bugs,
 
-$(P
 $(LI $(BUGZILLA 15173): rdmd man page incorrect/outdated)
 $(LI $(BUGZILLA 15174): Add or undocument --tmpdir switch)
 $(LI $(BUGZILLA 15175): rdmd --loop and --eval now complain about std.stream deprecation warnings)
 )
-)
 $(BUGSTITLE Installer bugs,
 
-$(P
 $(LI $(BUGZILLA 15456): sc.ini: Access denied for non-superusers on Windows 10)
 $(LI $(BUGZILLA 15572): Windows installer leaves "sc.ini" inaccessible)
-)
 )
 
 )

--- a/changelog/2.070.1.dd
+++ b/changelog/2.070.1.dd
@@ -8,19 +8,15 @@ $(BR)$(BIG List of all bug fixes and enhancements in D $(VER):)
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 15490): [REG 2.067] Error variable __nrvoretval cannot be modified at compile time when using -inline)
 $(LI $(BUGZILLA 15524): [REG2.069] 64bit app with anon-class crashes in contract)
 $(LI $(BUGZILLA 15661): [REG2.067.0] Destructor called while object still alive)
 $(LI $(BUGZILLA 15674): [REG 2.066] alias this rejected for 'out' parameter)
 $(LI $(BUGZILLA 15681): [REG2.067] Nested user type enum not retaining value properly.)
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 15664): [REG2.064] incorrect initialisation of member of an immutable struct)
-)
 )
 
 )

--- a/changelog/2.070.2.dd
+++ b/changelog/2.070.2.dd
@@ -8,9 +8,7 @@ $(BR)$(BIG List of all bug fixes and enhancements in D $(VER):)
 
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 15665): Templated scope class with constructor don't compile)
-)
 )
 
 )

--- a/changelog/2.071.0.dd
+++ b/changelog/2.071.0.dd
@@ -225,7 +225,6 @@ $(BR)$(BIG $(LNAME2 bugfix-list, List of all bug fixes and enhancements in D $(V
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 14965): [REG2.031] Forward reference to inferred return type of function call when using auto return type)
 $(LI $(BUGZILLA 14973): [REG2.068] compiler inference of contexts for nested map seems broken)
 $(LI $(BUGZILLA 15296): [REG2.069] cannot inline simple function that calls use non-inlinable statements)
@@ -245,10 +244,8 @@ $(LI $(BUGZILLA 15815): [REG2.071-devel] deprecation for aliased template instan
 $(LI $(BUGZILLA 15817): [REG2.068] ICE $(LPAREN)with no stacktrace$(RPAREN) instead of 'cannot index null array counts' with CTFE AA)
 $(LI $(BUGZILLA 15839): [REG2.071-b1] this.outer is of wrong type)
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 143): 'package' does not work at all)
 $(LI $(BUGZILLA 313): [module] Fully qualified names bypass private imports)
 $(LI $(BUGZILLA 314): [module] Static, renamed, and selective imports are always public)
@@ -302,27 +299,21 @@ $(LI $(BUGZILLA 15794): Lambda cannot get a chance to run its codegen)
 $(LI $(BUGZILLA 15811): -transition=import and -transition=checkimport have oddly behaviors)
 $(LI $(BUGZILLA 15825): dmd's -transition=checkimports reports a false positive for tuple __dollar)
 )
-)
 $(BUGSTITLE DMD Compiler enhancements,
 
-$(P
 $(LI $(BUGZILLA 10378): Prevent local imports from hiding local symbols)
 $(LI $(BUGZILLA 12954): deprecated doesn't work with concatenated strings or anything else but a string literal)
 $(LI $(BUGZILLA 14383): [ddoc] documented unittests don't work for module declaration)
 $(LI $(BUGZILLA 15644): Change object layout ABI to MI style)
 )
-)
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 15222): std.experimental omitted from phobos zip file)
 $(LI $(BUGZILLA 15782): [Reg 2.071-devel] Alias no longer strips qualifiers from user defined types)
 $(LI $(BUGZILLA 15807): Array!bool insertBack is broken)
 )
-)
 $(BUGSTITLE Phobos bugs,
 
-$(P
 $(LI $(BUGZILLA 1238): Private identifiers in imported modules create conflicts with public ones)
 $(LI $(BUGZILLA 15543): [ndslice] assumeSameStructure has useless flag)
 $(LI $(BUGZILLA 15545): csv Reader line feed '\r' failure)
@@ -341,39 +332,30 @@ $(LI $(BUGZILLA 15715): [ndslice] rangeHasMutableElements is not defined)
 $(LI $(BUGZILLA 15721): free error when calling Mallocator.dispose on interfaces)
 $(LI $(BUGZILLA 15772): emplace works with abstract classes but it shouldn't)
 )
-)
 $(BUGSTITLE Phobos enhancements,
 
-$(P
 $(LI $(BUGZILLA 15377): std.stdio: Use MSVCRT's _fseeki64 / _ftelli64 on Windows COFF)
 $(LI $(BUGZILLA 15532): [ndslice] iota$(LPAREN)5$(RPAREN).sliced$(LPAREN)2,2$(RPAREN) should throw error)
 $(LI $(BUGZILLA 15596): strip with delimiter?)
 $(LI $(BUGZILLA 15714): [ndslice] byElement seems to be missing some slicing primitives)
 )
-)
 $(BUGSTITLE Druntime regressions,
 
-$(P
 $(LI $(BUGZILLA 15224): making 'clean' results in garbage commands)
 $(LI $(BUGZILLA 15779): DWARF EH fails when using stack stomping $(LPAREN)-gx$(RPAREN))
 $(LI $(BUGZILLA 15822): InvalidMemoryOperationError when calling GC.removeRange/Root from a finalizer)
 )
-)
 $(BUGSTITLE Druntime enhancements,
 
-$(P
 $(LI $(BUGZILLA 15628): Exceptions in fibers never caught with /SAFESEH)
-)
 )
 $(BUGSTITLE dlang.org bugs,
 
-$(P
 $(LI $(BUGZILLA 10987): Add documentation for 'extern $(LPAREN)C++$(RPAREN)' classes)
 $(LI $(BUGZILLA 15344): m32mscoff switch missing from documentation.)
 $(LI $(BUGZILLA 15666): Grammar does not allow member function attributes on static constructors)
 $(LI $(BUGZILLA 15696): The website logo overlaps the Learn tab when using Microsoft Edge)
 $(LI $(BUGZILLA 15697): The script for This Week in D is served over HTTP even when accessing the website over HTTPs.)
-)
 )
 
 )

--- a/changelog/2.071.1.dd
+++ b/changelog/2.071.1.dd
@@ -8,7 +8,6 @@ $(BR)$(BIG List of all bug fixes and enhancements in D $(VER):)
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 15629): [REG2.066.0] wrong code with '-O -inline' but correct with '-O')
 $(LI $(BUGZILLA 15861): [REG 2.069] Wrong double-to-string conversion with -O)
 $(LI $(BUGZILLA 15897): private base class method not seen through derived class)
@@ -20,31 +19,22 @@ $(LI $(BUGZILLA 16022): [REG2.069] dmd assertion failure due to misplaced comma 
 $(LI $(BUGZILLA 16027): Wrong result of double multiplication)
 $(LI $(BUGZILLA 16080): [REG2.071.0] Internal error: backend\cgobj.c 3406 when building static library)
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 15856): Confusing error message with -transition=checkimports)
-)
 )
 $(BUGSTITLE DMD Compiler enhancements,
 
-$(P
 $(LI $(BUGZILLA 15402): allow private access to package symbols)
-)
 )
 $(BUGSTITLE Phobos regressions,
 
-$(P
 $(LI $(BUGZILLA 15914): [REG 2.071] getopt doesn't accept anymore a character for a bool option)
 $(LI $(BUGZILLA 15941): [REG v2.069] rbtree no longer supports classes)
 )
-)
 $(BUGSTITLE Druntime regressions,
 
-$(P
 $(LI $(BUGZILLA 15911): undefined __Unwind_GetIPInfo for x86_64)
-)
 )
 
 )

--- a/changelog/2.071.2_pre.dd
+++ b/changelog/2.071.2_pre.dd
@@ -8,7 +8,6 @@ $(BR)$(BIG List of all bug fixes and enhancements in D $(VER):)
 
 $(BUGSTITLE DMD Compiler regressions,
 
-$(P
 $(LI $(BUGZILLA 15780): [REG2.069] CTFE foreach fails with tuple)
 $(LI $(BUGZILLA 15900): [REG 2.071] $(LPAREN)Import deprecation$(RPAREN) Public import ignored when using fully qualified name)
 $(LI $(BUGZILLA 15907): Unjustified "is not visible from module" deprecation warning when using getMember trait)
@@ -20,12 +19,9 @@ $(LI $(BUGZILLA 16316): [REG 2.071] $(LPAREN)Import deprecation$(RPAREN) fully q
 $(LI $(BUGZILLA 16348): [REG 2.070.2] ICE with package visibility)
 $(LI $(BUGZILLA 16460): [REG2.071] ICE for package visibility check in function literal)
 )
-)
 $(BUGSTITLE DMD Compiler bugs,
 
-$(P
 $(LI $(BUGZILLA 15857): incorrect checkimports mismatch for overload sets)
-)
 )
 
 )


### PR DESCRIPTION
Done by:

```
rdmd '--eval=
foreach (f; dirEntries(".", "2.*.dd", SpanMode.shallow))
{
    auto replaced = readText(f)
        .replaceAll(regex(`\$\(P\n((\$\(LI[^\n]+\n)+)\)\n`), "$1");
    std.file.write(f, replaced);
}'
```