### PR TITLE
grammar: Remove dangling closing parenthesis

### DIFF
--- a/spec/grammar.dd
+++ b/spec/grammar.dd
@@ -1626,7 +1626,6 @@ $(GNAME LinkageType):
     $(D Pascal)
     $(D System)
     $(D Objective-C)
-)
 
 $(GNAME CppAggregateType):
     $(D class)


### PR DESCRIPTION
I *think* this would fix:

http://dlang.org/spec/grammar.html#CppAggregateType
and
http://dlang.org/spec/grammar.html#copyright

Would have to double check that though.  Does the build-bot allow previewing the documentation?