### PR TITLE
Implicit catch statements are deprecated.

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1485,12 +1485,8 @@ $(GNAME TryStatement):
     $(D try) $(PSSCOPE) $(GLINK FinallyStatement)
 
 $(GNAME Catches):
-    $(GLINK LastCatch)
     $(GLINK Catch)
     $(GLINK Catch) $(I Catches)
-
-$(GNAME LastCatch):
-    $(D catch) $(PS0)
 
 $(GNAME Catch):
     $(D catch $(LPAREN)) $(GLINK CatchParameter) $(D $(RPAREN)) $(PS0)


### PR DESCRIPTION
Bring spec/statement.dd in line with spec/grammar.dd. See https://github.com/dlang/dlang.org/pull/1423 and https://github.com/dlang/dmd/pull/5183.