### PR TITLE
Changelog: build next stable (aka minor) version

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -14,7 +14,8 @@ ifeq (,${LATEST})
 LATEST:=$(shell cat VERSION)
 endif
 # Next major DMD release
-NEXT_VERSION:=$(shell bash -c 'version=$$(cat VERSION);a=($${version//./ });a[1]="10\#$${a[1]}";((a[1]++)); a[2]=0; echo $${a[0]}.0$${a[1]}.$${a[2]};' )
+NEXT_MAJOR_VERSION:=$(shell bash -c 'version=$$(cat VERSION);a=($${version//./ });a[1]="10\#$${a[1]}";((a[1]++)); a[2]=0; echo $${a[0]}.0$${a[1]}.$${a[2]};' )
+NEXT_MINOR_VERSION:=$(shell bash -c 'version=$$(cat VERSION);a=($${version//./ });a[2]="10\#$${a[2]}";((a[2]++)); echo $${a[0]}.$${a[1]}.$${a[2]};' )
 
 # Externals
 DMD_DIR=../dmd
@@ -154,7 +155,7 @@ SPEC_ROOT=$(addprefix spec/, \
 SPEC_DD=$(addsuffix .dd,$(SPEC_ROOT))
 
 CHANGELOG_FILES=$(basename $(subst _pre.dd,.dd,$(wildcard changelog/*.dd))) \
-				changelog/${NEXT_VERSION}
+				changelog/${NEXT_MAJOR_VERSION} changelog/${NEXT_MINOR_VERSION}
 
 # Website root filenames. They have extension .dd in the source
 # and .html in the generated HTML. Save for the expansion of
@@ -523,9 +524,13 @@ test:
 # Changelog generation
 ################################################################################
 
-changelog/${NEXT_VERSION}.dd: ${STABLE_DMD} ../tools ../installer
-	$(STABLE_RDMD) $(TOOLS_DIR)/changed.d "v${LATEST}..upstream/stable" -o changelog/${NEXT_VERSION}.dd \
-		--version "${NEXT_VERSION}"
+changelog/${NEXT_MAJOR_VERSION}.dd: ${STABLE_DMD} ../tools ../installer
+	$(STABLE_RDMD) $(TOOLS_DIR)/changed.d "v${LATEST}..upstream/master" -o changelog/${NEXT_MAJOR_VERSION}.dd \
+		--version "${NEXT_MAJOR_VERSION}"
+
+changelog/${NEXT_MINOR_VERSION}.dd: ${STABLE_DMD} ../tools ../installer
+	$(STABLE_RDMD) $(TOOLS_DIR)/changed.d "v${LATEST}..upstream/stable" -o changelog/${NEXT_MINOR_VERSION}.dd \
+		--version "${NEXT_MINOR_VERSION}" --no-text
 
 pending_changelog: changelog/${NEXT_VERSION}.dd html
 	@echo "Please open file:///$(shell pwd)/web/changelog/${NEXT_VERSION}.html in your browser"


### PR DESCRIPTION
> Sorry, but can we not use exactly the same method we use for the `master` branch but for the `stable` branch? And use the same method to generate the file name, except increment the minor version number instead of the major one.

Sure, but I am not sure whether this is useful because at the moment the manual text changelog files are only intended for major releases, so the page will only included a list of bugs from Bugzilla, which might introduce "semi-random" changes in the DAutoTest output.

OTOH it's nice to have a preview for this as well and we already have this Bugzilla bug problem for the generated major version.

Hence leaving this up to @MartinNowak