### PR TITLE
Make ddox the default doc for dlang.org menu

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -238,7 +238,7 @@ $(SUBMENU_MANUAL
 NAVIGATION_DOCUMENTATION=
 $(SUBMENU_MANUAL
     $(SUBMENU_LINK $(ROOT_DIR)spec/spec.html, Language Reference)
-    $(SUBMENU_LINK $(ROOT_DIR)phobos/index.html, Library Reference)
+    $(SUBMENU_LINK $(ROOT_DIR)library/index.html, Library Reference)
     $(SUBMENU_LINK $(ROOT_DIR)dmd.html, Command-line Reference)
     $(SUBMENU_LINK_DIVIDER $(ROOT_DIR)comparison.html, Feature Overview)
     $(SUBMENU_LINK $(ROOT_DIR)articles.html, Articles)

--- a/std_navbar-prerelease.ddoc
+++ b/std_navbar-prerelease.ddoc
@@ -4,7 +4,6 @@ $(SUBNAV_TEMPLATE
         $(H2 Library Reference)
         $(P $(SPANC smallprint, pre-release version $(SPANC separator, $(BR))
             switch to $(LINK2 ../phobos/index.html, $(LATEST)). $(BR)
-            $(LINK2 ../library-prerelease/index.html, preview) beta library reference.
             )
         )
         $(P $(LINK2 index.html, overview))

--- a/std_navbar-release.ddoc
+++ b/std_navbar-release.ddoc
@@ -5,7 +5,6 @@ $(SUBNAV_TEMPLATE
         $(P $(SPANC smallprint, version $(LATEST) $(SPANC separator, $(BR))
             switch to
             $(LINK2 ../phobos-prerelease/index.html, pre-release). $(BR)
-            $(LINK2 ../library/index.html, preview) beta library reference.
             )
         )
         $(P $(LINK2 index.html, overview))


### PR DESCRIPTION
Starting with step 1 as outlined [here](http://forum.dlang.org/post/uoknnsdkrkuauzyrqnfm@forum.dlang.org)

> 1. /library/ is promoted as the primary Phobos documentation in the site navigation.
> 2. /phobos/ is removed from search indexing.
> 3. /phobos/ is removed from site navigation.
> 4. /phobos/ is removed.

CC @s-ludwig

However I would love to love see the Disqus problem sorted out before. So let me summarize the three main options proposed so far:

### Option 1: self-hosted commenting

I share a similar opinion as @MartinNowak:

> I'd want to disable or replace discourse before we make it our official documentation. We could easily self-host some commenting functionality if deemed necessary, but adding an unmaintained communication channel isn't the best idea IMO.

### Option 2: use DFeed 

(from @CyberShadow)

> I think it wouldn't be too hard to embed DFeed as a comment system. What do you think? Then anyone can subscribe to new comments through the usual means. The same solution can be applied to the blog.
> I understand that the current bottleneck is someone adding new groups to the NNTP server. Can that be resolved?

### Option 3: remove Disqus

> Yeah, I'm not likely to ever use disqus but if it went through the same n.g./mailing list interface at least I'd consider talking at times (though I personally think comments in documentation should typically be used to just go back and improve the documentation rather than making readers actually wade through the out-of-date and repetitive comment thread...)

Note that removing Disqus has been [attempted this summer](https://github.com/dlang/dlang.org/pull/1363), which was reverted as @MartinNowak wasn't available at this time. 