### PR TITLE
Fix 17469 - View source code for object.d is broken

### DIFF
--- a/assert_writeln_magic.d
+++ b/assert_writeln_magic.d
@@ -188,6 +188,9 @@ void parseFile(string fileName, string destFile)
         warningf("%s is empty", inFile.name);
 
     ubyte[] sourceCode = uninitializedArray!(ubyte[])(to!size_t(inFile.size));
+    if (sourceCode.length == 0)
+        return;
+
     inFile.rawRead(sourceCode);
     LexerConfig config;
     auto cache = StringCache(StringCache.defaultBucketCount);

--- a/dpl-docs/dub.selections.json
+++ b/dpl-docs/dub.selections.json
@@ -4,11 +4,11 @@
 		"ddox": "0.15.18",
 		"experimental_allocator": "2.70.0-b1",
 		"hyphenate": "1.1.1",
-		"libasync": "0.7.9",
-		"libdparse": "0.7.0-beta.2",
+		"libasync": "0.8.3",
+		"libdparse": "0.7.0",
 		"libev": "5.0.0+4.04",
 		"libevent": "2.0.2+2.0.16",
-		"memutils": "0.4.8",
-		"vibe-d": "0.7.30"
+		"memutils": "0.4.9",
+		"vibe-d": "0.7.31"
 	}
 }

--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -163,7 +163,7 @@ html(lang='en-US')
             - string project = "dlang.org";
             - string path_prefix, line_suffix, filename;
             - if( modname )
-              - if( modname.startsWith("core.") )
+              - if( modname.startsWith("core.") || modname.startsWith("object"))
                 - project = "druntime", path_prefix = "src/";
               - else if( modname.startsWith("dmd.") || modname.startsWith("ddmd.") )
                 - project = "dmd", path_prefix = "src/";


### PR DESCRIPTION
Due to [17131](https://issues.dlang.org/show_bug.cgi?id=17131) a DUB dependency upgrade was necessary. I discovered that the assert-rewrite pipeline doesn't like empty files like the ones generated from the `publictests` target. A proper solution is to make the assert_writeln pipeline more selective, but the first commit should is a simple solution for now.