### PR TITLE
Fix dmd source links for DDoc and DDox

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -136,7 +136,7 @@ DDOCKEYVAL2=$(DIVC keyval $1, $(SPANC key key$1, $2:) $(DIVC val val$1, $(TAIL $
 DDSUBLINK=$(LINK2 $(ROOT_DIR)$1.html#$2, $3)
 _=
 
-DMDSRC=$(HTTPS github.com/D-Programming-Language/dmd/blob/master/src/$0, $0)
+DMDSRC=$(HTTPS github.com/dlang/dmd/blob/master/src/dmd/$0, $0)
 DOT_PREFIXED=.$1$(DOT_PREFIXED $+)
 DOT_PREFIXED_SKIP=$(DOT_PREFIXED $+)
 DRUNTIMESRC=$(HTTPS github.com/dlang/druntime/blob/master/src/$0, $0)
@@ -282,7 +282,7 @@ $(DIVID tools, $(DIV,
 		)
 	)
 	$(DIVC tip smallprint,
-		<a href="https://github.com/dlang/$(PROJECT)/edit/master/$(SRCFILENAME)">Improve this page</a>
+		<a href="https://github.com/dlang/$(PROJECT)/edit/master/$(PROJECT_SOURCE_DIR)$(SRCFILENAME)">Improve this page</a>
 		$(DIV,
 			Quickly fork, edit online, and submit a pull request for this page.
 			Requires a signed-in GitHub account. This works well for small changes.
@@ -486,4 +486,6 @@ _=
 
 YELLOW=$(SPANC yellow, $0)
 YES=$(CHECKMARK)
+
+PROJECT_SOURCE_DIR=
 _=

--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -165,6 +165,8 @@ html(lang='en-US')
             - if( modname )
               - if( modname.startsWith("core.") )
                 - project = "druntime", path_prefix = "src/";
+              - else if( modname.startsWith("dmd.") || modname.startsWith("ddmd.") )
+                - project = "dmd", path_prefix = "src/";
               - else
                 - project = "phobos", path_prefix = "";
               - if (info.docGroups.length >= 1 && !noExactSourceCodeLinks)


### PR DESCRIPTION
For Ddoc we have the problem that `ddoc` is run in the `src` directory, which means the `SRCFILENAME` starts with `ddmd/...`
For `druntime` this worked before as `ddoc` is run outside of the `src` directory.
My simple solution is to add a `PROJECT_SOURCE_DIR` variable to the `project.ddoc` file at `dmd`.


@RazvanN7 as you would need to update these files anyways, I was nice and already set them to `dmd` (nobody uses the online documentation of dmd at the moment anyways).

