### PR TITLE
Specify exact type of 501(c) organization

### DIFF
--- a/foundation.dd
+++ b/foundation.dd
@@ -3,7 +3,7 @@ Ddoc
 $(D_S $(TITLE),
 
 $(H4 The D Language Foundation is a
-    $(HTTPS en.wikipedia.org/wiki/501(c)_organization, 501(c) non-profit public charity)
+    $(HTTPS en.wikipedia.org/wiki/501(c)_organization, 501(c)(3) non-profit public charity)
      devoted to advancing open source technology related to the D programming language.
 )
 


### PR DESCRIPTION
According to http://forum.dlang.org/post/nq1pt6$1mba$1@digitalmars.com the exact type is (3). This change adds that to the foundation page.