### PR TITLE
Improve runnable examples

### DIFF
--- a/js/run.js
+++ b/js/run.js
@@ -478,7 +478,10 @@ function setupTextarea(el, opts)
             argsDiv.css('display', 'none');
         }
         outputDiv.css('display', 'none');
-        parent.parent().children("div.d_code").css('display', 'none');
+        if (!opts.keepCode)
+        {
+          parent.parent().children("div.d_code").css('display', 'none');
+        }
         code.css('display', 'none');
     };
 
@@ -525,7 +528,7 @@ function setupTextarea(el, opts)
         resetBtn.css('display', 'inline-block');
         $(this).attr("disabled", true);
         hideAllWindows();
-        output.css('height', height(31));
+        output.css('height', opts.outputHeight || height(31));
         outputDiv.css('display', 'block');
         outputTitle.text("Application output");
         output.html("Running...");
@@ -547,6 +550,7 @@ function setupTextarea(el, opts)
             data: data,
             success: function(data)
             {
+                data.defaultOutput = opts.defaultOutput;
                 parseOutput(data, output, outputTitle);
                 runBtn.attr("disabled", false);
             },

--- a/js/run_examples.js
+++ b/js/run_examples.js
@@ -80,8 +80,8 @@ $(document).ready(function()
                     + '</div>'
                     + '<div class="d_run_code" style="display: block">'
                         + '<textarea class="d_code" style="display: none;"></textarea>'
-                        + '<div class="d_code_output"><span class="d_code_title">Application output</span><br><textarea class="d_code_output" readonly>Running...</textarea>'
                     + '</div>'
+                    + '<div class="d_code_output"><span class="d_code_title">Application output</span><br><textarea class="d_code_output" readonly>Running...</textarea>'
                 + '</div>'
         );
     });
@@ -89,8 +89,16 @@ $(document).ready(function()
     $('textarea[class=d_code]').each(function(index) {
         var parent = $(this).parent();
         var btnParent = parent.parent().children(".d_example_buttons");
-        var outputDiv = parent.children("div.d_code_output");
-        setupTextarea(this,  {parent: btnParent, outputDiv: outputDiv,
-            stdin: false, args: false, transformOutput: wrapIntoMain});
+        var outputDiv = parent.parent().children(".d_code_output");
+      setupTextarea(this,  {
+        parent: btnParent,
+        outputDiv: outputDiv,
+        stdin: false,
+        args: false,
+        transformOutput: wrapIntoMain,
+        defaultOutput: "All tests passed",
+        keepCode: true,
+        outputHeight: "auto"
+      });
     });
 });


### PR DESCRIPTION
(incorporating the [forum feedback](http://forum.dlang.org/thread/o3969r$2qed$1@digitalmars.com))

- Put outputbox below the example
- Don't hide code during compilation
- Use "auto" width for the output box
- Use "All tests passed" as default output text