### PR TITLE
Ddox: support assert to writeln rewrite

### DIFF
--- a/js/run.js
+++ b/js/run.js
@@ -576,6 +576,7 @@ function setupTextarea(el, opts)
             }
         });
     });
+    return editor;
 };
 
 

--- a/js/run_examples.js
+++ b/js/run_examples.js
@@ -8,7 +8,7 @@
 
 // turns asserts into writeln
 function reformatExample(code) {
-    return code.replace(/(<span class="d_keyword">assert<\/span>\((.*)==(.*)\);)+/g, function(match, text, left, right) {
+    return code.replace(/(<span class="(?:d_keyword|kwd)">assert<\/span>(?:<span class="pun">)?\((.*)==(.*)\);)+/g, function(match, text, left, right) {
         return "writeln(" + left.trim() + "); "
             + "<span class='d_comment'>// " + right.trim() + "</span>";
     });

--- a/js/run_examples.js
+++ b/js/run_examples.js
@@ -90,15 +90,15 @@ $(document).ready(function()
         var parent = $(this).parent();
         var btnParent = parent.parent().children(".d_example_buttons");
         var outputDiv = parent.parent().children(".d_code_output");
-      setupTextarea(this,  {
-        parent: btnParent,
-        outputDiv: outputDiv,
-        stdin: false,
-        args: false,
-        transformOutput: wrapIntoMain,
-        defaultOutput: "All tests passed",
-        keepCode: true,
-        outputHeight: "auto"
-      });
+        var editor = setupTextarea(this,  {
+          parent: btnParent,
+          outputDiv: outputDiv,
+          stdin: false,
+          args: false,
+          transformOutput: wrapIntoMain,
+          defaultOutput: "All tests passed",
+          keepCode: true,
+          outputHeight: "auto"
+        });
     });
 });


### PR DESCRIPTION
There's already some very naive support to rewrite `assert`'s statements to `writeln` function calls for the ddoc build.
This just adds extend the RegExp for `ddox`.

This approach itself is pretty limited and of course it would be better to do this during compilation (e.g. as a plugin for ddox) and not via RegExp in Js. Moreover, the RegExp itself might catch some false positives and also doesn't support other common operations like `equal` or a plain assert.

So this is intended as temporary solution until someone has more time to invest into a proper solution.

Btw another reason which makes this complicated is that there are two code boxes (the editor and `code` highlighted produced by ddoc/ddox) and one can only edit the plain source code of the former. At the moment "reset" hides the editor and shows the original `code` from ddoc/ddox, but one could argue that there's no point in keeping this `code` box generated by ddoc/ddox