### PR TITLE
Improve runnable: disable assert to writeln transformation + make output a pre element

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1610,7 +1610,7 @@ div.changelog-nav
 
 /* Runnable-examples css */
 textarea.d_code {display: none;}
-textarea.d_code_output, textarea.d_code_stdin, textarea.d_code_args
+textarea.d_code_stdin, textarea.d_code_args
 {
     text-align: left;
     border: none;
@@ -1622,6 +1622,11 @@ textarea.d_code_output, textarea.d_code_stdin, textarea.d_code_args
     background: white;
     margin-left: 2px;
     outline: none;
+}
+
+pre.d_code_output {
+    border: none;
+    max-height: 30em;
 }
 
 div.d_code {margin: 0; padding: 0; background: #F5F5F5;}
@@ -1681,6 +1686,11 @@ input.editButton:active
     position: relative; top: 1px;
 }
 input.resetButton{display: none}
+
+/* Style for the example run buttons on the Phobos library documentation */
+.d_example_buttons {
+    text-align: left;
+}
 /* Runnable-examples css -end */
 
 .page-contents
@@ -2112,9 +2122,4 @@ dt.d_decl:hover .decl_anchor {
 .dont-highlight-link > a {
     text-decoration: none;
     color: #333;
-}
-
-/* Style for the example run buttons on the Phobos library documentation */
-.d_example_buttons {
-    text-align: left;
 }

--- a/js/run.js
+++ b/js/run.js
@@ -370,7 +370,7 @@ $(document).ready(function()
             + '<textarea class="d_code_stdin">'+stdin+'</textarea></div>'
             + '<div class="d_code_args"><span class="d_code_title">Command line arguments</span><br>'
             + '<textarea class="d_code_args">'+args+'</textarea></div>'
-            + '<div class="d_code_output"><span class="d_code_title">Application output</span><br><textarea class="d_code_output" readonly>Running...</textarea></div>'
+            + '<div class="d_code_output"><span class="d_code_title">Application output</span><br><pre class="d_code_output" readonly>Running...</pre></div>'
             + '<input type="button" class="editButton" value="Edit">'
             + '<input type="button" class="argsButton" value="Args">'
             + '<input type="button" class="inputButton" value="Input">'
@@ -456,7 +456,7 @@ function setupTextarea(el, opts)
 
     var plainSourceCode = parent.parent().children("div.d_code");
 
-    var output = outputDiv.children("textarea.d_code_output");
+    var output = outputDiv.children("pre.d_code_output");
     var outputTitle = outputDiv.children("span.d_code_title");
     if (opts.args) {
         var argsBtn = parent.children("input.argsButton");

--- a/js/run_examples.js
+++ b/js/run_examples.js
@@ -82,7 +82,7 @@ $(document).ready(function()
                     + '<div class="d_run_code" style="display: block">'
                         + '<textarea class="d_code" style="display: none;"></textarea>'
                     + '</div>'
-                    + '<div class="d_code_output"><span class="d_code_title">Application output</span><br><textarea class="d_code_output" readonly>Running...</textarea>'
+                    + '<div class="d_code_output"><span class="d_code_title">Application output</span><br><pre class="d_code_output" readonly>Running...</pre>'
                 + '</div>'
         );
     });

--- a/js/run_examples.js
+++ b/js/run_examples.js
@@ -59,7 +59,8 @@ $(document).ready(function()
         var currentExample = $(this);
         var orig = currentExample.html();
 
-        orig = reformatExample(orig);
+        // disable regex assert -> writeln rewrite logic (for now)
+        //orig = reformatExample(orig);
 
         // check whether it is from a ddoced unittest
         // 1) check is for ddoc, 2) for ddox


### PR DESCRIPTION
As of http://forum.dlang.org/post/enjjesmilghothyjlfid@forum.dlang.org

1) the Regex doesn't seem to handle all cases of `assert` -> removed
2) `textarea` shouldn't be used for a readonly output -> `pre`
3) For consistency I also moved the separated CSS up into its group