### PR TITLE
Enable Ddoc DMD release + Ddox prerelease build of DMD docs + verbatim target for DMD

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -511,12 +511,14 @@ docs.json : ${DMD_REL} ${DRUNTIME_STABLE_DIR} \
 	  --only-documented $(MOD_EXCLUDES_PRERELEASE)
 	rm .release-files.txt .release-dummy.html
 
+# DDox tries to generate the docs for all `.d` files. However for dmd this is tricky,
+# because the `{mach, elf, mscoff}` are platform dependent.
+# Thus the need to exclude these files (and the `objc.d` files).
 docs-prerelease.json : ${DMD} ${DMD_DIR} ${DRUNTIME_DIR} \
 		${PHOBOS_FILES_GENERATED} | dpl-docs
 	find ${DMD_DIR}/src -name '*.d' | \
-		sed -e /objc.d/d -e /mscoff/d -e '/dmd\/src\/id.d/d' \
-			-e /objc_glue.d/d ${DMD_EXCLUDE}  \
-		> .prerelease-files.txt
+		sed -e /objc.d/d -e /mscoff/d -e /objc_glue.d/d ${DMD_EXCLUDE}  \
+			> .prerelease-files.txt
 	find ${DRUNTIME_DIR}/src -name '*.d' | sed -e '/gcstub/d' \
 	  -e /unittest/d >> .prerelease-files.txt
 	find ${PHOBOS_DIR_GENERATED} -name '*.d' | sed -e /unittest.d/d \

--- a/posix.mak
+++ b/posix.mak
@@ -370,21 +370,24 @@ $(DMD_REL) : ${DMD_STABLE_DIR}
 
 dmd-release : $(STD_DDOC) $(DMD_DIR) $(DMD)
 	$(MAKE) AUTO_BOOTSTRAP=1 --directory=$(DMD_DIR) -f posix.mak -j4 html \
-		DOCDIR=${DOC_OUTPUT_DIR}/phobos \
-		DOCFMT="$(addprefix `pwd`/, $(STD_DDOC))"
+		STDDOC="$(addprefix `pwd`/, $(STD_DDOC))" \
+		DOC_OUTPUT_DIR="${DOC_OUTPUT_DIR}/phobos" \
+		DOCSRC="$(realpath .)"
 
 dmd-prerelease : $(STD_DDOC_PRE) $(DMD_DIR) $(DMD)
 	$(MAKE) AUTO_BOOTSTRAP=1 --directory=$(DMD_DIR) -f posix.mak -j4 html \
-		DOCDIR=${DOC_OUTPUT_DIR}/phobos-prerelease \
-		DOCFMT="$(addprefix `pwd`/, $(STD_DDOC_PRE))"
+		STDDOC="$(addprefix `pwd`/, $(STD_DDOC_PRE))" \
+		DOCSRC="$(realpath .)" \
+		DOC_OUTPUT_DIR="${DOC_OUTPUT_DIR}/phobos-prerelease"
 
 dmd-prerelease-verbatim : $(STD_DDOC_PRE) $(DMD_DIR) \
 		${DOC_OUTPUT_DIR}/phobos-prerelease/mars.verbatim
 ${DOC_OUTPUT_DIR}/phobos-prerelease/mars.verbatim: verbatim.ddoc
 	mkdir -p $(dir $@)
 	$(MAKE) AUTO_BOOTSTRAP=1 --directory=$(DMD_DIR) -f posix.mak -j4 html \
-		DOCDIR=${DOC_OUTPUT_DIR}/phobos-prerelease-verbatim \
-		DOCFMT="`pwd`/verbatim.ddoc"
+		DOC_OUTPUT_DIR="${DOC_OUTPUT_DIR}/phobos-prerelease-verbatim" \
+		STDDOC="`pwd`/verbatim.ddoc" \
+		DOCSRC="$(realpath .)"
 	$(call CHANGE_SUFFIX,html,verbatim,${DOC_OUTPUT_DIR}/phobos-prerelease-verbatim)
 	mv ${DOC_OUTPUT_DIR}/phobos-prerelease-verbatim/* $(dir $@)
 	rm -r ${DOC_OUTPUT_DIR}/phobos-prerelease-verbatim


### PR DESCRIPTION
I excluded the DDoc release build because it would be directly added to the menu (of the release build) and there's still a lot that isn't documented properly or shouldn't be exposed publicly.

However, as a quick preview here's a screenshot the Ddox menu (prerelease!):

![image](https://cloud.githubusercontent.com/assets/4370550/23199667/1599541e-f8d0-11e6-871a-d9bd8e4aa49f.png)

And ddox's awesome auto-completion:

![image](https://cloud.githubusercontent.com/assets/4370550/23199673/1e3f34bc-f8d0-11e6-8b55-73fc600f5e3e.png)

To enable dmd on the menu for the prerelease pages, https://github.com/dlang/dlang.org/pull/1580 is needed