### PR TITLE
download and changelog for 2.072.2-b2

### DIFF
--- a/changelog/2.072.2_pre.dd
+++ b/changelog/2.072.2_pre.dd
@@ -4,22 +4,48 @@ $(CHANGELOG_NAV_LAST 2.072.1)
 
 $(VERSION Dec 30, 2016, =================================================,
 
-$(BR)$(BIG List of all bug fixes and enhancements in D $(VER):)
+$(BUGSTITLE Library Changes,
+    $(LI $(RELATIVE_LINK2 drt-cycle-deprecated, The --DRT-cycle=deprecate runtime switch was added.))
+)
+
+$(BR)$(BIG $(RELATIVE_LINK2 bugfix-list, List of all bug fixes and enhancements in D $(VER).))
+
+$(HR)
+
+$(BUGSTITLE Library Changes,
+
+    $(LI $(LNAME2 drt-cycle-deprecated, The --DRT-cycle=deprecate runtime switch was added.)
+
+        $(P As a follow-up to the fixed module cycle detection in
+            2.072.0, the $(LINK2 $(ROOT_DIR)spec/module.html#override_cycle_abort,--DRT-oncycle)
+            runtime switch got a deprecate option.
+            It was made default, instead of --DRT-oncycle=abort, in
+            order to deprecate code that was relying on previously
+            undected module constructor cycles.
+        )
+    )
+)
+
+$(BR)$(BIG $(LNAME2 bugfix-list, List of all bug fixes and enhancements in D $(VER):))
 
 $(BUGSTITLE DMD Compiler regressions,
 
 $(LI $(BUGZILLA 16747): [Reg 2.072] Cannot have stack allocated classes in @safe code)
+$(LI $(BUGZILLA 16980): [REG2.072.0] wrong interface called)
 $(LI $(BUGZILLA 17029): [Reg 2.072] scope variable may not be returned)
 )
 $(BUGSTITLE Phobos regressions,
 
 $(LI $(BUGZILLA 16667): [REG] dub test fails on std.conv after upgrade to dmd 2.072.0)
-$(LI $(BUGZILLA 16211): Update: cycles previously undetected will print a deprecation message instead of failing)
 )
 $(BUGSTITLE Phobos bugs,
 
 $(LI $(BUGZILLA 9378): std.internal.digest.sha_SSE3 breaks if compiled with PIC)
 $(LI $(BUGZILLA 16794): dmd not working on Ubuntu 16.10 because of default PIE linking)
+)
+$(BUGSTITLE Druntime regressions,
+
+$(LI $(BUGZILLA 16974): [REG2.068] Equal associative arrays with associative array keys are considered unequal)
 )
 $(BUGSTITLE dlang.org bugs,
 

--- a/download.dd
+++ b/download.dd
@@ -170,7 +170,7 @@ Macros:
     _=BETA=$(COMMENT $0)
     BETA=$0
     B_DMDV2=2.072.2
-    B_SUFFIX=b1
+    B_SUFFIX=b2
 
 	DEB32=$(DLSITE dmd_$(DMDV2)-0_i386.deb)
 	DEB64=$(DLSITE dmd_$(DMDV2)-0_amd64.deb)


### PR DESCRIPTION
- moved the manually added Bugzilla entry (the list is generated automatically
  from the commits) to a proper changelog entry, also see #1531.