### PR TITLE
Fix Issue 17501 - Runnable unittest problem with AST rewrite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+dist: trusty
+sudo: false
+
+language: d
+os:
+ - linux
+d:
+ - dmd
+ - dmd-beta
+ - dmd-nightly
+ - ldc
+ - ldc-beta
+
+script:
+  - make -f posix.mak test

--- a/changelog/2.072.0.dd
+++ b/changelog/2.072.0.dd
@@ -372,13 +372,13 @@ $(BUGSTITLE Library Changes,
             or program may malfunction due to changed call order of module static construction/destruction.
             In order to preserve the program behaviour without the need to specify `--DRT-oncycle` command line argument,
             it is possible to instruct the linker by declaring the following array in the source code:)
-            
+
             ---
             extern(C) __gshared string[] rt_options = [ "oncycle=ignore" ];
             ---
-            
+
         ($P For more information, please consult the D language specification, section Overriding Cycle Detection Abort in chapter 4
-            and chapter 28.7 Configuring the Garbage Collector.)        
+            and chapter 28.7 Configuring the Garbage Collector.)
     )
 
     $(LI $(LNAME2 std-digest-murmurhash, Implementation of `std.digest.murmurhash`).

--- a/changelog/2.073.0.dd
+++ b/changelog/2.073.0.dd
@@ -37,7 +37,7 @@ $(BUGSTITLE Compiler changes,
 $(LI $(LNAME2 mscrtlib-option,New command line option $(B -mscrtlib=$(I libname)) for Windows MS-COFF object files.)
     $(P
         If building MS-COFF object files with -m64 or -m32mscoff, this option
-        specifies the reference to the C runtime library $(I libname) that is 
+        specifies the reference to the C runtime library $(I libname) that is
         embedded into the object file containing `main`,
         `DllMain` or `WinMain` for automatic linking. The default is $(TT libcmt)
         (release version with static linkage), the other usual alternatives are

--- a/foundation.dd
+++ b/foundation.dd
@@ -63,8 +63,8 @@ $(H3 Official contacts)
 $(P The D Language Foundation has been incorporated with the state of Washington, USA.
     The employer ID is 47-5352856.)
 
-$(P To contact the D Language Foundation, please direct emails to 
-$(LINK2 mailto:foundation@dlang.org, foundation@dlang.org) and other correspondence to 
+$(P To contact the D Language Foundation, please direct emails to
+$(LINK2 mailto:foundation@dlang.org, foundation@dlang.org) and other correspondence to
 6830 NE Bothell Way, Suite C-162, Kenmore WA 98028.)
 
 )

--- a/posix.mak
+++ b/posix.mak
@@ -589,12 +589,12 @@ d.tag : chmgen.d $(STABLE_DMD) $(ALL_FILES) phobos-release druntime-release
 
 ASSERT_WRITELN_BIN = $(GENERATED)/assert_writeln_magic
 
-$(ASSERT_WRITELN_BIN): assert_writeln_magic.d $(DUB)
+$(ASSERT_WRITELN_BIN): assert_writeln_magic.d $(DUB) $(STABLE_DMD)
 	@mkdir -p $(dir $@)
 	$(DUB) build --single --compiler=$(STABLE_DMD) $<
 	@mv ./assert_writeln_magic $@
 
-$(ASSERT_WRITELN_BIN)_test: assert_writeln_magic.d $(DUB)
+$(ASSERT_WRITELN_BIN)_test: assert_writeln_magic.d $(DUB) $(STABLE_DMD)
 	@mkdir -p $(dir $@)
 	$(DUB) build --single --compiler=$(STABLE_DMD) --build=unittest $<
 	@mv ./assert_writeln_magic $@

--- a/posix.mak
+++ b/posix.mak
@@ -560,7 +560,7 @@ ${STABLE_DMD}:
 		unzip -qd ${STABLE_DMD_ROOT} $${TMPFILE}.zip && rm $${TMPFILE}.zip
 
 ${DUB}: ${DUB_DIR} ${STABLE_DMD}
-	cd ${DUB_DIR} && DC="$(abspath ${STABLE_DMD}) -conf=$(abspath ${STABLE_DMD_CONF})" ./build.sh
+	cd ${DUB_DIR} && DMD="${STABLE_DMD}" ./build.sh
 
 ################################################################################
 # chm help files

--- a/posix.mak
+++ b/posix.mak
@@ -594,6 +594,11 @@ $(ASSERT_WRITELN_BIN): assert_writeln_magic.d $(DUB)
 	$(DUB) build --single --compiler=$(STABLE_DMD) $<
 	@mv ./assert_writeln_magic $@
 
+$(ASSERT_WRITELN_BIN)_test: assert_writeln_magic.d $(DUB)
+	@mkdir -p $(dir $@)
+	$(DUB) build --single --compiler=$(STABLE_DMD) --build=unittest $<
+	@mv ./assert_writeln_magic $@
+
 $(PHOBOS_FILES_GENERATED): $(PHOBOS_DIR_GENERATED)/%: $(PHOBOS_DIR)/% $(DUB) $(ASSERT_WRITELN_BIN)
 	@mkdir -p $(dir $@)
 	@if [ $(subst .,, $(suffix $@)) == "d" ] && [ "$@" != "$(PHOBOS_DIR_GENERATED)/index.d" ] ; then \
@@ -610,9 +615,12 @@ $(PHOBOS_STABLE_FILES_GENERATED): $(PHOBOS_STABLE_DIR_GENERATED)/%: $(PHOBOS_STA
 # Style tests
 ################################################################################
 
-test:
+test: $(ASSERT_WRITELN_BIN)_test
 	@echo "Searching for trailing whitespace"
-	if [[ $$(find . -type f -name "*.dd" -exec egrep -l " +$$" {} \;) ]] ;  then $$(exit 1); fi
+	@echo "Check for trailing whitespace"
+	grep -n '[[:blank:]]$$' $$(find . -type f -name "*.dd") ; test $$? -eq 1
+	@echo "Executing assert_writeln_magic tests"
+	$<
 
 ################################################################################
 # Changelog generation

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -703,8 +703,8 @@ $(CONSOLE
         --------------
 
     $(P It is important to make sure that, if $(D opApply) catches any exceptions, that those
-        exceptions did not originate from the delegate passed to $(I opApply). The user would expect 
-        exceptions thrown from a `foreach` body to both terminate the loop, and propagate outside 
+        exceptions did not originate from the delegate passed to $(I opApply). The user would expect
+        exceptions thrown from a `foreach` body to both terminate the loop, and propagate outside
         the `foreach` body.
      )
 


### PR DESCRIPTION
@CyberShadow are you okay with enabling Travis here, s.t. we can easily run `test` on a CI?

It works on my fork:
https://travis-ci.org/wilzbach/dlang.org

![image](https://user-images.githubusercontent.com/4370550/27160728-8a6738ca-5176-11e7-9d78-1321b47966a0.png)


(I also wanted to revive the PR in which we build dlang.org from scratch on Travis, but that would be another step).