### PR TITLE
Switch to CircleCi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-dist: trusty
-sudo: false
-
-language: d
-os:
- - linux
-
-script:
-  - make -f posix.mak test

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - make -f posix.mak test


### PR DESCRIPTION
> Travis stuck again.

OK, apparently we can't use Travis for any other repo except for DMD.
Then let's switch to CircleCi. It's very trivial here as all setup is done within the Makefile :)

Worked immediately on my fork: https://circleci.com/gh/wilzbach/dlang.org/2