### PR TITLE
Remove invalid colon

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -179,7 +179,7 @@ $(GNAME Initializer):
     $(GLINK NonVoidInitializer)
 
 $(GNAME NonVoidInitializer):
-    $(GLINK ExpInitializer):
+    $(GLINK ExpInitializer)
     $(GLINK ArrayInitializer)
     $(GLINK StructInitializer)
 


### PR DESCRIPTION
There should not be a colon at the end of a NonVoidInitializer.