### PR TITLE
DStyle: Constraints on declarations should have the same indentation level

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -322,6 +322,12 @@ else if (…)
              (e.g. `pure nothrow @nogc @safe unittest { ... }`)
              to ensure the existence of attributes on the templated function.)
     )
+    $(LI Constraints on declarations should have the same indentation level as
+         their declaration:)
+-------------------------------
+void foo(R)
+if (R == 1)
+-------------------------------
 
 $(P
     We are not necessarily recommending that all code follow these rules.


### PR DESCRIPTION
Based on this discussion: https://github.com/dlang/phobos/pull/4964#discussion_r93830907