### PR TITLE
More expressive variable name in opApply example.

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -628,15 +628,15 @@ $(H4 $(LNAME2 foreach_over_struct_and_classes, Foreach over Structs and Classes 
 
             int opApply(scope int delegate(ref uint) dg)
             {
-                int result = 0;
+                int abort = 0;
 
                 for (int i = 0; i < array.length; i++)
                 {
-                    result = dg(array[i]);
-                    if (result)
+                    abort = dg(array[i]);
+                    if (abort)
                         break;
                 }
-                return result;
+                return abort;
             }
         }
         --------------


### PR DESCRIPTION
Replace the variable name "result" with "abort".