### PR TITLE
Simplify your-code-here rounding decimals example

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -30,22 +30,23 @@ $(DIVC intro, $(DIV, $(DIV,
         )
         $(DIVID your-code-here-default,
 ----
-// Round floating point numbers
-import std.algorithm, std.conv, std.functional,
-    std.math, std.regex, std.stdio;
+// Find decimal numbers, then round and print them
+import std.conv, std.math, std.regex, std.stdio;
 
-alias round = pipe!(to!real, std.math.round, to!string);
-static reFloatingPoint = ctRegex!`[0-9]+\.[0-9]+`;
+// Parse a Regular Expression at compile time
+static decimalRegex = ctRegex!`[0-9]+\.[0-9]+`;
 
 void main()
 {
-    // Replace anything that looks like a real
-    // number with the rounded equivalent.
-    stdin
-        .byLine
-        .map!(l => l.replaceAll!(c => c.hit.round)
-                                (reFloatingPoint))
-        .each!writeln;
+    foreach (line; stdin.byLine())
+    {
+        foreach (match; line.matchAll(decimalRegex))
+        {
+            // Parse matching text
+            real r = match.hit.to!real();
+            r.round().writeln();
+        }
+    }
 }
 ----
 )


### PR DESCRIPTION
* Print rounded numbers only, don't replace them.
* Use foreach instead of `map`, `each`.

The current example is a bit awkward for D newbies to decipher. Here we are showing D's `ctRegex`; dropping the functional `map` and lambdas makes this more universally understood. Using `matchAll` rather than `replaceAll` makes the example a bit simpler too.

(NG thread: http://forum.dlang.org/post/gifkdawcsfwfwyxxhqhh@forum.dlang.org).