### PR TITLE
Use only one instance for the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,6 @@ sudo: false
 language: d
 os:
  - linux
-d:
- - dmd
- - dmd-beta
- - dmd-nightly
- - ldc
- - ldc-beta
 
 script:
   - make -f posix.mak test


### PR DESCRIPTION
Follow-up to #1693

There's no point in testing with many compilers as we download and use `STABLE_DMD` anyhow.
