### PR TITLE
Improve runnable examples (v2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1638,7 +1638,7 @@ div.d_code_output, div.d_code_stdin, div.d_code_args, div.d_code_unittest
 .d_code_title {font-weight: bold;padding: 5px;}
 
 .CodeMirror-wrap {padding: 3px;}
-.CodeMirror {line-height: normal; border: 1px solid #CCC; background: #FCFCFC; }
+.CodeMirror {line-height: normal; border: 1px solid #CCC; background: #FCFCFC; height: auto}
 .cm-s-eclipse .CodeMirror-matchingbracket {border:1px solid grey;color:black !important;}
 
 input.runButton, input.resetButton, input.argsButton, input.inputButton, input.editButton

--- a/js/run.js
+++ b/js/run.js
@@ -454,6 +454,8 @@ function setupTextarea(el, opts)
     var code = $(editor.getWrapperElement());
     code.css('display', 'none');
 
+    var plainSourceCode = parent.parent().children("div.d_code");
+
     var output = outputDiv.children("textarea.d_code_output");
     var outputTitle = outputDiv.children("span.d_code_title");
     if (opts.args) {
@@ -469,8 +471,9 @@ function setupTextarea(el, opts)
         var orgStdin = stdin.val();
     }
 
-    var hideAllWindows = function()
+    var hideAllWindows = function(args)
     {
+        args = args || {};
         if (opts.stdin) {
             stdinDiv.css('display', 'none');
         }
@@ -478,11 +481,12 @@ function setupTextarea(el, opts)
             argsDiv.css('display', 'none');
         }
         outputDiv.css('display', 'none');
-        if (!opts.keepCode)
-        {
-          parent.parent().children("div.d_code").css('display', 'none');
+        if (!args.keepPlainSourceCode) {
+          plainSourceCode.css('display', 'none');
         }
-        code.css('display', 'none');
+        if (!args.keepCode) {
+          code.css('display', 'none');
+        }
     };
 
     if (opts.args) {
@@ -522,12 +526,18 @@ function setupTextarea(el, opts)
             stdin.val(orgStdin);
         }
         hideAllWindows();
-        parent.parent().children("div.d_code").css('display', 'block');
+        plainSourceCode.css('display', 'block');
     });
     runBtn.click(function(){
         resetBtn.css('display', 'inline-block');
         $(this).attr("disabled", true);
-        hideAllWindows();
+        var args = {};
+        // check what boxes are currently open
+        if (opts.keepCode) {
+          args.keepCode = code.is(":visible");
+          args.keepPlainSourceCode = plainSourceCode.is(":visible");
+        }
+        hideAllWindows(args);
         output.css('height', opts.outputHeight || height(31));
         outputDiv.css('display', 'block');
         outputTitle.text("Application output");


### PR DESCRIPTION
Two more small improvements:

-  Keep the correct editor/source code open if it's open on evalation
- use automatic height for CodeMirror boxes

The second commit (use automatic height for CodeMirror boxes) is important as it affects the main example as well. Hence, here are two examples of how its result:

### examples before:

![image](https://cloud.githubusercontent.com/assets/4370550/21381437/a438e30c-c75b-11e6-8038-d037ed3466e2.png)

(https://dlang.org/phobos-prerelease/std_algorithm_comparison.html#.among)

### examples after:

![image](https://cloud.githubusercontent.com/assets/4370550/21381428/8ef70352-c75b-11e6-8566-9a03be27ef21.png)

dlang.org frontpage before:
------------------------

![image](https://cloud.githubusercontent.com/assets/4370550/21381387/48bdd56e-c75b-11e6-8301-2d56c82ee598.png)


dlang.org frontpage after:
---------------------

![image](https://cloud.githubusercontent.com/assets/4370550/21381413/7b31acb4-c75b-11e6-980d-7a2877b373ec.png)


See also the [CodeMirror docs](https://codemirror.net/demo/resize.html).