### PR TITLE
Improvement for drt-oncycle library change description

### DIFF
--- a/changelog/2.072.0.dd
+++ b/changelog/2.072.0.dd
@@ -404,6 +404,18 @@ $(BUGSTITLE Library Changes,
             $(DT `--DRT-oncycle=ignore`)
             $(DD Do not print anything, and do not halt execution. Order of initialization is arbitrarily chosen based on the order the modules are in the binary)
         )
+        ($P As there were improvements of the cycle detection algorithm implemented within the scope of this release,
+            previously undetected (even harmless) module dependency cycles may start to abort program execution
+            or program may malfunction due to changed call order of module static construction/destruction.
+            In order to preserve the program behaviour without the need to specify `--DRT-oncycle` command line argument,
+            it is possible to instruct the linker by declaring the following array in the source code:)
+            
+            ---
+            extern(C) __gshared string[] rt_options = [ "oncycle=ignore" ];
+            ---
+            
+        ($P For more information, please consult the D language specification, section Overriding Cycle Detection Abort in chapter 4
+            and chapter 28.7 Configuring the Garbage Collector.)        
     )
 
     $(LI $(LNAME2 std-digest-murmurhash, Implementation of `std.digest.murmurhash`).


### PR DESCRIPTION
I added a useful information for the drt-oncycle topic with reference to the D language specification. When upgrading my project to DMD 2.072 I had a hard time preserving the application from the user perspective. So having a reference on how to instruct linker to ignore (harmless) module dependecy cycles in order to avoid additional command line arguments is valuable in this change description.