### PR TITLE
Fix Issue 17159 - Behavior of unions at compile time is not documented

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2104,6 +2104,7 @@ $(H3 $(LNAME2 interpretation, Compile Time Function Execution (CTFE)))
     $(LI Non-portable casts (eg, from $(D int[]) to $(D float[])), including
         casts which depend on endianness, are not permitted.
         Casts between signed and unsigned types are permitted)
+    $(LI Reinterpretation of overlapped fields in a Union.)
     )
 
     $(P Pointers are permitted in CTFE, provided they are used safely:)


### PR DESCRIPTION
```d
void main(string[] args)
{
    union U {
        int a;
        double b;
    }
    enum u = U(1);
    enum c = u.b;
}
```

```
> rdmd foo.d
foo.d(8): Error: reinterpretation through overlapped field b is not allowed in CTFE
```

CC @UplinkCoder 