### PR TITLE
Convert HTML comments to DDoc comments

### DIFF
--- a/cpptod.dd
+++ b/cpptod.dd
@@ -2,7 +2,7 @@ Ddoc
 
 $(COMMUNITY Programming in D for C++ Programmers,
 
-<!--img src="images/cpp1.gif" border="0" align="right" alt="C++"-->
+$(COMMENT img src="images/cpp1.gif" border="0" align="right" alt="C++")
 
 $(P Every experienced C++ programmer accumulates a series of idioms and techniques
 which become second nature. Sometimes, when learning a new language, those
@@ -28,7 +28,7 @@ $(UL
 )
 
 
-<hr><!-- -------------------------------------------- -->
+<hr>$(COMMENT  -------------------------------------------- )
 
 $(H3 <a name="constructors">Defining constructors</a>)
 
@@ -56,7 +56,7 @@ class Foo
 
 	which reflects how they are used in D.
 
-<hr><!-- -------------------------------------------- -->
+<hr>$(COMMENT  -------------------------------------------- )
 $(H3 <a name="baseclass">Base class initialization</a>)
 
 $(H4 The C++ Way)
@@ -125,7 +125,7 @@ class A
 }
 ------
 
-<hr><!-- -------------------------------------------- -->
+<hr>$(COMMENT  -------------------------------------------- )
 $(H3 <a name="structcmp">Comparing structs</a>)
 
 $(H4 The C++ Way)
@@ -188,7 +188,7 @@ if (x == y)
     ...
 ------
 
-<hr><!-- -------------------------------------------- -->
+<hr>$(COMMENT  -------------------------------------------- )
 $(H3 <a name="typedefs">Creating a new typedef'd type</a>)
 
 $(H4 The C++ Way)
@@ -255,7 +255,7 @@ if (h != Handle.init)
 	default initializer can be supplied to $(REF Typedef, std,typecons)
 	as a value of the underlying type.
 
-<hr><!-- -------------------------------------------- -->
+<hr>$(COMMENT  -------------------------------------------- )
 $(H3 <a name="friends">Friends</a>)
 
 $(H4 The C++ Way)
@@ -326,7 +326,7 @@ int abc(A p) { return p.a; }
 	The $(D private) attribute prevents other modules from
 	accessing the members.
 
-<hr><!-- -------------------------------------------- -->
+<hr>$(COMMENT  -------------------------------------------- )
 $(H3 <a name="operatoroverloading">Operator overloading</a>)
 
 $(H4 The C++ Way)
@@ -375,7 +375,7 @@ struct A
 	error prone. Far less code needs to be written to accomplish
 	the same effect.)
 
-<hr><!-- -------------------------------------------- -->
+<hr>$(COMMENT  -------------------------------------------- )
 $(H3 <a name="usingdeclaration">Namespace using declarations</a>)
 
 $(H4 The C++ Way)
@@ -410,7 +410,7 @@ alias x = foo.x;
 	declaration. Alias can be used to rename symbols, refer to
 	template members, refer to nested class types, etc.
 
-<hr><!-- -------------------------------------------- -->
+<hr>$(COMMENT  -------------------------------------------- )
 $(H3 <a name="raii">RAII (Resource Acquisition Is Initialization)</a>)
 
 $(H4 The C++ Way)
@@ -475,7 +475,7 @@ mechanism that lets you run arbitrary statements whenever leaving the current
 scope.)
 
 
-<hr><!-- -------------------------------------------- -->
+<hr>$(COMMENT  -------------------------------------------- )
 $(H3 <a name="properties">Properties</a>)
 
 $(H4 The C++ Way)
@@ -542,7 +542,7 @@ int x = a.property;
 	It's also a way to have interface classes, which do not have
 	data fields, behave syntactically as if they did.
 
-<hr><!-- -------------------------------------------- -->
+<hr>$(COMMENT  -------------------------------------------- )
 $(H3 <a name="recursivetemplates">Recursive Templates</a>)
 
 $(H4 The C++ Way)
@@ -593,7 +593,7 @@ void test()
 }
 ------
 
-<hr><!-- -------------------------------------------- -->
+<hr>$(COMMENT  -------------------------------------------- )
 
 $(H3 <a name="metatemplates">Meta Templates</a>)
 
@@ -745,7 +745,7 @@ int main()
 }
 ------
 
-<hr><!-- -------------------------------------------- -->
+<hr>$(COMMENT  -------------------------------------------- )
 
 $(H3 <a name="typetraits">Type Traits</a>)
 

--- a/ctod.dd
+++ b/ctod.dd
@@ -6,7 +6,7 @@ $(COMMENT $(BLOCKQUOTE_BY William Nerdspeare,
 Et tu, D? Then fall, C!
 ))
 
-<!--img src="images/c1.gif" border="0" align="right" alt="ouch!"-->
+$(COMMENT img src="images/c1.gif" border="0" align="right" alt="ouch!")
 
 $(P Every experienced C programmer accumulates a series of idioms and techniques
 which become second nature. Sometimes, when learning a new language, those
@@ -64,7 +64,7 @@ $(UL
 	$(LI $(RELATIVE_LINK2 variadic, Variadic Function Parameters))
 )
 
-<hr><!-- -------------------------------------------- -->
+<hr>$(COMMENT  -------------------------------------------- )
 $(H3 <a name="sizeof">Getting the Size of a Type</a>)
 
 $(H4 The C Way)
@@ -87,7 +87,7 @@ double.sizeof
 Foo.sizeof
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="maxmin">Get the max and min values of a type</a>)
 
 $(H4 The C Way)
@@ -111,7 +111,7 @@ ulong.max
 double.min
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="types">Primitive Types</a>)
 
 $(H4 C to D types)
@@ -143,7 +143,7 @@ $(P
 )
 $(P        Ints and unsigneds in C are of varying size; not so in D.)
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="floating">Special Floating Point Values</a>)
 
 $(H4 The C Way)
@@ -179,7 +179,7 @@ double.min_10_exp
 double.min_exp
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="modulus">Remainder after division of floating point numbers</a>)
 
 $(H4 The C Way)
@@ -202,7 +202,7 @@ double d = x % y;
 real r = x % y;
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="nans">Dealing with NANs in floating point compares</a>)
 
 $(H4 The C Way)
@@ -229,7 +229,7 @@ $(H4 The D Way)
 result = (x < y);        // false if x or y is nan
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="assert">Asserts are a necessary part of any good defensive coding strategy</a>)
 
 $(H4 The C Way)
@@ -251,7 +251,7 @@ D simply builds assert into the language:
 assert(e == 0);
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="arrayinit">Initializing all elements of an array</a>)
 
 $(H4 The C Way)
@@ -270,7 +270,7 @@ int[17] array;
 array[] = value;
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="arrayloop">Looping through an array</a>)
 
 $(H4 The C Way)
@@ -327,7 +327,7 @@ foreach (ref value; array)
     value += 42;
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="arraycreate">Creating an array of variable size</a>)
 
 $(H4 The C Way)
@@ -363,7 +363,7 @@ array.length = array.length + 1;
 array[array.length - 1] = x;
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="strcat">String Concatenation</a>)
 
 $(H4 The C Way)
@@ -418,7 +418,7 @@ s = s1 ~ s2;
 s ~= "hello";
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="printf">Formatted printing</a>)
 
 $(H4 The C Way)
@@ -447,7 +447,7 @@ import std.stdio;
 writefln("Calling all cars %s times!", ntimes);
 -----------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="forwardfunc">Forward referencing functions</a>)
 
 $(H4 The C Way)
@@ -490,7 +490,7 @@ void forwardfunc()
 }
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="funcvoid">Functions that have no arguments</a>)
 
 $(H4 The C Way)
@@ -512,7 +512,7 @@ void foo()
 }
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="labeledbreak">Labeled break and continue statements</a>)
 
 $(H4 The C Way)
@@ -559,7 +559,7 @@ Louter:
     // break Louter goes here
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="goto">Goto Statements</a>)
 
 $(H4 The C Way)
@@ -577,7 +577,7 @@ $(H4 The D Way)
        programmers who know when the rules need to be broken. So of course D
        supports goto statements.
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="tagspace">Struct tag name space</a>)
 
 $(H4 The C Way)
@@ -598,7 +598,7 @@ $(H4 The D Way)
 struct ABC { ... }
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="stringlookup">Looking up strings</a>)
 
 $(H4 The C Way)
@@ -665,7 +665,7 @@ void dostring(char[] s)
        to generate a fast lookup scheme for it, eliminating the bugs
        and time required in hand-coding one.
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="align">Setting struct member alignment</a>)
 
 $(H4 The C Way)
@@ -711,7 +711,7 @@ struct ABC
 }
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="anonymous">Anonymous Structs and Unions</a>)
 
 Sometimes, it's nice to control the layout of a struct with nested structs and unions.
@@ -771,7 +771,7 @@ f.y;
 f.p;
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="declaring">Declaring struct types and variables</a>)
 
 $(H4 The C Way)
@@ -805,7 +805,7 @@ Foo foo;
 	block {} in how semicolons are used.
 	)
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="fieldoffset">Getting the offset of a struct member</a>)
 
 $(H4 The C Way)
@@ -829,7 +829,7 @@ struct Foo { int x; int y; }
 off = Foo.y.offsetof;
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="unioninit">Union Initializations</a>)
 
 $(H4 The C Way)
@@ -855,7 +855,7 @@ U x = { a:5 };
 
        avoiding the confusion and maintenance problems.
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="structinit">Struct Initializations</a>)
 
 $(H4 The C Way)
@@ -884,7 +884,7 @@ S x = { b:3, a:5 };
 
        The meaning is clear, and there no longer is a positional dependence.
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="arrayinit2">Array Initializations</a>)
 
 $(H4 The C Way)
@@ -927,7 +927,7 @@ int[2][3] b = [ [2,3], [6,5], [3,4] ];
 int[2][3] b = [[2,6,3],[3,5,4]];            // error
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="stringlit">Escaped String Literals</a>)
 
 $(H4 The C Way)
@@ -962,7 +962,7 @@ string quotedString = `"[^\\]*(\\.[^\\]*)*"`;  // "[^\\]*(\\.[^\\]*)*"
 string hello = "hello world\n";
 ----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="ascii">ASCII versus Wide Characters</a>)
 
 $(P Modern programming requires that wchar strings be supported in an easy way, for internationalization of the programs.)
@@ -995,7 +995,7 @@ auto _utf16 = "hello"w;      // UTF-16 string
 auto _utf32 = "hello"d;      // UTF-32 string
 -----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="arrayenum">Arrays that parallel an enum</a>)
 
 $(H4 The C Way)
@@ -1021,7 +1021,7 @@ string[COLORS.max + 1] cstring =
 
 Not perfect, but better.
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="typedefs">Creating a new type with typedef</a>)
 
 $(H4 The C Way)
@@ -1117,7 +1117,7 @@ if (h != Handle.init)
 
 	There's only one name to remember: $(D Handle).
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="structcmp">Comparing structs</a>)
 
 $(H4 The C Way)
@@ -1163,7 +1163,7 @@ if (x == y)
 -----------------------------
 
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="stringcmp">Comparing strings</a>)
 
 $(H4 The C Way)
@@ -1206,7 +1206,7 @@ if (str < "betty")
 
 	which is useful for sorting/searching.
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="sort">Sorting arrays</a>)
 
 $(H4 The C Way)
@@ -1246,7 +1246,7 @@ type[] array;
 sort(array);      // sort array in-place
 -----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="strings">String literals</a>)
 
 $(H4 The C Way)
@@ -1276,7 +1276,7 @@ lines
 	So blocks of text can just be cut and pasted into the D
 	source.
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="traversal">Data Structure Traversal</a>)
 
 $(H4 The C Way)
@@ -1389,7 +1389,7 @@ Symbol symbol_membersearch(Symbol[] table, char[] id)
 }
 -----------------------------
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="ushr">Unsigned Right Shift</a>)
 
 $(H4 The C Way)
@@ -1437,7 +1437,7 @@ j = i >>> 3;
 	avoids the unsafe cast and will work as expected with any integral
 	type.
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="closures">Dynamic Closures</a>)
 
 $(H4 The C Way)
@@ -1531,7 +1531,7 @@ void func(Collection c)
 
 	eliminating the need to create irrelevant function names.
 
-<hr><!-- ============================================ -->
+<hr>$(COMMENT  ============================================ )
 $(H3 <a name="variadic">Variadic Function Parameters</a>)
 
 	The task is to write a function that takes a varying

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -1083,7 +1083,7 @@ $(H3 $(LNAME2 global_symbols, Globally Defined Symbols))
 $(GRAMMAR
 $(GNAME Symbols):
 $(MULTICOLS 4,
-    $(D $(LINK2 arrays.html#strings, string)) (alias to immutable(char)[]) <!-- This is important; people want to know these things up front. -->
+    $(D $(LINK2 arrays.html#strings, string)) (alias to immutable(char)[]) $(COMMENT This is important; people want to know these things up front.)
     $(D $(LINK2 arrays.html#strings, wstring)) (alias to immutable(wchar)[])
     $(D $(LINK2 arrays.html#strings, dstring)) (alias to immutable(dchar)[])
 


### PR DESCRIPTION
The target output is not always HTML.

Fixes HTML comments visible in the PDF.