### PR TITLE
Allow function parameter types in QualifiedName

### DIFF
--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -211,6 +211,7 @@ $(H3 $(LNAME2 name_mangling, Name Mangling))
     $(GNAME QualifiedName):
         $(GLINK SymbolName)
         $(GLINK SymbolName) $(I QualifiedName)
+        $(GLINK SymbolName) $(GLINK TypeFunctionNoReturn) $(I QualifiedName)
 
     $(GNAME SymbolName):
         $(GLINK LName)
@@ -454,7 +455,10 @@ $(H3 $(LNAME2 type_mangling, Type Mangling))
         $(B Nh) $(GLINK Type)
 
     $(GNAME TypeFunction):
-        $(GLINK CallConvention) $(GLINK FuncAttrs)$(OPT) $(GLINK Parameters)$(OPT) $(GLINK ParamClose) $(GLINK Type)
+        $(GLINK TypeFunctionNoReturn) $(GLINK Type)
+
+    $(GNAME TypeFunctionNoReturn):
+        $(GLINK CallConvention) $(GLINK FuncAttrs)$(OPT) $(GLINK Parameters)$(OPT) $(GLINK ParamClose)
 
     $(GNAME CallConvention):
         $(B F)       $(GREEN // D)

--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -212,7 +212,7 @@ $(H3 $(LNAME2 name_mangling, Name Mangling))
         $(GLINK SymbolName)
         $(GLINK SymbolName) $(I QualifiedName)
         $(GLINK SymbolName) $(GLINK TypeFunctionNoReturn) $(I QualifiedName)
-        $(GLINK SymbolName) $(B M) $(GLINK TypeFunctionNoReturn) $(I QualifiedName)
+        $(GLINK SymbolName) $(B M) $(GLINK TypeModifiers)$(OPT) $(GLINK TypeFunctionNoReturn) $(I QualifiedName)
 
     $(GNAME SymbolName):
         $(GLINK LName)

--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -212,6 +212,7 @@ $(H3 $(LNAME2 name_mangling, Name Mangling))
         $(GLINK SymbolName)
         $(GLINK SymbolName) $(I QualifiedName)
         $(GLINK SymbolName) $(GLINK TypeFunctionNoReturn) $(I QualifiedName)
+        $(GLINK SymbolName) $(B M) $(GLINK TypeFunctionNoReturn) $(I QualifiedName)
 
     $(GNAME SymbolName):
         $(GLINK LName)


### PR DESCRIPTION
Nested symbols encode the function arguments of the outer function, similar to template arguments.

Continuation of https://github.com/dlang/dlang.org/pull/1626