### PR TITLE
changelog/2.073.2: Fix VER

### DIFF
--- a/changelog/2.073.2.dd
+++ b/changelog/2.073.2.dd
@@ -29,5 +29,5 @@ $(LI $(BUGZILLA 17198): rdmd does not recompile when --extra-file is added)
 )
 $(CHANGELOG_NAV_LAST 2.073.1)
 Macros:
-    VER=LATEST
+    VER=2.073.2
     TITLE=Change Log: $(VER)


### PR DESCRIPTION
Fixes "LATEST" appearing instead of a version number in the 2.073.2 changelog.