### PR TITLE
Add footer navigation to the DLang specification

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -488,4 +488,6 @@ YELLOW=$(SPANC yellow, $0)
 YES=$(CHECKMARK)
 
 PROJECT_SOURCE_DIR=
+
+FA_ICON=<i class="fa fa-$1" aria-hidden="true"></i>
 _=

--- a/orgs-using-d.dd
+++ b/orgs-using-d.dd
@@ -209,7 +209,6 @@ $(P
 
 Macros:
     TITLE=Organizations using the D Language
-    FA_ICON=<i class="fa fa-$1" aria-hidden="true"></i>
     FA_HIRING=$(FA_ICON rocket) $(HTTP $1, Hiring)
     FA_GITHUB=$(FA_ICON github) $(HTTPS github.com/$1, Github)
     FA_TALK=$(FA_ICON youtube-play) $(HTTP $1, $2)

--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -954,6 +954,7 @@ $(H3 $(LNAME2 codeview, Codeview Debugger Extensions))
 	$(P The $(LINK2 http://ddbg.mainia.de/releases.html, Ddbg) debugger
 	supports them.)
 	)
+$(SPEC_SUBNAV_PREV_NEXT memory-safe-d, Memory Safety, simd, Vector Extensions)
 )
 
 Macros:

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -983,6 +983,7 @@ $(H2 $(LNAME2 implicit-conversions, Implicit Conversions))
         )
 
         $(P Where $(D U) is a base class of $(D T).)
+$(SPEC_SUBNAV_PREV_NEXT statement, Statements, hash-map, Associative Arrays)
 )
 
 Macros:

--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -813,6 +813,7 @@ pragma(msg, __traits(getAttributes, typeof(a))); // prints tuple("hello")
             attributes accumulate or override earlier ones is also up to how the user
             interprets them.
         )
+$(SPEC_SUBNAV_PREV_NEXT property, Properties, pragma, Pragmas)
 )
 
 Macros:

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -1343,6 +1343,7 @@ $(SECTION3 $(LEGACY_LNAME2 ConstClass, const-class, Const, Immutable and Shared 
         from it are also const, immutable or shared.
     )
 )
+$(SPEC_SUBNAV_PREV_NEXT struct, Structs and Unions, interface, Interfaces)
 )
 
 Macros:

--- a/spec/const3.dd
+++ b/spec/const3.dd
@@ -464,6 +464,7 @@ void main()
 	)
 
 
+$(SPEC_SUBNAV_PREV_NEXT enum, Enums, function, Functions)
 )
 
 Macros:

--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -256,6 +256,7 @@ $(H2 $(LNAME2 references, References))
 	$(LINK2 http://jan.newmarch.name/java/contracts/paper-long.html, Adding Contracts to Java)
 	)
 
+$(SPEC_SUBNAV_PREV_NEXT template-mixin, Template Mixins, version, Conditional Compilation)
 )
 
 Macros:

--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -892,6 +892,7 @@ foo(cast(immutable)&i, &i);
 )
 )
 
+$(SPEC_SUBNAV_PREV_NEXT interfaceToC, Interfacing to C, objc_interface, Interfacing to Objective-C)
 )
 
 Macros:

--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -1050,6 +1050,7 @@ $(P
     can be found on our $(LINK2 https://wiki.dlang.org/Community:Open_Source_Projects, wiki page).
 )
 
+$(SPEC_SUBNAV_PREV_NEXT iasm, D x86 Inline Assembler, interfaceToC, Interfacing to C)
 )
 
 Macros:

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -737,6 +737,7 @@ struct S
 }
 --------
 
+$(SPEC_SUBNAV_PREV_NEXT module, Modules, type, Types)
 )
 
 

--- a/spec/entity.dd
+++ b/spec/entity.dd
@@ -284,6 +284,7 @@ $(BR)
    $(TROW $(D lang), $(ARGS 10216), $(LANG))
    $(TROW $(D rang), $(ARGS 10217), $(RANG))
    )
+$(SPEC_SUBNAV_PREV_NEXT portability, Portability Guide, memory-safe-d, Memory Safety)
 )
 
 Macros:

--- a/spec/enum.dd
+++ b/spec/enum.dd
@@ -261,6 +261,7 @@ enum size = __traits(classInstanceSize, Foo);  // evaluated at compile-time
 	to force compile-time evaluation of an expression.)
 
 
+$(SPEC_SUBNAV_PREV_NEXT interface, Interfaces, const3, Type Qualifiers)
 )
 
 Macros:

--- a/spec/errors.dd
+++ b/spec/errors.dd
@@ -206,6 +206,7 @@ $(COMMENT
 	)
 )
 
+$(SPEC_SUBNAV_PREV_NEXT traits, Traits, unittest, Unit Tests)
 )
 
 Macros:

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2148,6 +2148,7 @@ $(H3 $(LNAME2 associativity, Associativity and Commutativity))
     $(P This rule precludes any associative or commutative reordering of
         floating point expressions.
     )
+$(SPEC_SUBNAV_PREV_NEXT pragma, Pragmas, statement, Statements)
 )
 
 Macros:

--- a/spec/float.dd
+++ b/spec/float.dd
@@ -179,6 +179,7 @@ $(COMMENT
 	$(P Of course, transformations that would alter side effects are also
 	invalid.)
 
+$(SPEC_SUBNAV_PREV_NEXT garbage, Garbage Collection, iasm, D x86 Inline Assembler)
 )
 
 Macros:

--- a/spec/footer_gen.d
+++ b/spec/footer_gen.d
@@ -1,0 +1,75 @@
+#!/usr/bin/env rdmd
+/*
+ * Footer generator for the specification pages.
+ * This script can be used to update the nav footers.
+ *
+ * Copyright (C) 2017 by D Language Foundation
+ *
+ * Author: Sebastian Wilzbach
+ *
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+*/
+// Written in the D programming language.
+
+void main()
+{
+    import std.algorithm, std.array, std.ascii, std.conv, std.file, std.path, std.range, std.string, std.typecons;
+    import std.stdio : File, writeln, writefln;
+    auto specDir = __FILE_FULL_PATH__.dirName.buildNormalizedPath;
+    auto mainFile = specDir.buildPath("./spec.ddoc");
+    enum ddocKey = "$(SPEC_SUBNAV_";
+
+    alias Entry = Tuple!(string, "name", string, "title");
+    Entry[] entries;
+
+    // parse the menu from the Ddoc file
+    auto specText = mainFile.readText;
+    if (!specText.findSkip("SUBMENU2"))
+        writeln("Menu file has an invalid format.");
+    foreach (line; specText.splitter("\n"))
+    {
+        enum ddocEntryStart = "$(ROOT_DIR)spec/";
+        if (line.canFind(ddocEntryStart))
+        {
+            auto ps = line.splitter(ddocEntryStart).dropOne.front.splitter(",");
+            entries ~= Entry(ps.front.stripExtension.withExtension(".dd").to!string,
+                             ps.dropOne.front.idup.strip);
+        }
+    }
+
+    foreach (i, entry; entries)
+    {
+        // build the prev|next Ddoc string
+        string navString = ddocKey;
+        if (i == 0)
+            navString ~= text("NEXT ", entries[i + 1].name.stripExtension, ", ", entries[i + 1].title);
+        else if (i < entries.length - 1)
+            navString ~= text("PREV_NEXT ", entries[i - 1].name.stripExtension, ", ", entries[i - 1].title, ", ",
+                entries[i + 1].name.stripExtension, ", ", entries[i + 1].title);
+        else
+            navString ~= text("PREV_NEXT ", entries[i - 1].name.stripExtension, ", ", entries[i - 1].title);
+
+        navString ~= ")";
+        writefln("%s: %s", entry.name, navString);
+        auto fileName = specDir.buildPath(entry.name);
+
+        auto text = fileName.readText;
+        // idempotency - check for existing tags, otherwise insert new
+        auto pos = text.representation.countUntil(ddocKey);
+        if (pos > 0)
+        {
+            auto len = text[pos .. $].representation.countUntil(")");
+            text = text.replace(text[pos .. pos + len + 1], navString);
+        }
+        else
+        {
+            // insert at the end of the ddoc page
+            auto v = text[0 .. $ - text.retro.countUntil((newline ~ "Macros:").retro)];
+            pos = v.length - v.retro.countUntil(")");
+            text.insertInPlace(pos - 1, navString ~ "\n");
+        }
+        fileName.write(text);
+    }
+}

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2470,6 +2470,7 @@ $(H3 $(LNAME2 pseudo-member, Uniform Function Call Syntax (UFCS)))
         }
         ---
 
+$(SPEC_SUBNAV_PREV_NEXT const3, Type Qualifiers, operatoroverloading, Operator Overloading)
 )
 
 Macros:

--- a/spec/garbage.dd
+++ b/spec/garbage.dd
@@ -443,6 +443,7 @@ $(H2 $(LNAME2 references, References))
 	$(LI $(AMAZONLINK 0471941484, Garbage Collection: Algorithms for Automatic Dynamic Memory Management))
 	)
 
+$(SPEC_SUBNAV_PREV_NEXT unittest, Unit Tests, float, Floating Point)
 )
 
 Macros:

--- a/spec/grammar.dd
+++ b/spec/grammar.dd
@@ -1834,6 +1834,7 @@ $(GNAME MixinDeclaration):
     $(D mixin) $(D $(LPAREN)) $(ASSIGNEXPRESSION) $(D $(RPAREN)) $(D ;)
 )
 
+$(SPEC_SUBNAV_PREV_NEXT lex, Lexical, module, Modules)
 )
 
 Macros:

--- a/spec/hash-map.dd
+++ b/spec/hash-map.dd
@@ -433,6 +433,7 @@ $(H3 $(LNAME2 aa_example, Associative Array Example: word count))
         }
         ---------
 
+$(SPEC_SUBNAV_PREV_NEXT arrays, Arrays, struct, Structs and Unions)
 )
 
 Macros:

--- a/spec/iasm.dd
+++ b/spec/iasm.dd
@@ -1159,6 +1159,7 @@ SMX
 getsec
 )
 
+$(SPEC_SUBNAV_PREV_NEXT float, Floating Point, ddoc, Embedded Documentation)
 )
 
 Macros:

--- a/spec/interface.dd
+++ b/spec/interface.dd
@@ -327,6 +327,7 @@ class Ifoo
 )
 
 
+$(SPEC_SUBNAV_PREV_NEXT class, Classes, enum, Enums)
 )
 
 Macros:

--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -355,6 +355,7 @@ $(H2 $(LEGACY_LNAME2 C Globals, c-globals, Accessing C Globals))
 extern (C) extern __gshared int x;
 ---
 
+$(SPEC_SUBNAV_PREV_NEXT ddoc, Embedded Documentation, cpp_interface, Interfacing to C++)
 )
 
 Macros:

--- a/spec/intro.dd
+++ b/spec/intro.dd
@@ -68,6 +68,7 @@ $(OL
 
 
 
+$(SPEC_SUBNAV_NEXT lex, Lexical)
 )
 
 Macros:

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -1147,6 +1147,7 @@ x;  // this is now line 6 of file foo\bar
 	$(P Note that the backslash character is not treated specially inside
 	$(GLINK Filespec) strings.
 	)
+$(SPEC_SUBNAV_PREV_NEXT intro, Introduction, grammar, Grammar)
 )
 
 Macros:

--- a/spec/memory-safe-d.dd
+++ b/spec/memory-safe-d.dd
@@ -44,6 +44,7 @@ $(H3 $(LNAME2 limitations, Limitations))
 	possibilities.
 	)
 
+$(SPEC_SUBNAV_PREV_NEXT entity, Named Character Entities, abi, Application Binary Interface)
 )
 
 Macros:

--- a/spec/module.dd
+++ b/spec/module.dd
@@ -677,6 +677,7 @@ $(H3 $(LEGACY_LNAME2 PackageModule, package-module, Package Module))
 
     void main() { }
     ---------
+$(SPEC_SUBNAV_PREV_NEXT grammar, Grammar, declaration, Declarations)
 )
 
 Macros:

--- a/spec/objc_interface.dd
+++ b/spec/objc_interface.dd
@@ -363,6 +363,7 @@ $(SPEC_S Interfacing to Objective-C,
     ---
     dmd -L-framework -LFoundation main.d
     ---
+$(SPEC_SUBNAV_PREV_NEXT cpp_interface, Interfacing to C++, portability, Portability Guide)
 )
 
 Macros:

--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -1078,6 +1078,7 @@ $(H2 $(LEGACY_LNAME2 Old-Style, old-style, D1 style operator overloading))
         are still allowed. There is no guarantee that these mechanisms will be
         supported in the future.
 	)
+$(SPEC_SUBNAV_PREV_NEXT function, Functions, template, Templates)
 )
 
 Macros:

--- a/spec/portability.dd
+++ b/spec/portability.dd
@@ -112,6 +112,7 @@ $(H2 $(LNAME2 os_specific_code, OS Specific Code))
 	specific import, and then using that constant in an
 	$(I IfStatement) or $(I StaticIfStatement).
 	)
+$(SPEC_SUBNAV_PREV_NEXT objc_interface, Interfacing to Objective-C, entity, Named Character Entities)
 )
 
 Macros:

--- a/spec/pragma.dd
+++ b/spec/pragma.dd
@@ -182,6 +182,7 @@ version (DigitalMars)
 }
 -----------------
 
+$(SPEC_SUBNAV_PREV_NEXT attribute, Attributes, expression, Expressions)
 )
 
 Macros:

--- a/spec/property.dd
+++ b/spec/property.dd
@@ -244,6 +244,7 @@ $(SECTION3 $(LNAME2 classproperties, User Defined Properties),
 	$(P User defined properties can be created using $(LINK2 function.html#property-functions, Property Functions).)
 )
 
+$(SPEC_SUBNAV_PREV_NEXT type, Types, attribute, Attributes)
 )
 
 Macros:

--- a/spec/simd.dd
+++ b/spec/simd.dd
@@ -247,6 +247,7 @@ $(H2 $(LNAME2 x86_64_vec, X86 And X86$(UNDERSCORE)64 Vector Extension Implementa
 $(H3 $(LNAME2 vector_op_intrinsics, Vector Operation Intrinsics))
 
 	$(P See $(CORE_SIMD) for the supported intrinsics.)
+$(SPEC_SUBNAV_PREV_NEXT abi, Application Binary Interface)
 )
 
 Macros:

--- a/spec/spec.ddoc
+++ b/spec/spec.ddoc
@@ -50,3 +50,21 @@ $(SUBNAV_TEMPLATE
         )
     )
 )
+SPEC_SUBNAV_NEXT=
+$(SPEC_NEXT $(LINK2 $(ROOT_DIR)/spec/$1.html, $2))
+$(CLEAR)
+
+SPEC_SUBNAV_PREV_NEXT=
+$(SPEC_PREV $(LINK2 $(ROOT_DIR)/spec/$1.html, $2))
+$(SPEC_NEXT $(LINK2 $(ROOT_DIR)/spec/$3.html, $4))
+$(CLEAR)
+
+SPEC_SUBNAV_PREV=
+$(SPEC_PREV $(LINK2 $(ROOT_DIR)/spec/$1.html, $2))
+$(CLEAR)
+
+SPEC_NEXT=<div style="float: right">$1 $(FA_ICON angle-right)</div>
+SPEC_PREV=<div style="float: left">$(FA_ICON angle-left) $1</div>
+
+CLEAR=<div style="clear:both"></div>
+_=

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1835,6 +1835,7 @@ void main()
 }
 ---
 
+$(SPEC_SUBNAV_PREV_NEXT expression, Expressions, arrays, Arrays)
 )
 
 Macros:

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -710,6 +710,7 @@ $(H2 $(LNAME2 unions_and_special_memb_funct, Unions and Special Member Functions
 
     $(P Unions may not have postblits, destructors, or invariants.)
 
+$(SPEC_SUBNAV_PREV_NEXT hash-map, Associative Arrays, class, Classes)
 )
 
 Macros:

--- a/spec/template-mixin.dd
+++ b/spec/template-mixin.dd
@@ -330,6 +330,7 @@ void test()
 }
 ------
 
+$(SPEC_SUBNAV_PREV_NEXT template, Templates, contracts, Contract Programming)
 )
 
 Macros:

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -1475,6 +1475,7 @@ $(H2 $(LNAME2 limitations, Limitations))
         }
         ------
     )
+$(SPEC_SUBNAV_PREV_NEXT operatoroverloading, Operator Overloading, template-mixin, Template Mixins)
 )
 
 Macros:

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -1071,6 +1071,7 @@ function: 'test.main', pretty function: 'int test.main(string[] args)',
 file full path: '/example/test.d'
 )
 
+$(SPEC_SUBNAV_PREV_NEXT version, Conditional Compilation, errors, Error Handling)
 )
 
 Macros:

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -338,6 +338,7 @@ $(SECTION3 $(LNAME2 ptrdiff_t, $(D ptrdiff_t)),
     $(P $(D ptrdiff_t) is an alias to the signed basic type the same size as $(D size_t).)
 )
 
+$(SPEC_SUBNAV_PREV_NEXT declaration, Declarations, property, Properties)
 )
 
 Macros:

--- a/spec/unittest.dd
+++ b/spec/unittest.dd
@@ -203,6 +203,7 @@ $(H3 $(LNAME2 versioning, Versioning))
 	is done with unit tests enabled.
 	)
 
+$(SPEC_SUBNAV_PREV_NEXT errors, Error Handling, garbage, Garbage Collection)
 )
 
 Macros:

--- a/spec/version.dd
+++ b/spec/version.dd
@@ -581,6 +581,7 @@ void foo()
 	additional information, such as a text string, that will be
 	printed out along with the error diagnostic.
 	)
+$(SPEC_SUBNAV_PREV_NEXT contracts, Contract Programming, traits, Traits)
 )
 
 Macros:


### PR DESCRIPTION
This adds a nice footer navigation to the specification documents:

![image](https://user-images.githubusercontent.com/4370550/27170926-0104b50a-51b0-11e7-90ed-e0e1b57e962a.png)

I doubt that we need to update it in the near future, but if, I put the script to do so in the `spec` folder.
Also once this is in, further navigation updates will be easier, because the Ddoc maco string can be matched nicely.