### PR TITLE
Fix invalid undefined Ddoc macros

### DIFF
--- a/faq.dd
+++ b/faq.dd
@@ -118,7 +118,7 @@ $(ITEM shared_synchronized, What does shared have to do with synchronization?)
 
 $(ITEM shared_memory_barriers, What does shared have to do with memory barriers?)
 
-	$(Currently the compiler does not insert memory barriers around shared variables.
+	$(P Currently the compiler does not insert memory barriers around shared variables.
 	)
 
 $(ITEM casting_to_shared, What are the semantics of casting FROM unshared TO shared?)

--- a/forum-template.dd
+++ b/forum-template.dd
@@ -32,7 +32,7 @@ $(DIVID footernav,
 	$(A /, Forum index) |
 	$(A /help#about, About this forum)
 )
-$(DIVCID smallprint, copyright, $(COPYRIGHT))
+$(DIVCID smallprint, copyright, $(COPYRIGHT_FOUNDATION))
 _=
 
 SUBNAV=


### PR DESCRIPTION
Seems like we should really check for such errors automatically ...

Discovered in https://github.com/dlang/dlang.org/pull/1694#issuecomment-308663796