### PR TITLE
Remove all mentions of -transition=safe from changelog

### DIFF
--- a/changelog/2.072.0.dd
+++ b/changelog/2.072.0.dd
@@ -20,7 +20,6 @@ $(BUGSTITLE Language Changes,
 
 $(BUGSTITLE Compiler Changes,
     $(LI $(RELATIVE_LINK2 iteration_closure, `opApply` now conservatively allocates a closure unless marked `scope`))
-    $(LI $(RELATIVE_LINK2 dash_safe, Add `-transition=safe` switch to enable additional `@safe` checks.))
     $(LI $(RELATIVE_LINK2 native_tls_osx, Native TLS on OS X 64 bit.))
     $(LI $(RELATIVE_LINK2 deferred_alias, Analysis for aliases in imported modules is deferred.))
     $(LI $(RELATIVE_LINK2 __FILE_FULL_PATH__, Special keyword replaced by the source file's absolute file name.))
@@ -250,42 +249,6 @@ $(BUGSTITLE Language Changes,
 )
 
 $(BUGSTITLE Compiler Changes,
-    $(LI $(LNAME2 iteration_closure, `opApply` now conservatively allocates a closure unless marked `scope`)
-
-    $(P This breaking change was required to fix bug with `@safe` violation: $(BUGZILLA 16193).)
-
-    $(P To list all places where closure may be allocated after the change, use `-transition=safe`
-        compiler switch.)
-
-    $(P Example:)
-
-        ---
-        struct S1 {
-            int opApply(int delegate(int) dg);
-        }
-
-        struct S2 {
-            int opApply(scope int delegate(int) dg);
-        }
-
-        void foo() {
-            foreach(i; S1.init) { // will allocate closure
-            }
-            foreach(i; S2.init) { // won't allocate closure
-            }
-        }
-        ---
-    )
-
-    $(LI $(LNAME2 dash_safe, Add `-transition=safe` switch to enable additional `@safe` checks.)
-	$(P Enables enhanced `@safe` checking, which will break some existing code.)
-	$(UL
-	$(LI Prevents dereferencing `array.ptr` because that bypasses array bounds check.)
-	$(LI Assumes opApply delegate parameter escapes unless marked `scope`. Escaping
-          delegates often require a GC allocated closure.)
-	)
-    )
-
     $(LI $(LNAME2 native_tls_osx, Native TLS on OS X 64 bit.)
 
         $(P


### PR DESCRIPTION
It won't be present in 2.072.0 in any form (2.072.1 will remove last traces
of it), thus mention in the changelog only spreads confusion.

See also https://github.com/dlang/dmd/pull/6251