### PR TITLE
Make link padding only apply to more specific cases

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -997,7 +997,28 @@ table td:not(:last-child), table th:not(:last-child)
     padding-right: 1em;
 }
 
-table.book tbody a
+/*
+  These next two rules are for pages like:
+  http://dlang.org/phobos-prerelease/std_regex.html
+
+  The idea is if we have a list of links, we want space
+  to the right of each one. But detecting a list of links
+  vs just a single link requires some thought: the css
+  adjacent sibling rule does well detecting all but the first
+  one in a list, so we'll add space to the right of them (that's
+  the second rule here), but that leaves an inconsistent space
+  after the first item.
+
+  That's where the following rule comes in: on the item directly
+  following the first link, add some left padding to simulate the
+  first one having the same space as the others.
+*/
+table.book tbody a:first-child + a
+{
+    padding-left: .6em;
+}
+
+table.book tbody a + a
 {
     padding-right: .6em;
 }


### PR DESCRIPTION
The old rule was too general and cause silly looking spaces as Andrei
described here:

http://forum.dlang.org/post/ohjurtkzhvufqsahmimj@forum.dlang.org

This makes it only happen where I believe it was intended to happen:
on the hand-written index replacement, such as here:
https://dlang.org/phobos-prerelease/std_algorithm.html

where we have a long list of links all right next to each other under
the quickindex div.