### PR TITLE
synchronize grammar for ModuleDeclaration with module.dd

### DIFF
--- a/spec/grammar.dd
+++ b/spec/grammar.dd
@@ -1772,7 +1772,15 @@ $(GNAME DeclDef):
 
 $(GRAMMAR
 $(GNAME ModuleDeclaration):
-    $(D module) $(I ModuleFullyQualifiedName) $(D ;)
+    $(I ModuleAttributes)$(OPT) $(D module) $(I ModuleFullyQualifiedName) $(D ;)
+
+$(GNAME ModuleAttributes):
+    $(GLINK ModuleAttribute)
+    $(GLINK ModuleAttribute) $(I ModuleAttributes)
+
+$(GNAME ModuleAttribute):
+    $(GLINK2 attribute, DeprecatedAttribute)
+    $(GLINK2 attribute, UserDefinedAttribute)
 
 $(GNAME ModuleFullyQualifiedName):
     $(I ModuleName)


### PR DESCRIPTION
As observed [here](https://forum.dlang.org/post/odoqjn$17eh$1@digitalmars.com), one of the rule is incomplete.