### PR TITLE
remove deprecated StringLiterals (implicit concat) from expressions

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1125,7 +1125,7 @@ $(GNAME PrimaryExpression):
     $(GLINK2 lex, IntegerLiteral)
     $(GLINK2 lex, FloatLiteral)
     $(GLINK CharacterLiteral)
-    $(GLINK StringLiterals)
+    $(GLINK StringLiteral)
     $(GLINK ArrayLiteral)
     $(GLINK AssocArrayLiteral)
     $(GLINK FunctionLiteral)
@@ -1233,9 +1233,8 @@ $(H4 $(LEGACY_LNAME2 CharacterLiteral, character-literal, Character Literals))
 $(H4 String Literals)
 
 $(GRAMMAR
-$(GNAME StringLiterals):
+$(GNAME StringLiteral):
     $(GLINK2 lex, StringLiteral)
-    $(I StringLiterals) $(GLINK2 lex, StringLiteral)
 )
 
     $(P String literals can implicitly convert to any


### PR DESCRIPTION
As observed [here](https://forum.dlang.org/post/odoqjn$17eh$1@digitalmars.com) the _StringLiterals_ rule is now deprecated.