### PR TITLE
Add labels to spec/lex.dd

### DIFF
--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -370,7 +370,7 @@ $(GNAME TokenString):
 	$(P In all string literal forms, an $(GLINK EndOfLine) is regarded as a single
 	$(D \n) character.)
 
-$(H4 Wysiwyg Strings)
+$(H4 $(LNAME2 wysiwyg, Wysiwyg Strings))
 
 	$(P
 	Wysiwyg ("what you see is what you get") quoted strings are enclosed by r" and ".
@@ -402,7 +402,7 @@ r"ab\n" // string is 4 characters,
         // 'a', '"', 'b', '\', 'n'
 ---------------
 
-$(H4 Double Quoted Strings)
+$(H4 $(LNAME2 double_quoted_strings, Double Quoted Strings))
 
 	$(P Double quoted strings are enclosed by "". Escape sequences can be
 	embedded into them with the typical $(D \) notation.)
@@ -419,7 +419,7 @@ $(H4 Double Quoted Strings)
 
 
 
-$(H4 Hex Strings)
+$(H4 $(LNAME2 hex_strings, Hex Strings))
 
 	$(P Hex strings allow string literals to be created using hex data.
 	The hex data need not form valid UTF characters.
@@ -481,7 +481,7 @@ r"a" ~ "bc"
 	$(P String literals are read only. Writes to string literals
 	cannot always be detected, but cause undefined behavior.)
 
-$(H4 Delimited Strings)
+$(H4 $(LNAME2 delimited_strings, Delimited Strings))
 
 	$(P Delimited strings use various forms of delimiters.
 	The delimiter, whether a character or identifer,
@@ -532,7 +532,7 @@ q"/foo]/"          // "foo]"
 // q"/abc/def/"    // error
 ---
 
-$(H4 Token Strings)
+$(H4 $(LNAME2 token_strings, Token Strings))
 
 	$(P Token strings open with the characters $(D q)$(CODE_LCURL) and close with
 	the token $(CODE_RCURL). In between must be valid D tokens.
@@ -551,7 +551,7 @@ q{ __TIME__ }       // " __TIME__ "
     // __EOF__ is not a token, it's end of file
 ---
 
-$(H4 Escape Sequences)
+$(H4 $(LNAME2 escape_sequences, Escape Sequences))
 
     $(P The following table explains the meaning of the escape sequences listed
     in $(GLINK EscapeSequence):)


### PR DESCRIPTION
Labels are nice and necessary if you want to direct a reader to a specific place of the D spec.