### PR TITLE
put auto-highlights in <code> tags

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1217,6 +1217,16 @@ These classes come from prettify.js:
 .cm-s-eclipse span.cm-link {color: #219;}
 
 
+.ddoc_keyword
+{
+    font-weight: bold;
+}
+
+.ddoc_param
+{
+    font-style: italic;
+}
+
 /* Focal symbol that is being documented */
 .d_psymbol, .ddoc_psymbol
 {

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -123,7 +123,9 @@ DDOC_PARAM_ID  = <td class="param_id">$0</td>
 DDOC_PARAM_DESC  = <td class="param_desc">$0</td>
 DDOC_PARAMS    = $(DDOCKEYVAL Parameters, <table class="params">$0</table>)
 DDOC_BLANKLINE	=
-DDOC_PSYMBOL = $(ADEF $0)$(SPANC ddoc_psymbol, $0)
+DDOC_KEYWORD = $(TC code, ddoc_keyword, $0)
+DDOC_PARAM = $(TC code, ddoc_param, $0)
+DDOC_PSYMBOL = $(ADEF $0)$(TC code, ddoc_psymbol, $0)
 DDOC_ANCHOR = $(ADEF .$1)$(DIVCID quickindex, quickindex.$1, )
 DDOC_DECL  = $(TC dt, d_decl, $(DIV, $0))
 DDOC_UNDEFINED_MACRO = $(DDOC_COMMENT UNDEFINED MACRO: "$1")


### PR DESCRIPTION
Makes them visually consistent with other code (monospaced font).
Carries more meaning that can be picked up by screen readers and such.