### PR TITLE
Do not use deprecated syntax in spec.

### DIFF
--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -95,7 +95,7 @@ $(H3 Postincrement $(I e)$(D ++) and Postdecrement $(I e)$(D --) Operators)
 	$(THEAD $(I op), $(I rewrite))
 	$(TROW
 	    $(ARGS $(I e)$(D --)),
-	    $(ARGS $(D $(LBRACE) auto t =) $(I e)$(D ; --)$(I e)$(D ; return t; $(RBRACE)$(LPAREN)$(RPAREN))))
+	    $(ARGS $(D { auto t =) $(I e)$(D ; --)$(I e)$(D ; return t; }$(LPAREN)$(RPAREN))))
 	$(TROW
 	    $(ARGS $(I e)$(D ++)),
 	    $(ARGS $(D $(LBRACE) auto t =) $(I e)$(D ; ++)$(I e)$(D ; return t; $(RBRACE)$(LPAREN)$(RPAREN))))

--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -94,11 +94,11 @@ $(H3 Postincrement $(I e)$(D ++) and Postdecrement $(I e)$(D --) Operators)
 	$(TABLE2 Postfix Operator Rewrites,
 	$(THEAD $(I op), $(I rewrite))
 	$(TROW
-	$(ARGS $(I e)$(D --)),
-	$(ARGS $(D $(LPAREN)auto t =) $(I e)$(D , --)$(I e)$(D , t$(RPAREN))))
+	    $(ARGS $(I e)$(D --)),
+	    $(ARGS $(D $(LBRACE) auto t =) $(I e)$(D ; --)$(I e)$(D ; return t; $(RBRACE)$(LPAREN)$(RPAREN))))
 	$(TROW
-	$(ARGS $(I e)$(D ++)),
-	$(ARGS $(D $(LPAREN)auto t =) $(I e)$(D , ++)$(I e)$(D , t$(RPAREN))))
+	    $(ARGS $(I e)$(D ++)),
+	    $(ARGS $(D $(LBRACE) auto t =) $(I e)$(D ; ++)$(I e)$(D ; return t; $(RBRACE)$(LPAREN)$(RPAREN))))
 	)
 
 $(H3 Overloading Index Unary Operators)

--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -98,7 +98,7 @@ $(H3 Postincrement $(I e)$(D ++) and Postdecrement $(I e)$(D --) Operators)
 	    $(ARGS $(D { auto t =) $(I e)$(D ; --)$(I e)$(D ; return t; }$(LPAREN)$(RPAREN))))
 	$(TROW
 	    $(ARGS $(I e)$(D ++)),
-	    $(ARGS $(D $(LBRACE) auto t =) $(I e)$(D ; ++)$(I e)$(D ; return t; $(RBRACE)$(LPAREN)$(RPAREN))))
+	    $(ARGS $(D { auto t =) $(I e)$(D ; ++)$(I e)$(D ; return t; }$(LPAREN)$(RPAREN))))
 	)
 
 $(H3 Overloading Index Unary Operators)


### PR DESCRIPTION
Done corrective action as proposed in the [List of Deprecated Features](https://dlang.org/deprecate.html#Using%20the%20result%20of%20a%20comma%20expression).