### PR TITLE
Struct and Class Comparison Table changed

### DIFF
--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -69,7 +69,7 @@ $(SPEC_S Structs and Unions,
         $(TROW default public, $(CHECK), $(CHECK), $(CHECK),$(CHECK), $(UNCHECK))
         $(TROW tag name space, $(UNCHECK), $(UNCHECK), $(CHECK),
         $(CHECK), $(CHECK))
-        $(TROW anonymous, $(CHECK), $(UNCHECK), $(CHECK), $(CHECK), $(CHECK))
+        $(TROW anonymous, $(CHECK), $(CHECK), $(CHECK), $(CHECK), $(CHECK))
         $(TROW static constructor, $(CHECK), $(CHECK), $(UNCHECK),
         $(UNCHECK), $(UNCHECK))
         $(TROW static destructor, $(CHECK), $(CHECK), $(UNCHECK),


### PR DESCRIPTION
Depending on what "anonymous" means. But if I am correct, "anonymous" does not have name  of type identifier, and in case of anonymous struct, the struct behaves the same as "named" struct. 
```d
struct { int x; int y;}
``` 
is almost equivalent to 
```d
struct S
{ 
    int x;
    int y;
}
``` 

So, in case of class,  a way to do this is 
```d
new class { int x; int y; int distance(){return sqrt(x * x + y * y);} }
```
is almost equivalent to
```d
class Point
{
    int x;
    int y;
    int distance()
    {
        return sqrt(x*x + y*y);
    }
}
```
so this should be checked.