### PR TITLE
Link to release description on downloads.dd

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -267,6 +267,16 @@ Macros:
         </div>
         )
     )
+    C_A=$1:$2;
+    EXTRA_HEADERS=$(T style,
+        .download_paragraph > span {
+            visibility: hidden;
+            $(C_A font-size, 125%)
+        }
+        .download_paragraph:hover > span {
+            visibility: visible;
+        }
+    )
     DOWNLOAD_OTHER =
     $(DIV,
         $(DIVC download_image, $1)

--- a/download.dd
+++ b/download.dd
@@ -64,17 +64,29 @@ $(DIVC download_channels,
 
     $(BR)$(BR)
 
-    $(DOWNLOAD $(WINDOWS), Windows, $(SBTN $(WINEXE), exe) $(SBTN $(ARCH windows, 7z), 7z))
+    $(DOWNLOAD Windows, $(WINDOWS), windows,
+        $(SBTN $(WINEXE), exe) $(SBTN $(ARCH windows, 7z), 7z)
+    )
 
-    $(DOWNLOAD $(OSX), OS X, $(SBTN $(OSXDMG), dmg) $(SBTN $(ARCH osx, tar.xz), tar.xz))
+    $(DOWNLOAD macOS, $(OSX), osx,
+        $(SBTN $(ARCH osx, tar.xz), tar.xz)
+    )
 
-    $(DOWNLOAD $(UBUNTU) &nbsp; $(DEBIAN), Ubuntu/Debian, $(SBTN $(DEB32), i386) $(SBTN $(DEB64), x86_64) $(SBTN $(ARCH linux, tar.xz), tar.xz))
+    $(DOWNLOAD Ubuntu/Debian, $(UBUNTU) &nbsp; $(DEBIAN), linux,
+        $(SBTN $(DEB32), i386) $(SBTN $(DEB64), x86_64) $(SBTN $(ARCH linux, tar.xz), tar.xz)
+    )
 
-    $(DOWNLOAD $(FEDORA) &nbsp; $(CENTOS), Fedora/CentOS, $(SBTN $(RPM32), i386) $(SBTN $(RPM64), x86_64) $(SBTN $(ARCH linux, tar.xz), tar.xz))
+    $(DOWNLOAD Fedore/CentOS, $(FEDORA) &nbsp; $(CENTOS), linux,
+        $(SBTN $(RPM32), i386) $(SBTN $(RPM64), x86_64) $(SBTN $(ARCH linux, tar.xz), tar.xz)
+    )
 
-    $(DOWNLOAD $(OPENSUSE), openSUSE, $(SBTN $(SUSE32), i386) $(SBTN $(SUSE64), x86_64) $(SBTN $(ARCH linux, tar.xz), tar.xz))
+    $(DOWNLOAD openSUSE, $(OPENSUSE), linux,
+        $(SBTN $(SUSE32), i386) $(SBTN $(SUSE64), x86_64) $(SBTN $(ARCH linux, tar.xz), tar.xz)
+    )
 
-    $(DOWNLOAD $(FREEBSD), FreeBSD, $(SBTN $(ARCH freebsd-32, tar.xz), i386) $(SBTN $(ARCH freebsd-64, tar.xz), x86_64))
+    $(DOWNLOAD FreeBSD, $(FREEBSD), linux,
+         $(SBTN $(ARCH freebsd-32, tar.xz), i386) $(SBTN $(ARCH freebsd-64, tar.xz), x86_64)
+    )
 
     $(INSTALL_SCRIPT curl -fsS https://dlang.org/install.sh | bash -s dmd)
   )
@@ -86,17 +98,29 @@ $(DIVC download_channels,
 
     $(BR)$(BR)
 
-    $(DOWNLOAD $(WINDOWS), Windows, $(SBTN $(B_WINEXE), exe) $(SBTN $(B_ARCH windows, 7z), 7z))
+    $(DOWNLOAD Windows, $(WINDOWS), windows,
+        $(SBTN $(B_WINEXE), exe) $(SBTN $(B_ARCH windows, 7z), 7z)
+    )
 
-    $(DOWNLOAD $(OSX), OS X, $(SBTN $(B_OSXDMG), dmg) $(SBTN $(B_ARCH osx, tar.xz), tar.xz))
+    $(DOWNLOAD macOS, $(OSX), osx,
+        $(SBTN $(B_OSXDMG), dmg) $(SBTN $(B_ARCH osx, tar.xz), tar.xz)
+    )
 
-    $(DOWNLOAD $(UBUNTU) &nbsp; $(DEBIAN), Ubuntu/Debian, $(SBTN $(B_DEB32), i386) $(SBTN $(B_DEB64), x86_64) $(SBTN $(B_ARCH linux, tar.xz), tar.xz))
+    $(DOWNLOAD Ubuntu/Debian, $(UBUNTU) &nbsp; $(DEBIAN), linux,
+        $(SBTN $(B_DEB32), i386) $(SBTN $(B_DEB64), x86_64) $(SBTN $(B_ARCH linux, tar.xz), tar.xz)
+    )
 
-    $(DOWNLOAD $(FEDORA) &nbsp; $(CENTOS), Fedora/CentOS, $(SBTN $(B_RPM32), i386) $(SBTN $(B_RPM64), x86_64) $(SBTN $(B_ARCH linux, tar.xz), tar.xz))
+    $(DOWNLOAD Fedore/CentOS, $(FEDORA) &nbsp; $(CENTOS), linux,
+        $(SBTN $(B_RPM32), i386) $(SBTN $(B_RPM64), x86_64) $(SBTN $(B_ARCH linux, tar.xz), tar.xz)
+    )
 
-    $(DOWNLOAD $(OPENSUSE), openSUSE, $(SBTN $(B_SUSE32), i386) $(SBTN $(B_SUSE64), x86_64) $(SBTN $(B_ARCH linux, tar.xz), tar.xz))
+    $(DOWNLOAD openSUSE, $(OPENSUSE), linux,
+        $(SBTN $(B_SUSE32), i386) $(SBTN $(B_SUSE64), x86_64) $(SBTN $(B_ARCH linux, tar.xz), tar.xz)
+    )
 
-    $(DOWNLOAD $(FREEBSD), FreeBSD, $(SBTN $(B_ARCH freebsd-32, tar.xz), i386) $(SBTN $(B_ARCH freebsd-64, tar.xz), x86_64))
+    $(DOWNLOAD FreeBSD, $(FREEBSD), linux,
+        $(SBTN $(B_ARCH freebsd-32, tar.xz), i386) $(SBTN $(B_ARCH freebsd-64, tar.xz), x86_64)
+    )
 
     $(INSTALL_SCRIPT curl -fsS https://dlang.org/install.sh | bash -s dmd-beta)
     )
@@ -107,17 +131,29 @@ $(DIVC download_channels,
 
     $(BR)$(BR)
 
-    $(DOWNLOAD $(WINDOWS), Windows, $(SBTN $(N_ARCH windows, 7z), 7z))
+    $(DOWNLOAD Windows, $(WINDOWS), windows,
+        $(SBTN $(N_ARCH windows, 7z), 7z)
+    )
 
-    $(DOWNLOAD $(OSX), OS X, $(SBTN $(N_ARCH osx, tar.xz), tar.xz))
+    $(DOWNLOAD macOS, $(OSX), osx,
+        $(SBTN $(N_ARCH osx, tar.xz), tar.xz)
+    )
 
-    $(DOWNLOAD $(UBUNTU) &nbsp; $(DEBIAN), Ubuntu/Debian, $(SBTN $(N_ARCH linux, tar.xz), tar.xz))
+    $(DOWNLOAD Ubuntu/Debian, $(UBUNTU) &nbsp; $(DEBIAN), linux,
+        $(SBTN $(N_ARCH linux, tar.xz), tar.xz)
+    )
 
-    $(DOWNLOAD $(FEDORA) &nbsp; $(CENTOS), Fedora/CentOS, $(SBTN $(N_ARCH linux, tar.xz), tar.xz))
+    $(DOWNLOAD Fedore/CentOS, $(FEDORA) &nbsp; $(CENTOS), linux,
+        $(SBTN $(N_ARCH linux, tar.xz), tar.xz)
+    )
 
-    $(DOWNLOAD $(OPENSUSE), openSUSE, $(SBTN $(N_ARCH linux, tar.xz), tar.xz))
+    $(DOWNLOAD openSUSE, $(OPENSUSE), linux,
+        $(SBTN $(N_ARCH linux, tar.xz), tar.xz)
+    )
 
-    $(DOWNLOAD $(FREEBSD), FreeBSD, $(SBTN $(N_ARCH freebsd-32, tar.xz), i386) $(SBTN $(N_ARCH freebsd-64, tar.xz), x86_64))
+    $(DOWNLOAD FreeBSD, $(FREEBSD), linux,
+        $(SBTN $(N_ARCH freebsd-32, tar.xz), i386) $(SBTN $(N_ARCH freebsd-64, tar.xz), x86_64)
+    )
 
     $(INSTALL_SCRIPT curl -fsS https://dlang.org/install.sh | bash -s dmd-nightly)
   )
@@ -136,21 +172,21 @@ $(H2 Third-party downloads)
 These links are not maintained by the same people maintaining the official downloads.
 $(BR)$(BR)
 
-$(DOWNLOAD $(ARCHLINUX), $(LINK2 https://wiki.archlinux.org/index.php/D_(programming_language), Arch Linux), $(CONSOLE pacman -S dlang))
+$(DOWNLOAD_OTHER $(ARCHLINUX), $(LINK2 https://wiki.archlinux.org/index.php/D_(programming_language), Arch Linux), $(CONSOLE pacman -S dlang))
 
-$(DOWNLOAD $(CHOCOLATEY), Chocolatey, $(CONSOLE choco install dmd))
+$(DOWNLOAD_OTHER $(CHOCOLATEY), Chocolatey, $(CONSOLE choco install dmd))
 
-$(DOWNLOAD $(GENTOO), $(LINK2 https://wiki.gentoo.org/wiki/Dlang, Gentoo), $(CONSOLE layman -f -a dlang))
+$(DOWNLOAD_OTHER $(GENTOO), $(LINK2 https://wiki.gentoo.org/wiki/Dlang, Gentoo), $(CONSOLE layman -f -a dlang))
 
-$(DOWNLOAD $(HOMEBREW), Homebrew, $(CONSOLE brew install dmd))
+$(DOWNLOAD_OTHER $(HOMEBREW), Homebrew, $(CONSOLE brew install dmd))
 
-$(DOWNLOAD $(UBUNTU) $(DEBIAN), Ubuntu/Debian, $(LINK2 http://d-apt.sourceforge.net/, APT repository)
+$(DOWNLOAD_OTHER $(UBUNTU) $(DEBIAN), Ubuntu/Debian, $(LINK2 http://d-apt.sourceforge.net/, APT repository)
 $(CONSOLE sudo wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
 sudo apt-get update && sudo apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
 sudo apt-get update && sudo apt-get install dmd-compiler)
 )
 
-$(DOWNLOAD $(OPENSUSE), OpenSUSE Tumbleweed, $(CONSOLE sudo zypper install dmd))
+$(DOWNLOAD_OTHER $(OPENSUSE), OpenSUSE Tumbleweed, $(CONSOLE sudo zypper install dmd))
 
 $(H2 Other Downloads)
 
@@ -210,6 +246,8 @@ Macros:
 	CHOCOLATEY=$(LOGO chocolatey, Chocolatey)
 	WINDOWS=$(LOGO windows, Windows)
 
+	LINK_OS=<a href="$(ROOT_DIR)dmd-$1.html" style="text-decoration: none;">$2</a>
+
     SBTN=$(SPANC sig_btn,$(BTN $1,$+)<br>$(BTN $1.sig,sig))
     BTN=<a href="$1" class="btn">$+</a>
     H3I=<h3 class="download">$0</h3>
@@ -217,6 +255,19 @@ Macros:
     B_DLSITE=http://downloads.dlang.org/pre-releases/2.x/$(B_DMDV2)/$0
     N_DLSITE=//nightlies.dlang.org/dmd-nightly/$0
     DOWNLOAD =
+    $(DIV,
+        $(DIVC download_image, $2)
+        $(DIVC download_paragraph,
+        <h3 style="display: inline-block">$1</h3>
+        <span style="display: inline-block">
+            $(LINK_OS $3, <i class="fa fa-info-circle" aria-hidden="true"></i>)
+        </span>
+        <div style="">
+            $4
+        </div>
+        )
+    )
+    DOWNLOAD_OTHER =
     $(DIV,
         $(DIVC download_image, $1)
         $(DIVC download_paragraph, $(H3 $2) $3)


### PR DESCRIPTION
Cherry-picked from #1694 as this was controversial:

> Not sure about making the platform name a link to the documentation. I'd think that being on the 
download page, clicking it would take me to all Windows downloads.

We could also add a link "Docs", but I though that this is the leaner way to do it.