### PR TITLE
Use Makefile's pattern rules for the intermediate assert/writeln translation

### DIFF
--- a/osmodel.mak
+++ b/osmodel.mak
@@ -1,0 +1,55 @@
+# This Makefile snippet detects the OS and the architecture MODEL
+# Keep this file in sync between druntime, phobos, and dmd repositories!
+
+ifeq (,$(OS))
+  uname_S:=$(shell uname -s)
+  ifeq (Darwin,$(uname_S))
+    OS:=osx
+  endif
+  ifeq (Linux,$(uname_S))
+    OS:=linux
+  endif
+  ifeq (FreeBSD,$(uname_S))
+    OS:=freebsd
+  endif
+  ifeq (NetBSD,$(uname_S))
+    OS:=netbsd
+  endif
+  ifeq (OpenBSD,$(uname_S))
+    OS:=openbsd
+  endif
+  ifeq (Solaris,$(uname_S))
+    OS:=solaris
+  endif
+  ifeq (SunOS,$(uname_S))
+    OS:=solaris
+  endif
+  ifeq (,$(OS))
+    $(error Unrecognized or unsupported OS for uname: $(uname_S))
+  endif
+endif
+
+# When running make from XCode it may set environment var OS=MACOS.
+# Adjust it here:
+ifeq (MACOS,$(OS))
+  OS:=osx
+endif
+
+ifeq (,$(MODEL))
+  ifeq ($(OS), solaris)
+    uname_M:=$(shell isainfo -n)
+  else
+    uname_M:=$(shell uname -m)
+  endif
+  ifneq (,$(findstring $(uname_M),x86_64 amd64))
+    MODEL:=64
+  endif
+  ifneq (,$(findstring $(uname_M),i386 i586 i686))
+    MODEL:=32
+  endif
+  ifeq (,$(MODEL))
+    $(error Cannot figure 32/64 model from uname -m: $(uname_M))
+  endif
+endif
+
+MODEL_FLAG:=-m$(MODEL)

--- a/posix.mak
+++ b/posix.mak
@@ -349,7 +349,7 @@ dlangspec.verbatim.txt : $(DMD) verbatim.ddoc dlangspec-consolidated.d
 ../%-${DUB_VER} :
 	git clone --depth=1 -b v${DUB_VER} ${GIT_HOME}/$* $@
 
-${DMD_DIR} ${DRUNTIME_DIR} ${PHOBOS_DIR} :
+${DMD_DIR} ${DRUNTIME_DIR} ${PHOBOS_DIR} ${TOOLS_DIR} ${INSTALLER_DIR}:
 	git clone --depth=1 ${GIT_HOME}/$(@F) $@
 
 ################################################################################
@@ -575,11 +575,5 @@ changelog/${NEXT_VERSION}.dd: ${STABLE_DMD} ../tools ../installer
 
 pending_changelog: changelog/${NEXT_VERSION}.dd html
 	@echo "Please open file:///$(shell pwd)/web/changelog/${NEXT_VERSION}.html in your browser"
-
-../tools:
-	git clone https://github.com/dlang/tools ../tools
-
-../installer:
-	git clone https://github.com/dlang/installer ../installer
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)

--- a/posix.mak
+++ b/posix.mak
@@ -9,6 +9,8 @@
 # make -f posix.mak rsync
 #
 
+include osmodel.mak
+
 # Latest released version
 ifeq (,${LATEST})
 LATEST:=$(shell cat VERSION)
@@ -88,47 +90,6 @@ REBASE = MYBRANCH=`git rev-parse --abbrev-ref HEAD` &&\
 CHANGE_SUFFIX = \
  for f in `find "$3" -iname '*.$1'`; do\
   mv $$f `dirname $$f`/`basename $$f .$1`.$2; done
-
-# Set to 1 in the command line to minify css files
-CSS_MINIFY=
-
-# OS and MODEL
-OS:=
-uname_S:=$(shell uname -s)
-ifeq (Darwin,$(uname_S))
-    OS:=osx
-endif
-ifeq (Linux,$(uname_S))
-    OS:=linux
-endif
-ifeq (FreeBSD,$(uname_S))
-    OS:=freebsd
-endif
-ifeq (OpenBSD,$(uname_S))
-    OS:=openbsd
-endif
-ifeq (Solaris,$(uname_S))
-    OS:=solaris
-endif
-ifeq (SunOS,$(uname_S))
-    OS:=solaris
-endif
-ifeq (,$(OS))
-    $(error Unrecognized or unsupported OS for uname: $(uname_S))
-endif
-
-ifeq (,$(MODEL))
-    uname_M:=$(shell uname -m)
-    ifneq (,$(findstring $(uname_M),x86_64 amd64))
-        MODEL:=64
-    endif
-    ifneq (,$(findstring $(uname_M),i386 i586 i686))
-        MODEL:=32
-    endif
-    ifeq (,$(MODEL))
-        $(error Cannot figure 32/64 model from uname -m: $(uname_M))
-    endif
-endif
 
 # Disable all dynamic content that could potentially have an unrelated impact
 # on a diff

--- a/posix.mak
+++ b/posix.mak
@@ -16,15 +16,19 @@ endif
 # Next major DMD release
 NEXT_VERSION:=$(shell bash -c 'version=$$(cat VERSION);a=($${version//./ });a[1]="10\#$${a[1]}";((a[1]++)); a[2]=0; echo $${a[0]}.0$${a[1]}.$${a[2]};' )
 
-# Externals
+# DLang directories
 DMD_DIR=../dmd
 PHOBOS_DIR=../phobos
 DRUNTIME_DIR=../druntime
 TOOLS_DIR=../tools
+INSTALLER_DIR=../installer
 DUB_DIR=../dub-${DUB_VER}
+
+# External binaries
 DMD=$(DMD_DIR)/src/dmd
-DMD_REL=$(DMD_DIR)-${LATEST}/src/dmd
 DUB=${DUB_DIR}/bin/dub
+
+# External directories
 DOC_OUTPUT_DIR:=$(shell pwd)/web
 GIT_HOME=https://github.com/dlang
 DPL_DOCS_PATH=dpl-docs
@@ -33,17 +37,24 @@ REMOTE_DIR=d-programming@digitalmars.com:data
 
 # Last released versions
 DMD_STABLE_DIR=${DMD_DIR}-${LATEST}
+DMD_REL=$(DMD_STABLE_DIR)/src/dmd
 DRUNTIME_STABLE_DIR=${DRUNTIME_DIR}-${LATEST}
 PHOBOS_STABLE_DIR=${PHOBOS_DIR}-${LATEST}
 
+################################################################################
 # Automatically generated directories
 GENERATED=.generated
 PHOBOS_DIR_GENERATED=$(GENERATED)/phobos-prerelease
 PHOBOS_STABLE_DIR_GENERATED=$(GENERATED)/phobos-release
+# The assert_writeln_magic tool transforms all source files from Phobos. Hence
+# - a temporary folder with a copy of Phobos needs to be generated
+# - a list of all files in Phobos and the temporary copy is needed to setup proper
+#   Makefile dependencies and rules
 PHOBOS_FILES := $(shell find $(PHOBOS_DIR) -name '*.d' -o -name '*.mak' -o -name '*.ddoc')
 PHOBOS_FILES_GENERATED := $(subst $(PHOBOS_DIR), $(PHOBOS_DIR_GENERATED), $(PHOBOS_FILES))
 PHOBOS_STABLE_FILES := $(shell find $(PHOBOS_STABLE_DIR) -name '*.d' -o -name '*.mak' -o -name '*.ddoc')
 PHOBOS_STABLE_FILES_GENERATED := $(subst $(PHOBOS_STABLE_DIR), $(PHOBOS_STABLE_DIR_GENERATED), $(PHOBOS_STABLE_FILES))
+################################################################################
 
 # stable dub and dmd versions used to build dpl-docs
 DUB_VER=1.1.0
@@ -128,14 +139,12 @@ else
 	CHANGELOG_VERSION := "v${LATEST}..upstream/stable"
 endif
 
-# Documents
+################################################################################
+# Resources
+################################################################################
 
-DDOC=$(addsuffix .ddoc, macros html dlang.org doc ${GENERATED}/${LATEST}) $(NODATETIME)
-STD_DDOC=$(addsuffix .ddoc, macros html dlang.org ${GENERATED}/${LATEST} std std_navbar-release ${GENERATED}/modlist-${LATEST}) $(NODATETIME)
-STD_DDOC_PRE=$(addsuffix .ddoc, macros html dlang.org ${GENERATED}/${LATEST} std std_navbar-prerelease ${GENERATED}/modlist-prerelease) $(NODATETIME)
-SPEC_DDOC=${DDOC} spec/spec.ddoc
-CHANGELOG_DDOC=${DDOC} changelog/changelog.ddoc $(NODATETIME)
-CHANGELOG_PRE_DDOC=${CHANGELOG_DDOC} changelog/prerelease.ddoc
+# Set to 1 in the command line to minify css files
+CSS_MINIFY=
 
 ORGS_USING_D=$(wildcard images/orgs-using-d/*)
 IMAGES=favicon.ico $(ORGS_USING_D) $(addprefix images/, \
@@ -158,6 +167,17 @@ JAVASCRIPT=$(addsuffix .js, $(addprefix js/, \
 
 STYLES=$(addsuffix .css, $(addprefix css/, \
 	style print codemirror ddox))
+
+################################################################################
+# HTML Files
+################################################################################
+
+DDOC=$(addsuffix .ddoc, macros html dlang.org doc ${GENERATED}/${LATEST}) $(NODATETIME)
+STD_DDOC=$(addsuffix .ddoc, macros html dlang.org ${GENERATED}/${LATEST} std std_navbar-release ${GENERATED}/modlist-${LATEST}) $(NODATETIME)
+STD_DDOC_PRE=$(addsuffix .ddoc, macros html dlang.org ${GENERATED}/${LATEST} std std_navbar-prerelease ${GENERATED}/modlist-prerelease) $(NODATETIME)
+SPEC_DDOC=${DDOC} spec/spec.ddoc
+CHANGELOG_DDOC=${DDOC} changelog/changelog.ddoc $(NODATETIME)
+CHANGELOG_PRE_DDOC=${CHANGELOG_DDOC} changelog/prerelease.ddoc
 
 PREMADE=appendices.html articles.html fetch-issue-cnt.php howtos.html	\
 language-reference.html robots.txt .htaccess .dpl_rewrite_map.txt	\
@@ -201,7 +221,9 @@ $(PREMADE) $(STYLES) $(IMAGES) $(JAVASCRIPT))
 
 ALL_FILES = $(ALL_FILES_BUT_SITEMAP) $(DOC_OUTPUT_DIR)/sitemap.html
 
+################################################################################
 # Pattern rulez
+################################################################################
 
 # NOTE: Depending on the version of make, order matters here. Therefore, put
 # sub-directories before their parents.


### PR DESCRIPTION
- only regeneration when real changes happen
- removes the ugly `rsync` workaround