### PR TITLE
posix.mak: Work around DMD bug manifesting on certain filesystems

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -455,7 +455,7 @@ docs.json : ${DMD_REL} ${DRUNTIME_DIR}-${LATEST} \
 	find ${DRUNTIME_DIR}-${LATEST}/src -name '*.d' | \
 	  sed -e /unittest.d/d -e /gcstub/d > .release-files.txt
 	find ${PHOBOS_DIR}-${LATEST} -name '*.d' | \
-	  sed -e /unittest.d/d -e /windows/d >> .release-files.txt
+	  sed -e /unittest.d/d -e /windows/d | sort >> .release-files.txt
 	${DMD_REL} -c -o- -version=CoreDdoc -version=StdDdoc -Df.release-dummy.html \
 	  -Xfdocs.json -I${PHOBOS_DIR}-${LATEST} @.release-files.txt
 	${DPL_DOCS} filter docs.json --min-protection=Protected \


### PR DESCRIPTION
If the files are passed to DMD in a different order, Phobos fails to
compile. For example, this happens when the Phobos source code is on a
tmpfs, but not on ext4 or btrfs. Work around this by sorting the
Phobos source file list before passing in to DMD.