### PR TITLE
Ensure that the phobos-stable directory exists

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -55,6 +55,8 @@ PHOBOS_STABLE_DIR_GENERATED=$(GENERATED)/phobos-release
 #   Makefile dependencies and rules
 PHOBOS_FILES := $(shell find $(PHOBOS_DIR) -name '*.d' -o -name '*.mak' -o -name '*.ddoc')
 PHOBOS_FILES_GENERATED := $(subst $(PHOBOS_DIR), $(PHOBOS_DIR_GENERATED), $(PHOBOS_FILES))
+$(shell [ ! -d $(PHOBOS_DIR) ] && git clone --depth=1 ${GIT_HOME}/phobos $(PHOBOS_DIR))
+$(shell [ ! -d $(PHOBOS_STABLE_DIR) ] && git clone -b v${LATEST} --depth=1 ${GIT_HOME}/phobos $(PHOBOS_STABLE_DIR))
 PHOBOS_STABLE_FILES := $(shell find $(PHOBOS_STABLE_DIR) -name '*.d' -o -name '*.mak' -o -name '*.ddoc')
 PHOBOS_STABLE_FILES_GENERATED := $(subst $(PHOBOS_STABLE_DIR), $(PHOBOS_STABLE_DIR_GENERATED), $(PHOBOS_STABLE_FILES))
 ################################################################################


### PR DESCRIPTION
A simple fix to solve the problem of a non-existent stable Phobos directory as introduced in https://github.com/dlang/dlang.org/pull/1590.

The current repository layout assumes that the latest, stable phobos
(e.g. ../phobos-2.074.0) exists. For now, this is automatically ensured
before the Makefile targets are evaluated.

A similar trick is used at the [DMD Makefile](https://github.com/dlang/dmd/blob/master/src/posix.mak#L48) and we would use `git clone` anyways.