### PR TITLE
Fix Issue 17121 - DDoc documentation is out of date

### DIFF
--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -682,6 +682,8 @@ $(P
     minimal definitions needed by Ddoc to format and highlight
     the presentation.
     The definitions are for simple HTML.
+    The $(LINK2 https://github.com/dlang/dmd/blob/master/res/default_ddoc_theme.ddoc,
+    curent defintion) is a bit enhanced and includes more styling.
 )
 
 $(DDOCCODE

--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -683,7 +683,7 @@ $(P
     the presentation.
     The definitions are for simple HTML.
     The $(LINK2 https://github.com/dlang/dmd/blob/master/res/default_ddoc_theme.ddoc,
-    curent defintion) is a bit enhanced and includes more styling.
+    current definition) is a bit enhanced and provides more options for styling.
 )
 
 $(DDOCCODE


### PR DESCRIPTION
Not really sure on the best course of action here. Just dumping the entire file with all its stylesheets feels wrong.

> The new predefined macros are in a separate file [1]. Is it possible to embed that in the rest of the Ddoc documentation?

@jacob-carlborg I guess you would like to be able to preprocess DDoc, e.g. https://github.com/dlang/dlang.org/pull/1688?

CC @acehreli 