### PR TITLE
Renname DDOC_VARS_STABLE -> DDOC_VARS_STABLE_HTML

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -110,7 +110,7 @@ endif
 ################################################################################
 # Ddoc build variables
 ################################################################################
-DDOC_VARS_STABLE=\
+DDOC_VARS_STABLE_HTML=\
 	  DOC_OUTPUT_DIR="${DOC_OUTPUT_DIR}/phobos" \
 	  STDDOC="$(addprefix $(PWD)/, $(STD_DDOC))" \
 	  DMD="$(DMD_STABLE)" \
@@ -401,7 +401,7 @@ $(DMD_STABLE) : ${DMD_STABLE_DIR}
 	${MAKE} --directory=${DMD_STABLE_DIR}/src -f posix.mak AUTO_BOOTSTRAP=1
 
 dmd-release : $(STD_DDOC) $(DMD_STABLE_DIR) $(DMD_STABLE)
-	$(MAKE) AUTO_BOOTSTRAP=1 --directory=$(DMD_STABLE_DIR) -f posix.mak html $(DDOC_VARS_STABLE)
+	$(MAKE) AUTO_BOOTSTRAP=1 --directory=$(DMD_STABLE_DIR) -f posix.mak html $(DDOC_VARS_STABLE_HTML)
 
 dmd-prerelease : $(STD_DDOC_PRE) $(DMD_DIR) $(DMD)
 	$(MAKE) AUTO_BOOTSTRAP=1 --directory=$(DMD_DIR) -f posix.mak html $(DDOC_VARS_HTML)
@@ -426,7 +426,7 @@ druntime-prerelease : ${DRUNTIME_DIR} $(DMD) $(STD_DDOC_PRE)
 		DOCFMT="$(addprefix `pwd`/, $(STD_DDOC_PRE))"
 
 druntime-release : ${DRUNTIME_STABLE_DIR} $(DMD_STABLE) $(STD_DDOC)
-	${MAKE} --directory=${DRUNTIME_STABLE_DIR} -f posix.mak target doc $(DDOC_VARS_STABLE) \
+	${MAKE} --directory=${DRUNTIME_STABLE_DIR} -f posix.mak target doc $(DDOC_VARS_STABLE_HTML) \
 	  DOCDIR=${DOC_OUTPUT_DIR}/phobos \
 	  DOCFMT="$(addprefix `pwd`/, $(STD_DDOC))"
 
@@ -451,7 +451,7 @@ phobos-prerelease : ${PHOBOS_FILES_GENERATED} $(STD_DDOC_PRE) druntime-prereleas
 
 phobos-release : ${PHOBOS_STABLE_FILES_GENERATED} $(DMD_STABLE) $(STD_DDOC) \
 		druntime-release dmd-release
-	$(MAKE) --directory=$(PHOBOS_STABLE_DIR_GENERATED) -f posix.mak html $(DDOC_VARS_STABLE)
+	$(MAKE) --directory=$(PHOBOS_STABLE_DIR_GENERATED) -f posix.mak html $(DDOC_VARS_STABLE_HTML)
 
 phobos-prerelease-verbatim : ${PHOBOS_FILES_GENERATED} ${DOC_OUTPUT_DIR}/phobos-prerelease/index.verbatim
 ${DOC_OUTPUT_DIR}/phobos-prerelease/index.verbatim : verbatim.ddoc \


### PR DESCRIPTION
Follow-up to https://github.com/dlang/dlang.org/commit/4129e45951a56c90a7245b41d0ca01c23fa8206d

> The term `DDOC_VARS_STABLE` doesn't relate to `DDOC_VARS_HTML` and `DDOC_VARS_VERBATIM`.
Following the existing naming schemas, it prolly should be named `DDOC_VARS_HTML_STABLE`, 

OK (see this PR).

> or maybe you just use 2 variables `DDOC_VARS_HTML` and `DDOC_VARS_STABLE` (for the compiler) here.

I am already proud that I reduced them from being spread everyone to one common place ;-)
Do I understand you correctly that instead of:

```
DDOC_VARS=\
	DMD="${DMD}" \
	DRUNTIME_PATH="${DRUNTIME_DIR}" \
	DOCSRC="$(PWD)" \
	VERSION="${DMD_DIR}/VERSION"

DDOC_VARS_HTML=$(DDOC_VARS) \
	DOC_OUTPUT_DIR="${DOC_OUTPUT_DIR}/phobos-prerelease" \
	STDDOC="$(addprefix $(PWD)/, $(STD_DDOC_PRE))"

DDOC_VARS_VERBATIM=$(DDOC_VARS) \
	DOC_OUTPUT_DIR="${DOC_OUTPUT_DIR}/phobos-prerelease-verbatim" \
	STDDOC="$(PWD)/verbatim.ddoc"
```

you would want sth. like?

```
DDOC_VARS_HTML=\
	DMD="${DMD}" \
	DRUNTIME_PATH="${DRUNTIME_DIR}" \
	DOCSRC="$(PWD)" \
	VERSION="${DMD_DIR}/VERSION"
	DOC_OUTPUT_DIR="${DOC_OUTPUT_DIR}/phobos-prerelease" \
	STDDOC="$(addprefix $(PWD)/, $(STD_DDOC_PRE))"

DDOC_VARS_VERBATIM=$(DDOC_VARS_HTML) \
	DOC_OUTPUT_DIR="${DOC_OUTPUT_DIR}/phobos-prerelease-verbatim" \
	STDDOC="$(PWD)/verbatim.ddoc"
```

I am not convinced yet that this is nicer...