### PR TITLE
Remove gratuitous "empty" clause.

### DIFF
--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -469,7 +469,6 @@ $(H3 $(LNAME2 type_mangling, Type Mangling))
         $(GLINK FuncAttr) $(I FuncAttrs)
 
     $(GNAME FuncAttr):
-        $(I empty)
         $(GLINK FuncAttrPure)
         $(GLINK FuncAttrNogc)
         $(GLINK FuncAttrNothrow)


### PR DESCRIPTION
FuncAttrs is already optional, so FuncAttr does not need to contain an empty clause.