### PR TITLE
Added padding to links in Phobos book table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -997,6 +997,11 @@ table td:not(:last-child), table th:not(:last-child)
     padding-right: 1em;
 }
 
+table.book tbody a
+{
+    padding-right: .6em;
+}
+
 hr
 {
     margin: 2em 0;


### PR DESCRIPTION
Just a small improvement. I think the links can use a little breathing room.

CC @wilzbach 