### PR TITLE
Make links in 404 pages absolute

### DIFF
--- a/errorpage.ddoc
+++ b/errorpage.ddoc
@@ -1,0 +1,2 @@
+ROOT_DIR=/
+ROOT=

--- a/posix.mak
+++ b/posix.mak
@@ -189,6 +189,9 @@ $(DOC_OUTPUT_DIR)/changelog/%.html : changelog/%_pre.dd $(CHANGELOG_PRE_DDOC) $(
 $(DOC_OUTPUT_DIR)/spec/%.html : spec/%.dd $(SPEC_DDOC) $(DMD)
 	$(DMD) -c -o- -Df$@ $(SPEC_DDOC) $<
 
+$(DOC_OUTPUT_DIR)/404.html : 404.dd $(DDOC) $(DMD)
+	$(DMD) -conf= -c -o- -Df$@ $(DDOC) errorpage.ddoc $<
+
 $(DOC_OUTPUT_DIR)/%.html : %.dd $(DDOC) $(DMD)
 	$(DMD) -conf= -c -o- -Df$@ $(DDOC) $<
 


### PR DESCRIPTION
Fixes display of 404 pages for any non-root URL (e.g. http://dlang.org/phobos/nonexisting.html).

There's more than one way to skin this cat, such as to use full URLs (set `ROOT` to `//dlang.org`) or convert `404.html` to a PHP file, but this is probably the simplest.

For some reason putting the `ROOT_DIR` / `ROOT` macros in the `404.dd` file itself didn't work.