### PR TITLE
Remove "Call for submissions" from news

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -84,7 +84,7 @@ $(DIVID news,
 $(DIVC boxes,
     $(DIVC row,
         $(TOUR newspaper-o, News,
-            $(P $(LINK2 http://dconf.org/2017/index.html, DConf 2017):
+            $(P $(LINK2 http://dconf.org/2017/index.html, DConf 2017)
                 is coming up: May 4-7 in Berlin, Germany. $(BR)
                 $(LINK2 http://dconf.org/2017/registration.html, Secure your seat)
                 before it's sold out!

--- a/index.dd
+++ b/index.dd
@@ -85,11 +85,9 @@ $(DIVC boxes,
     $(DIVC row,
         $(TOUR newspaper-o, News,
             $(P $(LINK2 http://dconf.org/2017/index.html, DConf 2017):
-                Call for Submissions is open. $(BR)
-                The $(LINK2 $(ROOT_DIR)foundation.html, D Language Foundation)
-                has been accepted as a 501(c) non-profit public charity
-                and thus can handle
-                $(LINK2 $(ROOT_DIR)donate.html, donations).
+                is coming up: May 4-7 in Berlin, Germany. $(BR)
+                $(LINK2 http://dconf.org/2017/registration.html, Secure your seat)
+                before it's sold out!
             )
             $(P Stay updated with
                 $(LINK2 http://arsdnet.net/this-week-in-d,


### PR DESCRIPTION
The Call for submissions is closed and we need a replacement "news". I shamelessly copy/pasted from last year.