### PR TITLE
Qualify C-style memory allocation functions as pure

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -173,7 +173,7 @@ int foo();
 
 $(H4 $(LNAME2 pure-functions, Pure Functions))
 
-        $(P Pure functions are functions which cannot access global or static, mutable
+        $(P Pure functions are functions which cannot access neither global nor static mutable
         state save through their arguments.
     This enables optimizations based on the fact that a pure function may at most mutate state
     reachable through its parameters.
@@ -192,7 +192,7 @@ $(H4 $(LNAME2 pure-functions, Pure Functions))
         $(P As a concession to practicality, a pure function can:)
 
         $(UL
-        $(LI allocate memory via a $(GLINK2 expression, NewExpression))
+        $(LI allocate memory via a $(GLINK2 expression, NewExpression) or via C-style memory (re)allocation functions such as $(D malloc()) and $(D realloc()))
         $(LI terminate the program)
         $(LI read and write the floating point exception flags)
         $(LI read and write the floating point mode flags, as long as those flags


### PR DESCRIPTION
Update according to https://github.com/dlang/druntime/pull/1683

I'm not sure if this is enough or if I should update the general formulation of purity aswell.

Made an existing statement more clear via a neither-nor formulation.