### PR TITLE
Better diff mode (DIFFABLE=1)

### DIFF
--- a/dpl-docs/source/app.d
+++ b/dpl-docs/source/app.d
@@ -5,12 +5,16 @@ import std.getopt;
 import std.process;
 import vibe.core.log;
 
+bool noExactSourceCodeLinks;
+
 int main(string[] args)
 {
 	string git_target = "master";
 	getopt(args, std.getopt.config.passThrough,
-		"git-target", &git_target);
+		"git-target", &git_target,
+		"no-exact-source-links", &noExactSourceCodeLinks);
 	environment["GIT_TARGET"] = git_target;
+	environment["NO_EXACT_SOURCE_CODE_LINKS"] = noExactSourceCodeLinks ? "1" : "0";
 	setLogFormat(FileLogger.Format.plain);
 	return ddoxMain(args);
 }

--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -6,6 +6,7 @@ html(lang='en-US')
     | http://digitalmars.com
   - import std.process : environment;
   - string version_id = environment["GIT_TARGET"];
+  - bool noExactSourceCodeLinks = environment["NO_EXACT_SOURCE_CODE_LINKS"] == "1";
   - bool haveVersion = version_id.startsWith("v");
   - string version_name = haveVersion ? version_id[1 .. $] : "Prerelease";
   - string root_dir = info.linkTo(null) ~ (req is null ? "../" : "");
@@ -164,7 +165,7 @@ html(lang='en-US')
                 - project = "druntime", path_prefix = "src/";
               - else
                 - project = "phobos", path_prefix = "";
-              - if (info.docGroups.length >= 1)
+              - if (info.docGroups.length >= 1 && !noExactSourceCodeLinks)
                 - if (auto decl = cast(Declaration)info.docGroups[0].members[0]) line_suffix = "#L"~to!string(decl.line);
               - if (info.node.module_.isPackageModule)
                 - filename = replace(modname, ".", "/") ~ "/package.d";


### PR DESCRIPTION
Follow-up to https://github.com/dlang/tools/pull/222 and https://github.com/dlang/dlang.org/pull/1537/

>> Btw as this could also lead to unrelated diffs, should we disable the Bugzilla query for bugs for the changelog builder in "nightly mode"?

> Hmm, yeah, changes that shouldn't result in documentation changes should not have documentation changes indicated in the status line, because then inadvertent documentation changes will get through. I guess with this and https://github.com/dlang/dlang.org/pull/1537 we should expand `NODATETIME` to something more generic.