### PR TITLE
Ddox: Show exact source code links for multiple declarations

### DIFF
--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -164,7 +164,7 @@ html(lang='en-US')
                 - project = "druntime", path_prefix = "src/";
               - else
                 - project = "phobos", path_prefix = "";
-              - if (info.docGroups.length == 1)
+              - if (info.docGroups.length >= 1)
                 - if (auto decl = cast(Declaration)info.docGroups[0].members[0]) line_suffix = "#L"~to!string(decl.line);
               - if (info.node.module_.isPackageModule)
                 - filename = replace(modname, ".", "/") ~ "/package.d";


### PR DESCRIPTION
If there are multiple declarations, the source code link should go to the first declaration - not to the header of the file. 

Example e.g.: http://dlang.org/library/std/algorithm/comparison/among.html