### PR TITLE
Test tour.dlang.org as alternative backend

### DIFF
--- a/js/run_examples.js
+++ b/js/run_examples.js
@@ -100,7 +100,8 @@ $(document).ready(function()
           transformOutput: wrapIntoMain,
           defaultOutput: "All tests passed",
           keepCode: true,
-          outputHeight: "auto"
+          outputHeight: "auto",
+          backend: "tour"
         });
     });
 });


### PR DESCRIPTION
Proof of concept PR (it's ugly!) to switch over to the DLang Tour as code executor for the executable blocks on dlang.org

However, unfortunately DLang Tour doesn't support `STDIN` nor `ARGS`, so it would only work for the runnable code block in the documentation.