### PR TITLE
Remove special casing for `objc.d` from the Posix makefile

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -518,11 +518,11 @@ docs.json : ${DMD_REL} ${DRUNTIME_STABLE_DIR} \
 
 # DDox tries to generate the docs for all `.d` files. However for dmd this is tricky,
 # because the `{mach, elf, mscoff}` are platform dependent.
-# Thus the need to exclude these files (and the `objc.d` files).
+# Thus the need to exclude these files (and the `objc_glue.d` file).
 docs-prerelease.json : ${DMD} ${DMD_DIR} ${DRUNTIME_DIR} \
 		${PHOBOS_FILES_GENERATED} | dpl-docs
 	find ${DMD_DIR}/src -name '*.d' | \
-		sed -e /objc.d/d -e /mscoff/d -e /objc_glue.d/d ${DMD_EXCLUDE}  \
+		sed -e /mscoff/d -e /objc_glue.d/d ${DMD_EXCLUDE}  \
 			> .prerelease-files.txt
 	find ${DRUNTIME_DIR}/src -name '*.d' | sed -e '/gcstub/d' \
 	  -e /unittest/d >> .prerelease-files.txt


### PR DESCRIPTION
This file is now shared for all platforms after the Objective-C integration refactoring: https://github.com/dlang/dmd/pull/6679.