### PR TITLE
abi: Template symbol parameters are either Qualified or Mangled.

### DIFF
--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -244,8 +244,8 @@ $(H3 $(LNAME2 name_mangling, Name Mangling))
         $(GNAME TemplateArgX):
             $(B T) $(GLINK Type)
             $(B V) $(GLINK Type) $(GLINK Value)
-            $(B S) $(GLINK SymbolName)
-            $(B S) $(GLINK MangledName)
+            $(B S) $(GLINK Number) $(GLINK QualifiedName)
+            $(B S) $(GLINK Number) $(GLINK MangledName)
 
         $(GNAME Value):
             $(B n)


### PR DESCRIPTION
An example of a QualifiedName found in a TemplateArg can be seen when dump the symbols of this compiled program: https://github.com/dlang/phobos/blob/31e1b462d2311f9d8cecb33172b28eab587b255d/std/parallelism.d#L43-L77

Also symbol parameters are prefixed with their symbol length, as per bugzilla 3043.

Implementation and Notes: https://github.com/dlang/dmd/blob/15b3ee1603b7dcc0317ba63c54f77ee9718f90e4/src/ddmd/dtemplate.d#L8323-L8331

