### PR TITLE
fix empty href for 404.html dlang logo

### DIFF
--- a/errorpage.ddoc
+++ b/errorpage.ddoc
@@ -1,2 +1,3 @@
 ROOT_DIR=/
-ROOT=
+_=ROOT is only used for top left dlang.org logo and cannot be empty `<a href="$(ROOT)">`, so use / even though it breaks when served under /subpath/.
+ROOT=/


### PR DESCRIPTION
- caused chmgen to fail
- no nice idea how to get the real root from arbitrary
  path/to/nonexistent