### PR TITLE
Added druntime's runtime gc switch to documentation

### DIFF
--- a/spec/garbage.dd
+++ b/spec/garbage.dd
@@ -398,6 +398,7 @@ $(H2 $(LNAME2 gc_config, Configuring the Garbage Collector))
         $(UL
         $(LI disable:0|1    - start disabled)
         $(LI profile:0|1    - enable profiling with summary when terminating program)
+        $(LI gc:conservative|manual - select gc implementation (default = conservative))
         $(LI initReserve:N  - initial memory to reserve in MB)
         $(LI minPoolSize:N  - initial and minimum pool size in MB)
         $(LI maxPoolSize:N  - maximum pool size in MB)


### PR DESCRIPTION
Not sure if any other information should be added. It might be a good idea since a manual implementation was added, but I wasn't sure where to add that bit in the documentation. 