### PR TITLE
latex.ddoc: Remove breakatwhitespace

### DIFF
--- a/latex.ddoc
+++ b/latex.ddoc
@@ -428,7 +428,7 @@ DDOC=% Copyright (c) 1999-$(YEAR) by Digital Mars
 \usepackage{MnSymbol}
 \lstset{prebreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\rhookswarrow}}}
 \lstset{postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\rcurvearrowse\space}}}
-\lstset{breaklines=true,breakatwhitespace=true}
+\lstset{breaklines=true}
 \sloppy
 
 % Page size


### PR DESCRIPTION
The option seems to be gone in the 2016 edition of the listings package.

This should fix the documentation CI.