### PR TITLE
Updated makefile to use dmd/generated/os/release/model/dmd

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -27,7 +27,7 @@ INSTALLER_DIR=../installer
 DUB_DIR=../dub-${DUB_VER}
 
 # External binaries
-DMD=$(DMD_DIR)/src/dmd
+DMD=$(DMD_DIR)/generated/$(OS)/release/$(MODEL)/dmd
 DUB=${DUB_DIR}/bin/dub
 
 # External directories


### PR DESCRIPTION
I saw there is also the variable $(DMD_STABLE_DIR) which is used for $(DMD-REL) that uses the hierarchy dmd/src/dmd. I didn't modify that one to point to generated/.../dmd since I assume that the changes in [1] are not stable yet.

[1] https://github.com/dlang/dmd/pull/6562