### PR TITLE
Update LDC platform info

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -37,11 +37,11 @@ $(TABLEC download-compilers,
       $(UL
         $(LI $(LINK2 http://llvm.org/, LLVM)-based D compiler)
         $(LI Strong optimization)
-        $(LI Alpha support for mobile:
-          $(LINK2 https://github.com/smolt/ldc-iphone-dev/releases, iOS),
-          $(LINK2 https://github.com/joakim-noah/android/releases, Android)
+        $(LI Mobile support:
+          $(LINK2 https://github.com/smolt/ldc-iphone-dev/releases, iOS alpha),
+          $(LINK2 https://github.com/joakim-noah/android/releases, Android beta)
         )
-        $(LI Architectures: i386, amd64, armel, $(LINK2 https://wiki.dlang.org/Compilers#Comparison,others))
+        $(LI Architectures: i386, amd64, armel, armhf, $(LINK2 https://wiki.dlang.org/Compilers#Comparison,others))
       )
     )
   )


### PR DESCRIPTION
Android is now in beta, and armhf is well-supported.