### PR TITLE
Move changelog to a folder and use single file entries

### DIFF
--- a/language-changelog/README.md
+++ b/language-changelog/README.md
@@ -1,0 +1,34 @@
+How to add a new changelog entry to the pending changelog?
+==========================================================
+
+This will get copied to dlang.org and cleared when master gets
+merged into stable prior to a new release.
+
+```
+My fancy new feature X
+
+A long description of the new feature.
+-------
+import std.range;
+import std.algorithm.comparison;
+
+assert([1, 2, 3, 4, 5].padLeft(0, 7).equal([0, 0, 1, 2, 3, 4, 5]));
+
+assert("Hello World!".padRight('!', 15).equal("Hello World!!!!"));
+-------
+```
+
+The title can't contain links (it's already one).
+For more infos, see the [Ddoc spec](https://dlang.org/spec/ddoc.html).
+
+Preview changes
+---------------
+
+If you have cloned the [tools](https://github.com/dlang/tools) and [dlang.org](https://github.com/dlang/dlang.org) repo),
+you can preview the changelog:
+
+```
+../tools/changed.d -o ../dlang.org/changelog/pending.dd && make -C ../dlang.org -f posix.mak html
+```
+
+and then open `../dlang.org/web/changelog/pending.html` with your favorite browser.

--- a/language-changelog/README.md
+++ b/language-changelog/README.md
@@ -25,10 +25,8 @@ Preview changes
 ---------------
 
 If you have cloned the [tools](https://github.com/dlang/tools) and [dlang.org](https://github.com/dlang/dlang.org) repo),
-you can preview the changelog:
+you can preview the changelog with:
 
 ```
-../tools/changed.d -o ../dlang.org/changelog/pending.dd && make -C ../dlang.org -f posix.mak html
+make -C ../dlang.org -f posix.mak pending_changelog
 ```
-
-and then open `../dlang.org/web/changelog/pending.html` with your favorite browser.

--- a/language-changelog/mcpu_avx.dd
+++ b/language-changelog/mcpu_avx.dd
@@ -1,0 +1,1 @@
+Add `D_AVX` predefined version when $(TT -mcpu=avx) is used.

--- a/posix.mak
+++ b/posix.mak
@@ -521,4 +521,11 @@ test:
 	@echo "Searching for trailing whitespace"
 	if [[ $$(find . -type f -name "*.dd" -exec egrep -l " +$$" {} \;) ]] ;  then $$(exit 1); fi
 
+################################################################################
+# Changelog generation
+################################################################################
+
+pending_changelog:
+	@echo "This command will be available soon."
+
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)


### PR DESCRIPTION
Single file allow to enforce that every PR comes with a changelog as one can't run into a merge conflicts.

For DMD the idea was to move the language changelog directly to dlang.org, s.t. the DMD repo only contains the compiler changes.

For more details, see dlang/tools#186