### PR TITLE
Enable runnable examples on releases docs

### DIFF
--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -223,8 +223,7 @@ html(lang='en-US')
     script(type='text/javascript', src='#{root_dir}js/codemirror-compressed.js')
     |     
     script(type='text/javascript', src='#{root_dir}js/run.js')
-    - if (!haveVersion)
-      script(type='text/javascript', src='#{root_dir}js/run_examples.js')
+    script(type='text/javascript', src='#{root_dir}js/run_examples.js')
     script(type='text/javascript', src='#{root_dir}js/dlang.js')
     script(type='text/javascript', src='#{root_dir}js/listanchors.js')
     script(type='text/javascript').

--- a/std_navbar-release.ddoc
+++ b/std_navbar-release.ddoc
@@ -13,3 +13,4 @@ $(SUBNAV_TEMPLATE
     $(UL $(MODULE_MENU))
 )
 _=
+EXTRA_FOOTERS=$(SCRIPTLOAD $(STATIC js/run_examples.js))


### PR DESCRIPTION
Turns out that I have added another protection which didn't even add the JS for the runnable examples. So this finally adds `js/run_examples.js` to the released docs.