### PR TITLE
Use runnable examples for released docs

### DIFF
--- a/js/run_examples.js
+++ b/js/run_examples.js
@@ -44,10 +44,6 @@ $(document).ready(function()
     if (!$('body').hasClass("std"))
         return;
 
-    // only enable for pre-release version
-    if (location.pathname.indexOf("prerelease") < 0)
-        return;
-
     // ignore not yet compatible modules
     // copied from Phobos posix.mak
     var ignoredModulesList = "allocator/allocator_list.d,allocator/building_blocks/allocator_list.d,allocator/building_blocks/free_list.d,allocator/building_blocks/quantizer,allocator/building_blocks/quantizer,allocator/building_blocks/stats_collector.d,base64.d,bitmanip.d,concurrency.d,conv.d,csv.d,datetime.d,digest/hmac.d,digest/sha.d,file.d,index.d,isemail.d,logger/core.d,logger/nulllogger.d,math.d,ndslice/selection.d,ndslice/slice.d,numeric.d,stdio.d,traits.d,typecons.d,uni.d,utf.d,uuid.d".split(",")


### PR DESCRIPTION
With 2.073 released we could flip the switch and enable the runnable examples for the released doc pages.

Would be nice to get #1550 and #1551 as well.