### PR TITLE
Use a OS-independent link to the DMD manual

### DIFF
--- a/code_coverage.dd
+++ b/code_coverage.dd
@@ -65,7 +65,7 @@ and is integrated into gcc.)
 $(P The D code coverage analyser is built in as part of the D compiler.
 Therefore, it is always in perfect synchronization with the language
 implementation. It's implemented by establishing a counter for each
-line in each module compiled with the $(DDSUBLINK dmd-windows,switch-cov, $(B -cov)) switch.
+line in each module compiled with the $(DDSUBLINK dmd,switch-cov, $(B -cov)) switch.
 Code is inserted
 at the beginning of each statement to increment the corresponding counter.
 When the program finishes, the runtime collects all
@@ -215,7 +215,7 @@ $(H3 Controlling the Coverage Analyser)
 $(COMMENT The behavior of the coverage analyser can be controlled through
 the $(DRUNTIMESRC rt/cover.d) module.)
 
-$(P When the $(DDSUBLINK dmd-windows,switch-cov, $(B -cov)) switch is thrown,
+$(P When the $(DDSUBLINK dmd,switch-cov, $(B -cov)) switch is thrown,
 the $(DDSUBLINK spec/version, PredefinedVersions, version identifier)
 $(B D_Coverage) is defined.)
 

--- a/index.dd
+++ b/index.dd
@@ -137,7 +137,7 @@ $(DIVC boxes,
                 $(LINK2 $(ROOT_DIR)spec/spec.html, language) and for
                 $(LINK2 $(ROOT_DIR)phobos/index.html, phobos), D's standard
                 library. The
-                $(LINK2 $(ROOT_DIR)dmd-windows.html, DMD manual) tells you how
+                $(LINK2 $(ROOT_DIR)dmd.html, DMD manual) tells you how
                 to use the compiler. Read
                 $(LINK2 $(ROOT_DIR)articles.html, various articles) to deepen
                 your understanding.

--- a/spec/pragma.dd
+++ b/spec/pragma.dd
@@ -82,7 +82,7 @@ $(H3 $(LEGACY_LNAME2 Predefined-Pragmas, predefined-pragmas, Predefined Pragmas)
 pragma(inline)
 ---
         Sets the behavior to match the default behavior set by the compiler switch
-        $(DDSUBLINK dmd-windows, switch-inline, $(TT -inline)).
+        $(DDSUBLINK dmd, switch-inline, $(TT -inline)).
         )
         $(LI
 ---
@@ -94,7 +94,7 @@ pragma(inline, false)
 ---
 pragma(inline, true)
 ---
-        If a function cannot be inlined with the $(DDSUBLINK dmd-windows, switch-inline, $(TT -inline))
+        If a function cannot be inlined with the $(DDSUBLINK dmd, switch-inline, $(TT -inline))
         switch, an error message is issued. This is expected to be improved in the future to causing
         functions to always be inlined regardless of compiler switch settings. Whether a compiler can
         inline a particular function or not is implementation defined.

--- a/spec/unittest.dd
+++ b/spec/unittest.dd
@@ -30,7 +30,7 @@ unittest
     following it.
     )
 
-    $(P A compiler switch, such as $(DDSUBLINK dmd-windows, switch-unittest, $(B -unittest))
+    $(P A compiler switch, such as $(DDSUBLINK dmd, switch-unittest, $(B -unittest))
     for $(B dmd), will
     cause the unittest test code to be compiled and incorporated into
     the resulting executable. The unittest code gets run after

--- a/spec/version.dd
+++ b/spec/version.dd
@@ -109,7 +109,7 @@ else
 ------
 
 $(P The $(D version(unittest)) is satisfied if and only if the code is
-	compiled with unit tests enabled (the $(DDSUBLINK dmd-windows, switch-unittest, $(TT -unittest)) option on $(TT dmd)).
+	compiled with unit tests enabled (the $(DDSUBLINK dmd, switch-unittest, $(TT -unittest)) option on $(TT dmd)).
 	)
 
 
@@ -301,13 +301,13 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
 	$(TROW $(ARGS $(D ELFv1)) , $(ARGS The Executable and Linkable Format v1))
 	$(TROW $(ARGS $(D ELFv2)) , $(ARGS The Executable and Linkable Format v2))
 	$(TROW $(ARGS $(D D_Coverage)) , $(ARGS $(DDLINK code_coverage, Code coverage analysis, Code coverage analysis) instrumentation
-		(command line switch $(DDSUBLINK dmd-windows, switch-cov, $(TT -cov))) is being generated))
+		(command line switch $(DDSUBLINK dmd, switch-cov, $(TT -cov))) is being generated))
 	$(TROW $(ARGS $(D D_Ddoc)) , $(ARGS $(DDLINK spec/ddoc, Embedded Documentation, Ddoc) documentation
-		(command line switch $(DDSUBLINK dmd-windows, switch-D, $(TT -D))) is being generated))
+		(command line switch $(DDSUBLINK dmd, switch-D, $(TT -D))) is being generated))
 	$(TROW $(ARGS $(D D_InlineAsm_X86)) , $(ARGS $(DDLINK spec/iasm, Inline Assembler, Inline assembler) for X86 is implemented))
 	$(TROW $(ARGS $(D D_InlineAsm_X86_64)) , $(ARGS $(DDLINK spec/iasm, Inline Assembler, Inline assembler) for X86-64 is implemented))
 	$(TROW $(ARGS $(D D_LP64)) , $(ARGS $(B Pointers) are 64 bits
-		(command line switch $(DDSUBLINK dmd-windows, switch-m64, $(TT -m64))). (Do not confuse this with C's LP64 model)))
+		(command line switch $(DDSUBLINK dmd, switch-m64, $(TT -m64))). (Do not confuse this with C's LP64 model)))
 	$(TROW $(ARGS $(D D_X32)) , $(ARGS Pointers are 32 bits, but words are still 64 bits (x32 ABI) (This can be defined in parallel to $(D X86_64))))
 	$(TROW $(ARGS $(D D_HardFloat)) , $(ARGS The target hardware has a floating point unit))
 	$(TROW $(ARGS $(D D_SoftFloat)) , $(ARGS The target hardware does not have a floating point unit))
@@ -316,10 +316,10 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
 	$(TROW $(ARGS $(D D_SIMD)) , $(ARGS $(DDLINK spec/simd, simd, Vector extensions) (via $(D __simd)) are supported))
 	$(TROW $(ARGS $(D D_Version2)) , $(ARGS This is a D version 2 compiler))
 	$(TROW $(ARGS $(D D_NoBoundsChecks)) , $(ARGS Array bounds checks are disabled
-		(command line switch $(DDSUBLINK dmd-windows, switch-boundscheck, $(TT -boundscheck=off)))))
+		(command line switch $(DDSUBLINK dmd, switch-boundscheck, $(TT -boundscheck=off)))))
 	$(TROW $(ARGS $(D D_ObjectiveC)) , $(ARGS The target supports interfacing with Objective-C))
 	$(TROW $(ARGS $(D unittest)) , $(ARGS $(DDLINK spec/unittest, Unit Tests, Unit tests) are enabled
-		(command line switch $(DDSUBLINK dmd-windows, switch-unittest, $(TT -unittest)))))
+		(command line switch $(DDSUBLINK dmd, switch-unittest, $(TT -unittest)))))
 	$(TROW $(ARGS $(D assert)) , $(ARGS Checks are being emitted for $(GLINK2 expression, AssertExpression)s))
 	$(TROW $(ARGS $(D none)) , $(ARGS Never defined; used to just disable a section of code))
 	$(TROW $(ARGS $(D all)) , $(ARGS Always defined; used as the opposite of $(D none)))


### PR DESCRIPTION
We have added the `.htaccess`-based a long time ago, it's time to get rid of these OS-dependent links.
Example that the redirects work nicely:

dlang.org/dmd.html#switch-cov