### PR TITLE
Fix Issue 17305 - [SPEC] ABI page still has references to D1 Phobos

### DIFF
--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -869,11 +869,11 @@ $(H3 $(LNAME2 exception_handling, Exception Handling))
 
 $(H3 $(LNAME2 garbage_collection, Garbage Collection))
 
-	$(P The interface to this is found in $(D phobos/internal/gc).)
+	$(P The interface to this is found in Druntime's $(DRUNTIMESRC gc/gcinterface.d).)
 
 $(H3 $(LNAME2 runtime_helper_functions, Runtime Helper Functions))
 
-	$(P These are found in $(D phobos/internal).)
+	$(P These are found in Druntime's $(DRUNTIMESRC rt/).)
 
 $(H3 $(LNAME2 module_init_and_fina, Module Initialization and Termination))
 


### PR DESCRIPTION
We really need someone going over the spec/website regularly ... - there's so much room for improvement ;-)

CC @ibuclaw 