### PR TITLE
Changelog for new cycle detection behavior switches.

### DIFF
--- a/changelog/2.072.0_pre.dd
+++ b/changelog/2.072.0_pre.dd
@@ -108,6 +108,8 @@ $(BUGSTITLE Library Changes,
     $(LI $(RELATIVE_LINK2 emplace-inner-class, `std.conv.emplace` no longer allows
     to emplace classes directly nested inside other classes without specifying a
     suitable `outer` pointer))
+    $(LI $(RELATIVE_LINK2 drt-oncycle, New druntime switch `--DRT-oncycle`
+    allows specifying what to do on cycle detection in modules.))
 )
 
 $(BR)$(BIG $(RELATIVE_LINK2 bugfix-list, List of all bug fixes and enhancements in D $(VER).))
@@ -729,6 +731,16 @@ $(BUGSTITLE Library Changes,
     auto x = inner.getX();  // this used to cause a segmentation fault;
                             // now it works as expected
     -------
+    )
+
+    $(LI $(LNAME2 drt-oncycle, New druntime switch `--DRT-oncycle` allows
+        specifying what to do on cycle detection in modules.)
+        $(P When module cycles are detected, the default behavior is to print the cycle, and abort execution. However, in many cases, the cycles are not harmful. With the new `--DRT-oncycle` switch, you can effect a different behavior when cycles are detected:
+        $(OL
+            $(LI `--DRT-oncycle=abort` This is the default behavior, and will abort, printing the cycle to `stderr` when the first cycle is detected)
+            $(LI `--DRT-oncycle=print` Print all cycles that are detected to `stderr`, but do not halt execution. Order of initialization is arbitrarily chosen based on the order the modules are in the binary)
+            $(LI `--DRT-oncycle=ignore` Do not print anything, and do not halt execution. Order of initialization is arbitrarily chosen based on the order the modules are in the binary)
+        ))
     )
 )
 )

--- a/changelog/2.072.0_pre.dd
+++ b/changelog/2.072.0_pre.dd
@@ -735,12 +735,11 @@ $(BUGSTITLE Library Changes,
 
     $(LI $(LNAME2 drt-oncycle, New druntime switch `--DRT-oncycle` allows
         specifying what to do on cycle detection in modules.)
-        $(P When module cycles are detected, the default behavior is to print the cycle, and abort execution. However, in many cases, the cycles are not harmful. With the new `--DRT-oncycle` switch, you can effect a different behavior when cycles are detected:
         $(OL
             $(LI `--DRT-oncycle=abort` This is the default behavior, and will abort, printing the cycle to `stderr` when the first cycle is detected)
             $(LI `--DRT-oncycle=print` Print all cycles that are detected to `stderr`, but do not halt execution. Order of initialization is arbitrarily chosen based on the order the modules are in the binary)
             $(LI `--DRT-oncycle=ignore` Do not print anything, and do not halt execution. Order of initialization is arbitrarily chosen based on the order the modules are in the binary)
-        ))
+        )
     )
 )
 )

--- a/changelog/2.072.0_pre.dd
+++ b/changelog/2.072.0_pre.dd
@@ -735,10 +735,14 @@ $(BUGSTITLE Library Changes,
 
     $(LI $(LNAME2 drt-oncycle, New druntime switch `--DRT-oncycle` allows
         specifying what to do on cycle detection in modules.)
-        $(OL
-            $(LI `--DRT-oncycle=abort` This is the default behavior, and will abort, printing the cycle to `stderr` when the first cycle is detected)
-            $(LI `--DRT-oncycle=print` Print all cycles that are detected to `stderr`, but do not halt execution. Order of initialization is arbitrarily chosen based on the order the modules are in the binary)
-            $(LI `--DRT-oncycle=ignore` Do not print anything, and do not halt execution. Order of initialization is arbitrarily chosen based on the order the modules are in the binary)
+        $(P When module cycles are detected, the default behavior is to print the cycle, and abort execution. However, in many cases, the cycles are not harmful. With the new `--DRT-oncycle` switch, you can effect a different behavior when cycles are detected:)
+        $(DL
+            $(DT `--DRT-oncycle=abort`)
+            $(DD This is the default behavior, and will abort, printing the cycle to `stderr` when the first cycle is detected)
+            $(DT `--DRT-oncycle=print`)
+            $(DD Print all cycles that are detected to `stderr`, but do not halt execution. Order of initialization is arbitrarily chosen based on the order the modules are in the binary)
+            $(DT `--DRT-oncycle=ignore`)
+            $(DD Do not print anything, and do not halt execution. Order of initialization is arbitrarily chosen based on the order the modules are in the binary)
         )
     )
 )

--- a/spec/module.dd
+++ b/spec/module.dd
@@ -544,13 +544,18 @@ $(H3 $(LNAME2 order_of_static_ctor, Order of Static Construction))
 
 $(H3 $(LNAME2 override_cycle_abort, Overriding Cycle Detection Abort))
 
-        $(P You can override the cyclic detection behavior using the D Runtime switch `--DRT-oncycle=...`. The following behaviors are supported:
+        $(P You can override the cyclic detection behavior using the D Runtime
+        switch `--DRT-oncycle=...` The following behaviors are supported:
         )
 
         $(OL
             $(LI `abort` The default behavior.)
-            $(LI `print` Print all cycles detected, but do not abort execution. Order of static construction is implementation defined, and not guaranteed to be valid.)
-            $(LI `ignore` Do not abort execution or print any cycles. Order of static construction is implementation defined, and not guaranteed to be valid.)
+            $(LI `print` Print all cycles detected, but do not abort execution.
+            Order of static construction is implementation defined, and not
+            guaranteed to be valid.)
+            $(LI `ignore` Do not abort execution or print any cycles. Order of
+            static construction is implementation defined, and not guaranteed
+            to be valid.)
         )
 
 $(H3 $(LNAME2 order_of_static_ctors, Order of Static Construction within a Module))

--- a/spec/module.dd
+++ b/spec/module.dd
@@ -542,6 +542,17 @@ $(H3 $(LNAME2 order_of_static_ctor, Order of Static Construction))
 	in a runtime exception.
 	)
 
+$(H3 $(LNAME2 override_cycle_abort, Overriding Cycle Detection Abort))
+
+        $(P You can override the cyclic detection behavior using the D Runtime switch `--DRT-oncycle=...`. The following behaviors are supported:
+        )
+
+        $(OL
+            $(LI `abort` The default behavior.)
+            $(LI `print` Print all cycles detected, but do not abort execution. Order of static construction is implementation defined, and not guaranteed to be valid.)
+            $(LI `ignore` Do not abort execution or print any cycles. Order of static construction is implementation defined, and not guaranteed to be valid.)
+        )
+
 $(H3 $(LNAME2 order_of_static_ctors, Order of Static Construction within a Module))
 
 	Within a module, the static construction occurs in the lexical


### PR DESCRIPTION
Also modifies spec to identify new switches.

See DRuntime pull request: https://github.com/dlang/druntime/pull/1668