### PR TITLE
Update FAQ: Shared does not cause memory barriers

### DIFF
--- a/faq.dd
+++ b/faq.dd
@@ -118,8 +118,7 @@ $(ITEM shared_synchronized, What does shared have to do with synchronization?)
 
 $(ITEM shared_memory_barriers, What does shared have to do with memory barriers?)
 
-	$(P Reading/writing shared data emits memory barriers to ensure sequential consistency (not
-	implemented).
+	$(Currently the compiler does not insert memory barriers around shared variables.
 	)
 
 $(ITEM casting_to_shared, What are the semantics of casting FROM unshared TO shared?)


### PR DESCRIPTION
There's been a question about this in D.learn recently:
http://forum.dlang.org/post/apoqhsoqksuwieklcnjj@forum.dlang.org

If I remember correctly the final decision from 2012 was that shared variables do not automatically cause any memory barriers, but we never documented this:
http://forum.dlang.org/post/k7pn19$bre$1@digitalmars.com
http://forum.dlang.org/post/mailman.1904.1352922666.5162.digitalmars-d@puremagic.com

ping @WalterBright @andralex