### PR TITLE
Set bottom subnav to a single pix

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -382,7 +382,7 @@ span#search-submit span /* hide 'go' */
 {
     background: #F5F5F5;
     border: 0 solid #CCC;
-    border-width: 0 1px;
+    border-width: 0 1px 1px;
     padding-left: 1em;
     padding-right: 1em;
     width: 15em;


### PR DESCRIPTION
It's needed in the  forum, sometimes the subnav doesn't snap to the page bottom, eg here https://forum.dlang.org/post/yjpgswjigrenryplyvji@forum.dlang.org