### PR TITLE
Removed redundant DMD_GEN variable and replaced it's occurences with DMD

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -525,7 +525,7 @@ docs-prerelease.json : ${DMD} ${DMD_DIR} ${DRUNTIME_DIR} \
 	  -e /unittest/d >> .prerelease-files.txt
 	find ${PHOBOS_DIR_GENERATED} -name '*.d' | sed -e /unittest.d/d \
 	  -e /windows/d >> .prerelease-files.txt
-	${DMD} -J$(DMD_DIR)/res -J$(DMD) -c -o- -version=MARS -version=CoreDdoc \
+	${DMD} -J$(DMD_DIR)/res -J$(dir $(DMD)) -c -o- -version=MARS -version=CoreDdoc \
 	  -version=StdDdoc -Df.prerelease-dummy.html \
 	  -Xfdocs-prerelease.json -I${PHOBOS_DIR_GENERATED} @.prerelease-files.txt
 	${DPL_DOCS} filter docs-prerelease.json --min-protection=Protected \

--- a/posix.mak
+++ b/posix.mak
@@ -93,8 +93,6 @@ CHANGE_SUFFIX = \
  for f in `find "$3" -iname '*.$1'`; do\
   mv $$f `dirname $$f`/`basename $$f .$1`.$2; done
 
-DMD_GEN=$(DMD_DIR)/generated/$(OS)/release/$(MODEL)
-
 # Disable all dynamic content that could potentially have an unrelated impact
 # on a diff
 ifeq (1,$(DIFFABLE))
@@ -527,7 +525,7 @@ docs-prerelease.json : ${DMD} ${DMD_DIR} ${DRUNTIME_DIR} \
 	  -e /unittest/d >> .prerelease-files.txt
 	find ${PHOBOS_DIR_GENERATED} -name '*.d' | sed -e /unittest.d/d \
 	  -e /windows/d >> .prerelease-files.txt
-	${DMD} -J$(DMD_DIR)/res -J$(DMD_GEN) -c -o- -version=MARS -version=CoreDdoc \
+	${DMD} -J$(DMD_DIR)/res -J$(DMD) -c -o- -version=MARS -version=CoreDdoc \
 	  -version=StdDdoc -Df.prerelease-dummy.html \
 	  -Xfdocs-prerelease.json -I${PHOBOS_DIR_GENERATED} @.prerelease-files.txt
 	${DPL_DOCS} filter docs-prerelease.json --min-protection=Protected \


### PR DESCRIPTION
The makefile had a redundant variable : $DMD_GEN which stored the same path as $DMD. I erased it and replaced it's occurences with $DMD. 

CC @wilzbach : regarding the other matter, I think it would be best to add dmd to the list of dumped modules after the switch: ddmd -> dmd