### PR TITLE
Allow examples of the D spec to be runnable

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -615,11 +615,10 @@ $(PHOBOS_STABLE_FILES_GENERATED): $(PHOBOS_STABLE_DIR_GENERATED)/%: $(PHOBOS_STA
 # Style tests
 ################################################################################
 
-test: $(ASSERT_WRITELN_BIN)_test all
+test: $(ASSERT_WRITELN_BIN)_test
 	@echo "Searching for trailing whitespace"
-	@grep -n '[[:blank:]]$$' $$(find . -type f -name "*.dd") ; test $$? -eq 1
-	@echo "Searching for undefined macros"
-	@grep -n "UNDEFINED MACRO" $$(find $(DOC_OUTPUT_DIR) -type f -name "*.html" -not -path "$(DOC_OUTPUT_DIR)/phobos/*") ; test $$? -eq 1
+	@echo "Check for trailing whitespace"
+	grep -n '[[:blank:]]$$' $$(find . -type f -name "*.dd") ; test $$? -eq 1
 	@echo "Executing assert_writeln_magic tests"
 	$<
 

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -884,10 +884,12 @@ printf("the string is '%.*s'\n", str.length, str.ptr);
         $(P The best way is to use std.stdio.writefln, which can handle
         D strings:)
 
+$(RUNNABLE_EXAMPLE
 ---------
 import std.stdio;
 writefln("the string is '%s'", str);
 ---------
+)
 
 $(H3 $(LNAME2 void_arrays, Void Arrays))
 
@@ -906,6 +908,7 @@ $(H3 $(LNAME2 void_arrays, Void Arrays))
     and it is an error to convert to an array type whose element size does not
     evenly divide the length of the void array.)
 
+$(RUNNABLE_EXAMPLE
 ---------
 void main()
 {
@@ -924,10 +927,12 @@ void main()
                                    // bytes.
 }
 ---------
+)
 
     $(P Void arrays can also be static if their length is known at
     compile-time. The length is specified in bytes:)
 
+$(RUNNABLE_EXAMPLE
 ---------
 void main()
 {
@@ -938,6 +943,7 @@ void main()
     void[2] b = y; // Error: int[2] is 8 bytes long, doesn't fit in 2 bytes.
 }
 ---------
+)
 
     $(P While it may seem that void arrays are just fancy syntax for
     $(D ubyte[]), there is a subtle distinction. The garbage collector

--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -321,6 +321,7 @@ $(GNAME DeprecatedAttribute):
         $(P Calling CTFE-able functions or using manifest constants is also possible.
         )
 
+        $(RUNNABLE_EXAMPLE
         ---------------
         import std.format;
         enum Message = format("%s and all its members are obsolete", Foobar.stringof);
@@ -329,6 +330,7 @@ $(GNAME DeprecatedAttribute):
         deprecated(format("%s is also obsolete", "This class")) class BarFoo {}
         auto bf = new BarFoo();  // Deprecated: class test.BarFoo is deprecated - This class is also obsolete
         ---------------
+        )
 
         $(P $(D Implementation Note:) The compiler should have a switch
         specifying if $(D deprecated) should be ignored, cause a warning, or cause an error during compilation.
@@ -399,6 +401,7 @@ $(H3 $(LNAME2 const, $(D const) Attribute))
         where $(D T) is the type specified (or inferred) for the introduced symbol in the absence of $(D const).
         )
 
+        $(RUNNABLE_EXAMPLE
         ---------------
         const int foo = 7;
         static assert(is(typeof(foo) == const(int)));
@@ -424,6 +427,7 @@ $(H3 $(LNAME2 const, $(D const) Attribute))
         static assert(is(typeof(C.foo) == typeof(C.bar)) &&
                       is(typeof(C.bar) == typeof(C.baz)));
         ---------------
+        )
 
 $(H3 $(LNAME2 immutable, $(D immutable) Attribute))
 
@@ -459,6 +463,7 @@ $(H3 $(LNAME2 gshared, $(D __gshared) Attribute))
         except that the variable is shared by all threads rather than being
         thread local.)
 
+        $(RUNNABLE_EXAMPLE
         ---
         class Foo
         {
@@ -471,6 +476,7 @@ $(H3 $(LNAME2 gshared, $(D __gshared) Attribute))
             return bar++; // Not thread safe.
         }
         ---
+        )
 
         $(P Unlike the $(D shared) attribute, $(D __gshared) provides no
         safe-guards against data races or other multi-threaded synchronization
@@ -487,6 +493,7 @@ $(H3 $(LNAME2 disable, $(D @disable) Attribute))
         at compile time rather than relying on generating a runtime error.
         )
 
+        $(RUNNABLE_EXAMPLE
         ---
         @disable void foo() { }
 
@@ -495,6 +502,7 @@ $(H3 $(LNAME2 disable, $(D @disable) Attribute))
             foo();   // error, foo is disabled
         }
         ---
+        )
 
         $(P $(DDSUBLINK spec/struct, Struct-Constructor, Disabling struct no-arg constructor)
         disallows default construction of the struct.
@@ -513,6 +521,7 @@ $(H3 $(LNAME2 nogc, $(D @nogc) Attribute))
         such as array concatenation and dynamic closures.
         )
 
+        $(RUNNABLE_EXAMPLE
         ---
         @nogc void foo(char[] a)
         {
@@ -523,11 +532,13 @@ $(H3 $(LNAME2 nogc, $(D @nogc) Attribute))
 
         void bar() { }
         ---
+        )
 
         $(P $(D @nogc) affects the type of the function. An $(D @nogc) function is covariant
         with a non-$(D @nogc) function.
         )
 
+        $(RUNNABLE_EXAMPLE
         ---
         void function() fp;
         void function() @nogc gp;  // pointer to @nogc function
@@ -543,6 +554,7 @@ $(H3 $(LNAME2 nogc, $(D @nogc) Attribute))
             gp = &bar; // ok
         }
         ---
+        )
 
 $(H3 $(LNAME2 property, $(D @property) Attribute))
 
@@ -574,6 +586,7 @@ $(H3 $(LNAME2 override, $(D override) Attribute))
         their overriding functions updated.
         )
 
+$(RUNNABLE_EXAMPLE
 ---------------
 class Foo
 {
@@ -590,6 +603,7 @@ class Foo2 : Foo
     }
 }
 ---------------
+)
 
 $(H3 $(LNAME2 static, $(D static) Attribute))
 
@@ -758,10 +772,12 @@ struct Bar
             UDA's can be extracted into an expression tuple using $(D __traits):
         )
 
+$(RUNNABLE_EXAMPLE
 ---
 @('c') string s;
 pragma(msg, __traits(getAttributes, s)); // prints tuple('c')
 ---
+)
 )
 
         $(P
@@ -769,6 +785,7 @@ pragma(msg, __traits(getAttributes, s)); // prints tuple('c')
             The expression tuple can be turned into a manipulatable tuple:
         )
 
+$(RUNNABLE_EXAMPLE
 ---
 template Tuple (T...)
 {
@@ -784,6 +801,7 @@ alias TP = Tuple!(__traits(getAttributes, foo));
 pragma(msg, TP); // prints tuple(3, 4, 7, (SSS))
 pragma(msg, TP[2]); // prints 7
 ---
+)
 
         $(P
             Of course the tuple types can be used to declare things:

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -112,6 +112,7 @@ $(H3 $(LNAME2 fields, Fields))
 	$(P Members of a base class can be accessed by prepending the name of
 	the base class followed by a dot:)
 
+$(RUNNABLE_EXAMPLE
 ---
 class A { int a; int a2;}
 class B : A { int a; }
@@ -123,6 +124,7 @@ void foo(B b)
     b.A.a = 5; // accesses field A.a
 }
 ---
+)
 
         $(P The D compiler is free to rearrange the order of fields in a class to
         optimally pack them in an implementation-defined manner.
@@ -170,6 +172,8 @@ $(H3 $(LNAME2 class_properties, Class Properties))
         in the class, excluding the hidden fields and the fields in the
         base class.
         )
+
+$(RUNNABLE_EXAMPLE
 ---
 class Foo { int x; long y; }
 void test(Foo foo)
@@ -180,6 +184,7 @@ void test(Foo foo)
         write(x);       // prints 12
 }
 ---
+)
 
         $(P The properties $(D .__vptr) and $(D .__monitor) give access
         to the class object's vtbl[] and monitor, respectively, but
@@ -204,6 +209,8 @@ $(H3 $(LNAME2 member-functions, Member Functions))
 	$(D const), $(D immutable), $(D shared), or $(D inout).
 	These attributes apply to the hidden $(I this) parameter.
 	)
+
+$(RUNNABLE_EXAMPLE
 ---
 class C
 {
@@ -218,6 +225,7 @@ class C
     }
 }
 ---
+)
 
 
 $(H3 $(LNAME2 synchronized-classes, Synchronized Classes))
@@ -304,6 +312,8 @@ $(GNAME Constructor):
         there can be a static initializer to be
         used instead of the default:
         )
+
+        $(RUNNABLE_EXAMPLE
         ------
         class Abc
         {
@@ -312,6 +322,7 @@ $(GNAME Constructor):
             float f;    // default initializer for f is NAN
         }
         ------
+        )
 
         This static initialization is done before any constructors are
         called.
@@ -686,6 +697,7 @@ $(GNAME StaticConstructor):
         having good control over exactly when the code is executed, for example:
 	)
 
+$(RUNNABLE_EXAMPLE
 ------
 class Foo
 {
@@ -693,6 +705,7 @@ class Foo
     static int b = a * 2;
 }
 ------
+)
 
         What values do a and b end up with, what order are the initializations
         executed in, what
@@ -988,6 +1001,7 @@ $(GNAME AliasThis):
         member.
         )
 
+$(RUNNABLE_EXAMPLE
 ---
 struct S
 {
@@ -997,7 +1011,7 @@ struct S
 
 int foo(int i) { return i * 2; }
 
-void test()
+void main()
 {
     S s;
     s.x = 7;
@@ -1008,11 +1022,13 @@ void test()
     i = foo(s);  // implicit conversion to int
 }
 ---
+)
 
         $(P If the member is a class or struct, undefined lookups will
         be forwarded to the $(I AliasThis) member.
         )
 
+$(RUNNABLE_EXAMPLE
 ---
 struct Foo
 {
@@ -1026,19 +1042,21 @@ class Bar
     alias foo this;
 }
 
-void test()
+void main()
 {
     auto bar = new Bar;
     int i = bar.baz; // i == 4
     i = bar.get(); // i == 7
 }
 ---
+)
 
         $(P If the $(I Identifier) refers to a property member
         function with no parameters, conversions and undefined
         lookups are forwarded to the return value of the function.
         )
 
+$(RUNNABLE_EXAMPLE
 ---
 struct S
 {
@@ -1050,13 +1068,14 @@ struct S
     alias get this;
 }
 
-void test()
+void main()
 {
     S s;
     s.x = 2;
     int i = s; // i == 4
 }
 ---
+)
 
         $(P Multiple $(I AliasThis) are allowed. For implicit conversions
         and forwarded lookups, all $(I AliasThis) declarations are attempted;
@@ -1111,6 +1130,7 @@ $(H2 $(LNAME2 nested, Nested Classes))
         A nested class has access to the variables and other symbols
         of the classes and functions it is nested inside:
 
+$(RUNNABLE_EXAMPLE
 ------
 class Outer
 {
@@ -1138,11 +1158,13 @@ void func()
     }
 }
 ------
+)
 
         If a nested class has the $(D static) attribute, then it can
         not access variables of the enclosing scope that are local to the
         stack or need a $(D this):
 
+$(RUNNABLE_EXAMPLE
 ------
 class Outer
 {
@@ -1174,6 +1196,7 @@ void func()
     }
 }
 ------
+)
 
         Non-static nested classes work by containing an extra hidden member
         (called the context pointer)
@@ -1187,6 +1210,7 @@ void func()
         A non-static nested class can only be instantiated when the necessary
         context pointer information is available:)
 
+$(RUNNABLE_EXAMPLE
 ------
 class Outer
 {
@@ -1206,6 +1230,7 @@ void func()
     Nested n = new Nested;      // Ok
 }
 ------
+)
 
 
 
@@ -1213,6 +1238,7 @@ void func()
         inner class instance by prefixing it to the $(I NewExpression):
         )
 
+$(RUNNABLE_EXAMPLE
 ---------
 class Outer
 {
@@ -1235,6 +1261,7 @@ int bar()
     return oi.foo();    // returns 3
 }
 ---------
+)
 
         $(P Here $(D o) supplies the $(I this) to the outer class
         instance of $(D Outer).
@@ -1246,6 +1273,7 @@ int bar()
         function frame with $(D void*).
         )
 
+$(RUNNABLE_EXAMPLE
 ----
 class Outer
 {
@@ -1306,6 +1334,7 @@ class Outer
     }
 }
 ----
+)
 
 $(H3 $(LNAME2 anonymous, Anonymous Nested Classes))
 

--- a/spec/const3.dd
+++ b/spec/const3.dd
@@ -334,6 +334,7 @@ $(H2 $(LNAME2 immutable_member_functions, Immutable Member Functions))
 	They are declared as:
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 struct S
 {
@@ -346,6 +347,7 @@ struct S
     }
 }
 ---
+)
     $(P Note that using $(D_KEYWORD immutable) on the left hand side of a method does not apply to the return type:
     )
 
@@ -444,6 +446,8 @@ $(H2 $(LNAME2 implicit_conversions, Implicit Conversions))
 	$(P A $(I Unique Expression) is one for which there are no other references to the
 	value of the expression and all expressions it transitively refers to are either
 	also unique or are immutable. For example:
+
+$(RUNNABLE_EXAMPLE
 ---
 void main()
 {
@@ -456,6 +460,7 @@ void main()
     immutable int** r = new immutable(int)*(&y); // ok, y is immutable
 }
 ---
+)
 	)
 
 	$(P Otherwise, a $(GLINK2 expression, CastExpression) can be used to force a conversion

--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -84,6 +84,8 @@ body
 	If the <code>out</code> clause is for a function
 	body, the variable <code>result</code> is declared and assigned the return
 	value of the function. For example, let's implement a square root function:)
+
+$(RUNNABLE_EXAMPLE
 ------
 long square_root(long x)
 in
@@ -99,6 +101,8 @@ body
     return cast(long)std.math.sqrt(cast(real)x);
 }
 ------
+)
+
 	$(P The assert's in the in and out bodies are called <dfn>contracts</dfn>.
 	Any other D
 	statement or expression is allowed in the bodies, but it is important
@@ -157,6 +161,7 @@ $(H2 $(LNAME2 Invariants, Invariants))
 	day must be 1..31 and the hour must be 0..23:
 	)
 
+$(RUNNABLE_EXAMPLE
 ------
 class Date
 {
@@ -176,6 +181,7 @@ class Date
     }
 }
 ------
+)
 
 	$(P The invariant is a contract saying that the asserts must hold true.
 	The invariant is checked when a class or struct constructor completes,
@@ -208,6 +214,7 @@ class Date
 	constructors.
 	)
 
+$(RUNNABLE_EXAMPLE
 ------
 class Foo
 {
@@ -221,6 +228,7 @@ class Foo
     }
 }
 ------
+)
 
 	The invariant can be checked with an $(CODE assert()) expression:
 

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -393,6 +393,7 @@ t4 v4;    // v4 is type int
         to another:
         )
 
+$(RUNNABLE_EXAMPLE
 --------------------
 version (Win32)
 {
@@ -403,6 +404,7 @@ version (linux)
     alias myfoo = linux.bar;
 }
 --------------------
+)
 
         $(P
         Aliasing can be used to $(SINGLEQUOTE import) a symbol from an import into the
@@ -418,6 +420,7 @@ alias strlen = string.strlen;
         be overloaded with functions in the current scope:
         )
 
+$(RUNNABLE_EXAMPLE
 --------------------
 class A
 {
@@ -439,7 +442,7 @@ class D : C
 {
 }
 
-void test()
+void main()
 {
     D b = new D();
     int i;
@@ -448,6 +451,7 @@ void test()
     i = b.foo(1);       // calls C.foo
 }
 --------------------
+)
 
         $(P
         $(B Note:) Type aliases can sometimes look indistinguishable from
@@ -506,6 +510,7 @@ $(GNAME Typeof):
         of an expression. For example:
         )
 
+        $(RUNNABLE_EXAMPLE
         --------------------
         void func(int i)
         {
@@ -518,20 +523,23 @@ $(GNAME Typeof):
             double c = cast(typeof(1.0))j; // cast j to double
         }
         --------------------
+        )
 
         $(P
         $(I Expression) is not evaluated, just the type of it is
         generated:
         )
 
+        $(RUNNABLE_EXAMPLE
         --------------------
-        void func()
+        void main()
         {
             int i = 1;
             typeof(++i) j; // j is declared to be an int, i is not incremented
             writefln("%d", i);  // prints 1
         }
         --------------------
+        )
 
         $(P There are  three special cases: )
     $(OL
@@ -597,13 +605,16 @@ $(GNAME VoidInitializer):
         used before it is set, undefined program behavior will result.
 	)
 
+$(RUNNABLE_EXAMPLE
 -------------------------
-void foo()
+void main()
 {
+    import std.stdio;
     int x = void;
     writeln(x);  // will print garbage
 }
 -------------------------
+)
 
         $(P Therefore, one should only use $(D void) initializers as a
         last resort when optimizing critical code.
@@ -661,6 +672,7 @@ struct S
 	storage class, there are some storage classes that cannot be used to
 	construct new types. One example is $(D ref):)
 
+$(RUNNABLE_EXAMPLE
 --------
 // ref declares the parameter x to be passed by reference
 void func(ref int x)
@@ -678,7 +690,9 @@ void main()
     ref(int) y; // Error: ref is not a type qualifier.
 }
 --------
+)
 
+$(RUNNABLE_EXAMPLE
 --------
 // Functions can also be declared as 'ref', meaning their return value is
 // passed by reference:
@@ -705,6 +719,7 @@ void main()
                           // does not inherit the ref storage class from func2().
 }
 --------
+)
 
 	$(P Due to the fact that some keywords, such as $(D const), can be used
 	both as a type qualifier and a storage class, it may sometimes result

--- a/spec/enum.dd
+++ b/spec/enum.dd
@@ -96,6 +96,7 @@ enum X { A, B, C }  // named enum
 	$(P All $(I EnumMember)s are in scope for the $(ASSIGNEXPRESSION)s.
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 enum A = 3;
 enum B
@@ -115,6 +116,7 @@ enum E : C
     E2      // error, C.D is C.max
 }
 ---
+)
 
 
 	$(P An empty enum body (For example $(CODE enum E;)) signifies an opaque

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -846,6 +846,7 @@ $(GNAME CastExpression):
         as a type paint, with the array length adjusted to match any change in
         element size. If there's not a match, a runtime error is generated.
 
+        $(RUNNABLE_EXAMPLE
         ---
         import std.stdio;
 
@@ -862,14 +863,16 @@ $(GNAME CastExpression):
             return 0;
         }
         ---
+        )
     )
 
     $(P Casting a floating point literal from one type to another
         changes its type, but internally it is retained at full
         precision for the purposes of constant folding.
 
+        $(RUNNABLE_EXAMPLE
         ---
-        void test()
+        void main()
         {
             real a = 3.40483L;
             real b;
@@ -884,11 +887,13 @@ $(GNAME CastExpression):
             assert(x == a);     // truncated if the initializer is visible
         }
         ---
+        )
     )
 
     $(P Casting a floating point value to an integral type is the equivalent
         of converting to an integer using truncation.
 
+        $(RUNNABLE_EXAMPLE
         ---
         void main()
         {
@@ -900,6 +905,7 @@ $(GNAME CastExpression):
             assert(c == -1);
         }
         ---
+        )
     )
 
     $(P Casting a value $(I v) to a struct $(I S), when value is not a struct
@@ -934,6 +940,7 @@ $(GNAME CastExpression):
         the result is unused. On $(GLINK2 statement, ExpressionStatement),
         it could be used properly to avoid "has no effect" error.
 
+        $(RUNNABLE_EXAMPLE
         ----
         void foo(lazy void exp) {}
         void main()
@@ -942,6 +949,7 @@ $(GNAME CastExpression):
             foo(cast(void)10);  // OK
         }
         ----
+        )
     )
 
 $(H3 $(LNAME2 pow_expressions, Pow Expressions))
@@ -1053,6 +1061,7 @@ $(GNAME Slice):
         the slice expression can be converted to a static array type
         $(D T[b - a]).
 
+        $(RUNNABLE_EXAMPLE
         -------------
         void foo(int[2] a)
         {
@@ -1080,6 +1089,7 @@ $(GNAME Slice):
           //baz(arr[1 .. 3]); // cannot match length
         }
         -------------
+        )
 
         Following forms of slice expression can be convertible to a static array type:
 
@@ -1160,6 +1170,7 @@ $(H4 $(LNAME2 this, this))
         If a member function is called with an explicit reference
         to $(D typeof(this)), a non-virtual call is made:
 
+        $(RUNNABLE_EXAMPLE
         -------------
         class A
         {
@@ -1182,6 +1193,7 @@ $(H4 $(LNAME2 this, this))
             assert(b.bar() == 'B');
         }
         -------------
+        )
     )
 
     $(P Assignment to $(D this) is not allowed.)
@@ -1255,6 +1267,7 @@ $(GNAME StringLiterals):
         count is known at compile time. So all string literals can be
         implicitly converted to static array types.
 
+        $(RUNNABLE_EXAMPLE
         -------------
         void foo(char[2] a)
         {
@@ -1274,6 +1287,7 @@ $(GNAME StringLiterals):
           //baz(str[1 .. 3]); // cannot match length
         }
         -------------
+        )
     )
 
     $(P String literals have a 0 appended to them, which makes
@@ -1308,6 +1322,7 @@ $(GNAME ArrayLiteral):
         count is known at compile time. So all array literals can be
         implicitly converted to static array types.
 
+        $(RUNNABLE_EXAMPLE
         -------------
         void foo(long[2] a)
         {
@@ -1335,6 +1350,7 @@ $(GNAME ArrayLiteral):
           //baz(arr[1 .. 3]); // cannot match length
         }
         -------------
+        )
     )
 
     $(P If any of the arguments in the $(GLINK ArgumentList) are
@@ -1358,6 +1374,7 @@ $(GNAME ArrayLiteral):
         When arrays that are not literals are cast, the array is
         reinterpreted as the new type, and the length is recomputed:
 
+        $(RUNNABLE_EXAMPLE
         ---
         import std.stdio;
 
@@ -1376,6 +1393,7 @@ $(GNAME ArrayLiteral):
             writeln(rt);  // writes [257]
         }
         ---
+        )
 
         In other words, casting literal expression will change the literal type.
     )
@@ -1488,6 +1506,7 @@ $(GNAME FunctionLiteralBody):
 
     $(P And:
 
+        $(RUNNABLE_EXAMPLE
         -------------
         int abc(int delegate(int i));
 
@@ -1499,9 +1518,11 @@ $(GNAME FunctionLiteralBody):
             abc(&foo);
         }
         -------------
+        )
 
         is exactly equivalent to:
 
+        $(RUNNABLE_EXAMPLE
         -------------
         int abc(int delegate(int i));
 
@@ -1512,11 +1533,13 @@ $(GNAME FunctionLiteralBody):
             abc( delegate int(int c) { return 6 + b; } );
         }
         -------------
+        )
     )
 
     $(P and the following where the return type $(D int) and
         $(D function)/$(D delegate) are inferred:
 
+        $(RUNNABLE_EXAMPLE
         -------------
         int abc(int delegate(int i));
         int def(int function(int s));
@@ -1532,11 +1555,13 @@ $(GNAME FunctionLiteralBody):
             // is inferred to delegate. But def cannot receive delegate.
         }
         -------------
+        )
     )
 
     $(P If the type of a function literal can be uniquely determined from its context,
         the parameter type inference is possible.
 
+        $(RUNNABLE_EXAMPLE
         -------------
         void foo(int function(int) fp);
 
@@ -1549,6 +1574,7 @@ $(GNAME FunctionLiteralBody):
             // The type of parameter n is inferred to int.
         }
         -------------
+        )
     )
 
     $(P Anonymous delegates can behave like arbitrary statement literals.
@@ -1611,6 +1637,7 @@ $(GNAME Lambda):
 
     $(P Example usage:
 
+        $(RUNNABLE_EXAMPLE
         ---
         import std.stdio;
 
@@ -1628,6 +1655,7 @@ $(GNAME Lambda):
             writeln(mul_n(i));   // prints 15
         }
         ---
+        )
     )
 
 $(H4 $(LNAME2 uniform_construction_syntax, Uniform construction syntax for built-in scalar types))
@@ -1710,12 +1738,14 @@ $(GNAME AssertExpression):
         result is false, and the string result is appended to the
         $(D AssertError)'s message.
 
+        $(RUNNABLE_EXAMPLE
         ----
         void main()
         {
             assert(0, "an" ~ " error message");
         }
         ----
+        )
     )
 
     $(P When compiled and run, it will produce the message:
@@ -1800,6 +1830,7 @@ $(GNAME TypeidExpression):
         of the dynamic type (i.e. the most derived type).
         The $(I Expression) is always executed.
 
+        $(RUNNABLE_EXAMPLE
         ---
         class A { }
         class B : A { }
@@ -1815,6 +1846,7 @@ $(GNAME TypeidExpression):
             writeln(typeid(typeof(a)));  // A
         }
         ---
+        )
     )
 
 $(H4 $(LNAME2 is_expression, IsExpression))
@@ -2094,6 +2126,7 @@ void foo(bar x)
         way implied template parameters are matched.
         )
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio, std.typecons;
 
@@ -2132,6 +2165,7 @@ void main()
     }
 }
 ---
+)
 
         )
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -249,6 +249,7 @@ pure int foo(int i,
     references of the result may be assumed to not refer to any object that
     existed before the function call. For example:)
 
+$(RUNNABLE_EXAMPLE
 ---
 struct List { int payload; List* next; }
 pure List* make(int a, int b)
@@ -258,6 +259,7 @@ pure List* make(int a, int b)
     return result;
 }
 ---
+)
 
     $(P Here, an implementation may assume (without having knowledge of the body
     of `make`) that all references in `make`'s result refer to other `List`
@@ -476,6 +478,7 @@ $(H4 $(LNAME2 optional-parenthesis, Optional Parentheses))
         $(RELATIVE_LINK2 property-functions, property function).
         )
 
+        $(RUNNABLE_EXAMPLE
         ---
         void foo() {}   // no arguments
     void fun(int x = 10) { }
@@ -492,9 +495,11 @@ $(H4 $(LNAME2 optional-parenthesis, Optional Parentheses))
             arr.bar;    // also OK
         }
         ---
+        )
 
     $(P Optional parentheses are not applied to delegates or function pointers.)
 
+    $(RUNNABLE_EXAMPLE
     ---
     void main()
     {
@@ -507,11 +512,13 @@ $(H4 $(LNAME2 optional-parenthesis, Optional Parentheses))
         assert(dg == 6);    // Error, incompatible types int delegate() and int
     }
     ---
+    )
 
     $(P If a function returns a delegate or function pointer, the parantheses are required if the
     returned value is to be called.
     )
 
+    $(RUNNABLE_EXAMPLE
     ---
     struct S {
         int function() callfp() { return &numfp; }
@@ -547,6 +554,7 @@ $(H4 $(LNAME2 optional-parenthesis, Optional Parentheses))
         assert(y == 6);
     }
     ---
+    )
 
 $(H4 $(LNAME2 property-functions, Property Functions))
 
@@ -651,6 +659,7 @@ $(H4 $(LNAME2 virtual-functions, Virtual Functions))
         For example:
         )
 
+$(RUNNABLE_EXAMPLE
 ------
 class A
 {
@@ -682,6 +691,7 @@ void func()
     test(b);
 }
 ------
+)
 
         $(P Covariant return types
         are supported, which means that the
@@ -689,6 +699,7 @@ void func()
         that is derived from the type returned by the overridden function:
         )
 
+$(RUNNABLE_EXAMPLE
 ------
 class A { }
 class B : A { }
@@ -703,6 +714,7 @@ class Bar : Foo
     override B test() { return null; } // overrides and is covariant with Foo.test()
 }
 ------
+)
 
         $(P Virtual functions all have a hidden parameter called the
         $(I this) reference, which refers to the class object for which
@@ -713,6 +725,7 @@ class Bar : Foo
         base class name before the member function name. For example:
         )
 
+$(RUNNABLE_EXAMPLE
 ------
 class B
 {
@@ -743,6 +756,7 @@ void main()
     d.test();
 }
 ------
+)
 
 $(H4 $(LNAME2 function-inheritance, Function Inheritance and Overriding))
 
@@ -904,6 +918,7 @@ void test()
         $(GLINK FunctionAttributes), the missing attributes will be
         automatically compensated by the compiler.)
 
+$(RUNNABLE_EXAMPLE
 ------
 class B
 {
@@ -920,6 +935,7 @@ void main()
     // prints "void delegate() pure nothrow @safe" in compile time
 }
 ------
+)
 
     $(P It's not allowed to mark an overridden method with the attributes
     $(LINK2 attribute.html#disable, $(D @disable)) or
@@ -929,6 +945,7 @@ void main()
     when it is virtual.
     )
 
+$(RUNNABLE_EXAMPLE
 ------
 class B
 {
@@ -946,6 +963,7 @@ void main()
     b.foo(); // would compiles and then the most derived would be called even if disabled.
 }
 ------
+)
 
 $(H4 $(LNAME2 inline-functions, Inline Functions))
 
@@ -1178,6 +1196,7 @@ def(z);
         a $(D lazy) argument can be executed 0 or more times. A $(D lazy) parameter
         cannot be an lvalue.)
 
+$(RUNNABLE_EXAMPLE
 ---
 void dotimes(int n, lazy void exp)
 {
@@ -1185,12 +1204,14 @@ void dotimes(int n, lazy void exp)
         exp();
 }
 
-void test()
+void main()
 {
+    import std.stdio : writeln;
     int x;
     dotimes(3, writeln(x++));
 }
 ---
+)
 
         $(P prints to the console:)
 
@@ -1313,6 +1334,7 @@ extern (C) int def(...); // error, must have at least one parameter
     module $(D core.stdc.stdarg).
     )
 
+$(RUNNABLE_EXAMPLE
 ------
 import core.stdc.stdarg;
 
@@ -1331,6 +1353,7 @@ void foo(int x, int y, ...)
     va_arg(args, z);  // z is set to 5
 }
 ------
+)
 
 
 $(H4 $(LNAME2 d_style_variadic_functions, D-style Variadic Functions))
@@ -1358,6 +1381,7 @@ import core.vararg;
         arguments. To access the arguments, $(D _argptr) must be used
     in conjuction with $(D va_arg):
 
+$(RUNNABLE_EXAMPLE
 ------
 import core.vararg;
 
@@ -1373,6 +1397,7 @@ void foo(int x, int y, ...)
     z = va_arg!int(_argptr); // z is set to 5
 }
 ------
+)
 
         An additional hidden argument
         with the name $(D _arguments) and type $(D TypeInfo[])
@@ -1380,6 +1405,7 @@ void foo(int x, int y, ...)
         $(D _arguments) gives the number of arguments and the type
         of each, enabling type safety to be checked at run time.
 
+$(RUNNABLE_EXAMPLE
 ------
 import std.stdio;
 import core.vararg;
@@ -1433,6 +1459,7 @@ void main()
     printargs(1, 2, 3L, 4.5, f, b);
 }
 ------
+)
 
         which prints:
 
@@ -1462,8 +1489,9 @@ $(H4 $(LNAME2 typesafe_variadic_functions, Typesafe Variadic Functions))
 
         $(P For arrays:)
 
+$(RUNNABLE_EXAMPLE
 ------
-int test()
+int main()
 {
     return sum(1, 2, 3) + sum(); // returns 6+0
 }
@@ -1482,11 +1510,13 @@ int sum(int[] ar ...)
     return s;
 }
 ------
+)
 
         For static arrays:
 
+$(RUNNABLE_EXAMPLE
 ------
-int test()
+int main()
 {
     return sum(2, 3);   // error, need 3 values for array
     return sum(1, 2, 3); // returns 6
@@ -1508,6 +1538,7 @@ int sum(int[3] ar ...)
     return s;
 }
 ------
+)
 
         For class objects:
 
@@ -1661,6 +1692,7 @@ void foo()
     rules, the names of them must be unique within a particular function.
     )
 
+$(RUNNABLE_EXAMPLE
 ---
 void main()
 {
@@ -1670,11 +1702,13 @@ void main()
     { int i; } // ok
 }
 ---
+)
 
 $(H3 $(LNAME2 nested, Nested Functions))
 
         $(P Functions may be nested within other functions:)
 
+$(RUNNABLE_EXAMPLE
 ------
 int bar(int a)
 {
@@ -1692,9 +1726,11 @@ void test()
     int i = bar(3); // i is assigned 4
 }
 ------
+)
 
         $(P Nested functions can be accessed only if the name is in scope.)
 
+$(RUNNABLE_EXAMPLE
 ------
 void foo()
 {
@@ -1722,9 +1758,11 @@ void foo()
     C(); // error, C undefined
 }
 ------
+)
 
         $(P and:)
 
+$(RUNNABLE_EXAMPLE
 ------
 int bar(int a)
 {
@@ -1739,12 +1777,14 @@ void test()
     int j = bar.foo(3); // error, bar.foo not visible
 }
 ------
+)
 
         $(P Nested functions have access to the variables and other symbols
         defined by the lexically enclosing function.
         This access includes both the ability to read and write them.
         )
 
+$(RUNNABLE_EXAMPLE
 ------
 int bar(int a)
 {
@@ -1766,9 +1806,11 @@ void test()
     int i = bar(3); // i is assigned 17
 }
 ------
+)
 
         $(P This access can span multiple nesting levels:)
 
+$(RUNNABLE_EXAMPLE
 ------
 int bar(int a)
 {
@@ -1785,12 +1827,14 @@ int bar(int a)
     return foo(3);
 }
 ------
+)
 
         $(P Static nested functions cannot access any stack variables of
         any lexically enclosing function, but can access static variables.
         This is analogous to how static member functions behave.
         )
 
+$(RUNNABLE_EXAMPLE
 ------
 int bar(int a)
 {
@@ -1806,9 +1850,11 @@ int bar(int a)
     return foo(a);
 }
 ------
+)
 
         $(P Functions can be nested within member functions:)
 
+$(RUNNABLE_EXAMPLE
 ------
 struct Foo
 {
@@ -1826,6 +1872,7 @@ struct Foo
     }
 }
 ------
+)
 
         $(P Nested functions always have the D function linkage type.
         )
@@ -1835,6 +1882,7 @@ struct Foo
         cannot mutually call each other:
         )
 
+$(RUNNABLE_EXAMPLE
 ------
 void test()
 {
@@ -1842,6 +1890,7 @@ void test()
     void bar() { foo(); } // ok
 }
 ------
+)
 
         $(P There are several workarounds for this limitation:)
 
@@ -1849,6 +1898,7 @@ $(UL
 
         $(LI Declare the functions to be static members of a nested struct:)
 
+$(RUNNABLE_EXAMPLE
 ------
 void test()
 {
@@ -1861,10 +1911,12 @@ void test()
     S.foo();  // compiles (but note the infinite runtime loop)
 }
 ------
+)
 
         $(LI Declare one or more of the functions to be function templates
         even if they take no specific template arguments:)
 
+$(RUNNABLE_EXAMPLE
 ------
 void test()
 {
@@ -1872,9 +1924,11 @@ void test()
     void bar()   { foo(); } // ok
 }
 ------
+)
 
         $(LI Declare the functions inside of a mixin template:)
 
+$(RUNNABLE_EXAMPLE
 ------
 mixin template T()
 {
@@ -1887,9 +1941,11 @@ void test()
     mixin T!();
 }
 ------
+)
 
         $(LI Use a delegate:)
 
+$(RUNNABLE_EXAMPLE
 ------
 void test()
 {
@@ -1899,6 +1955,7 @@ void test()
     fp = &bar;
 }
 ------
+)
 
     )
 
@@ -1908,6 +1965,7 @@ $(H4 $(LNAME2 closures, Delegates, Function Pointers, and  Closures))
 
         $(P A function pointer can point to a static nested function:)
 
+$(RUNNABLE_EXAMPLE
 ------
 int function() fp;
 
@@ -1919,12 +1977,13 @@ void test()
     fp = &foo;
 }
 
-void bar()
+void main()
 {
     test();
     int i = fp();       // i is set to 10
 }
 ------
+)
 
         $(P $(B Note:) Two functions with identical bodies, or two functions
         that compile to identical assembly code, are not guaranteed to have
@@ -1943,10 +2002,11 @@ int function() fp2 = &def;
 
         $(P A delegate can be set to a non-static nested function:)
 
+$(RUNNABLE_EXAMPLE
 ------
 int delegate() dg;
 
-void test()
+void main()
 {
     int a = 7;
     int foo() { return a + 3; }
@@ -1955,6 +2015,7 @@ void test()
     int i = dg(); // i is set to 10
 }
 ------
+)
 
 
         $(P The stack variables referenced by a nested function are
@@ -1985,6 +2046,7 @@ int* bar()
         the same type:
         )
 
+$(RUNNABLE_EXAMPLE
 ------
 struct Foo
 {
@@ -1997,7 +2059,7 @@ int foo(int delegate() dg)
     return dg() + 1;
 }
 
-void test()
+void main()
 {
     int x = 27;
     int abc() { return x; }
@@ -2008,6 +2070,7 @@ void test()
     i = foo(&f.bar); // i is set to 8
 }
 ------
+)
 
         $(P This combining of the environment and the function is called
         a $(I dynamic closure).
@@ -2053,6 +2116,7 @@ $(H3 $(LNAME2 function-templates, Function Templates))
     different parameter type, a single function template can be sufficient.
     For example:
     )
+$(RUNNABLE_EXAMPLE
 ---
 // Only one copy of func needs to be written
 void func(T)(T x)
@@ -2072,6 +2136,7 @@ void main()
     func(s);    // pass a struct
 }
 ---
+)
     $(P $(D func) takes a template parameter $(D T) and a runtime
     parameter, $(D x). $(D T) is a placeholder identifier that can accept
     any type. In this case $(D T) can be inferred from the runtime argument
@@ -2161,6 +2226,7 @@ $(H3 $(LNAME2 interpretation, Compile Time Function Execution (CTFE)))
     $(P Note that the above restrictions apply only to expressions which are
         actually executed. For example:
     )
+$(RUNNABLE_EXAMPLE
 ---
 static int y = 0;
 
@@ -2174,6 +2240,7 @@ int countTen(int x)
 static assert(countTen(6) == 6); // OK
 static assert(countTen(12) == 12);  // invalid, modifies y.
 ---
+)
     $(P The $(D __ctfe) boolean pseudo-variable, which evaluates to $(D_KEYWORD true)
         at compile time, but $(D_KEYWORD false) at run time, can be used to provide
         an alternative execution path to avoid operations which are forbidden
@@ -2193,6 +2260,7 @@ static assert(countTen(12) == 12);  // invalid, modifies y.
     $(LI argument for a template value parameter)
     )
 
+$(RUNNABLE_EXAMPLE
 ---
 template eval( A... )
 {
@@ -2212,6 +2280,7 @@ void foo()
     writeln(eval!(square(5))); // compile time
 }
 ---
+)
 
     $(P Executing functions at compile time can take considerably
     longer than executing it at run time.
@@ -2247,6 +2316,7 @@ $(H4 $(LNAME2 string-mixins, String Mixins and Compile Time Function Execution))
         run time. This means that the semantics of a function cannot
         depend on compile time values of the function. For example:)
 
+$(RUNNABLE_EXAMPLE
 ---
 int foo(char[] s)
 {
@@ -2255,6 +2325,7 @@ int foo(char[] s)
 
 const int x = foo("1");
 ---
+)
 
         $(P is illegal, because the runtime code for foo() cannot be
         generated. A function template would be the appropriate
@@ -2447,6 +2518,7 @@ $(H3 $(LNAME2 pseudo-member, Uniform Function Call Syntax (UFCS)))
         $(P The reason why local symbols are not considered by UFCS, is
         to avoid unexpected name conflicts. See below problematic examples.)
 
+        $(RUNNABLE_EXAMPLE
         ---
         int front(int[] arr) { return arr[0]; }
 
@@ -2469,6 +2541,7 @@ $(H3 $(LNAME2 pseudo-member, Uniform Function Call Syntax (UFCS)))
             }
         }
         ---
+        )
 
 $(SPEC_SUBNAV_PREV_NEXT const3, Type Qualifiers, operatoroverloading, Operator Overloading)
 )

--- a/spec/garbage.dd
+++ b/spec/garbage.dd
@@ -270,6 +270,7 @@ q = p - 1;       // error: undefined behavior
 	$(LI Do not misalign pointers if those pointers may
 	point into the GC heap, such as:
 
+$(RUNNABLE_EXAMPLE
 ------
 struct Foo
 {
@@ -278,6 +279,7 @@ struct Foo
     char* p;  // misaligned pointer
 }
 ------
+)
 
 	Misaligned pointers may be used if the underlying hardware
 	supports them $(B and) the pointer is never used to point

--- a/spec/hash-map.dd
+++ b/spec/hash-map.dd
@@ -359,6 +359,7 @@ $(H3 $(LNAME2 aa_example, Associative Array Example: word count))
         over code points and functions from $(LINK2 $(ROOT_DIR)phobos/std_uni.html,std.uni).
         )
 
+        $(RUNNABLE_EXAMPLE
         ---------
         import std.file;         // D file I/O
         import std.stdio;
@@ -432,6 +433,7 @@ $(H3 $(LNAME2 aa_example, Associative Array Example: word count))
             }
         }
         ---------
+        )
 
 $(SPEC_SUBNAV_PREV_NEXT arrays, Arrays, struct, Structs and Unions)
 )

--- a/spec/interface.dd
+++ b/spec/interface.dd
@@ -31,6 +31,7 @@ $(GNAME BaseInterfaceList):
     Classes cannot derive from an interface multiple times.
     )
 
+$(RUNNABLE_EXAMPLE
 ------
 interface D
 {
@@ -41,6 +42,7 @@ class A : D, D  // error, duplicate interface
 {
 }
 ------
+)
 
     An instance of an interface cannot be created.
 
@@ -61,6 +63,7 @@ D d = new D();  // error, cannot create instance of interface
     Interfaces are expected to implement static or final functions.
     )
 
+$(RUNNABLE_EXAMPLE
 ------
 interface D
 {
@@ -69,10 +72,12 @@ interface D
     final void abc() { } // ok
 }
 ------
+)
 
     $(P Classes that inherit from an interface may not override final or
     static interface member functions.)
 
+$(RUNNABLE_EXAMPLE
 ------
 interface D
 {
@@ -88,11 +93,14 @@ class C : D
     void abc() { } // error, cannot override final D.abc()
 }
 ------
+)
 
 
     $(P All interface functions must be defined in a class that inherits
     from that interface:
     )
+
+$(RUNNABLE_EXAMPLE
 ------
 interface D
 {
@@ -109,6 +117,7 @@ class B : D
     int foo() { }   // error, no void foo() implementation
 }
 ------
+)
 
     Interfaces can be inherited and functions overridden:
 
@@ -169,6 +178,7 @@ d2.foo();           // returns 2, even though it is A's D, not B's D
     functions, it does not inherit them from a super class:
     )
 
+$(RUNNABLE_EXAMPLE
 ------
 interface D
 {
@@ -184,6 +194,7 @@ class B : A, D
 {
 }       // error, no foo() for interface D
 ------
+)
 
 $(SECTION2 $(LEGACY_LNAME2 InterfaceContracts, interface-contracts, Interfaces with Contracts),
 
@@ -192,6 +203,7 @@ $(SECTION2 $(LEGACY_LNAME2 InterfaceContracts, interface-contracts, Interfaces w
     class member function that implements that interface member function.
     )
 
+$(RUNNABLE_EXAMPLE
 ---
 interface I
 {
@@ -202,6 +214,7 @@ interface I
     void bar();
 }
 ---
+)
 )
 
 $(SECTION2 $(LEGACY_LNAME2 ConstInterface, const-interface, Const and Immutable Interfaces),
@@ -241,6 +254,7 @@ $(SECTION2 $(LEGACY_LNAME2 COM-Interfaces, com-interfaces, COM Interfaces),
     D interfaces or classes (ones which do not inherit from $(D IUnknown)),
     you have to explicitly mark them as having the $(D extern(D)) linkage:
 
+    $(RUNNABLE_EXAMPLE
     ---
     import core.sys.windows.windows;
     import core.stdc.windows.com;
@@ -273,6 +287,7 @@ $(SECTION2 $(LEGACY_LNAME2 COM-Interfaces, com-interfaces, COM Interfaces),
         uint Release();
     }
     ---
+    )
 
     The same applies to other $(D Object) methods such as $(D opCmp), $(D toHash), etc.
 
@@ -292,6 +307,7 @@ $(SECTION2 $(LEGACY_LNAME2 CPP-Interfaces, cpp-interfaces, C++ Interfaces),
     $(P C++ interfaces are interfaces declared with C++ linkage:
     )
 
+$(RUNNABLE_EXAMPLE
 ---
 extern (C++) interface Ifoo
 {
@@ -299,6 +315,7 @@ extern (C++) interface Ifoo
     void bar();
 }
 ---
+)
 
     $(P which is meant to correspond with the following C++ declaration:)
 

--- a/spec/objc_interface.dd
+++ b/spec/objc_interface.dd
@@ -14,6 +14,7 @@ $(SPEC_S Interfacing to Objective-C,
 
     $(SECTION2 $(LNAME2 external-class, Declaring an External Class))
 
+    $(RUNNABLE_EXAMPLE
     ---
     extern (Objective-C)
     interface NSString
@@ -21,6 +22,7 @@ $(SPEC_S Interfacing to Objective-C,
         const(char)* UTF8String() @selector("UTF8String");
     }
     ---
+    )
 
     $(P
         Currently all Objective-C classes need to be declared as interfaces in
@@ -134,6 +136,7 @@ $(SPEC_S Interfacing to Objective-C,
         attribute to an interface. Example:
     )
 
+    $(RUNNABLE_EXAMPLE
     ---
     extern (Objective-C)
     interface NSObject
@@ -141,6 +144,7 @@ $(SPEC_S Interfacing to Objective-C,
         NSObject init() @selector("init");
     }
     ---
+    )
 
     $(P
         All methods inside an interface declared as `extern (Objective-C)` will
@@ -234,6 +238,7 @@ $(SPEC_S Interfacing to Objective-C,
         message using `NSLog` to stderr.
     )
 
+    $(RUNNABLE_EXAMPLE
     ---
     extern (Objective-C)
     interface Class
@@ -241,6 +246,7 @@ $(SPEC_S Interfacing to Objective-C,
         NSString alloc() @selector("alloc");
     }
     ---
+    )
 
     $(P
         This interface is used to emulate the $(LINK2 https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ObjCRuntimeRef/#//apple_ref/c/tdef/Class, `Class`)

--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -68,6 +68,7 @@ $(H2 $(LEGACY_LNAME2 Unary, unary, Unary Operator Overloading))
 	$(P For example, in order to overload the $(D -) (negation) operator for struct S, and
 	no other operator:)
 
+$(RUNNABLE_EXAMPLE
 ---
 struct S
 {
@@ -84,6 +85,7 @@ int foo(S s)
     return -s;
 }
 ---
+)
 
 $(H3 $(LNAME2 postincrement_postdecrement_operators, Postincrement $(I e)$(D ++) and Postdecrement $(I e)$(D --) Operators))
 
@@ -714,6 +716,8 @@ $(H2 $(LEGACY_LNAME2 ArrayOps, array-ops, Array Indexing and Slicing Operators O
 	explanations of the various constructs employed are given in the
 	sections following.)
 
+$(RUNNABLE_EXAMPLE
+$(RUNNABLE_EXAMPLE_ARGS -main -unittest)
 -------
 struct Array2D(E)
 {
@@ -802,6 +806,7 @@ unittest
     assert(slice4[0, 0] == 8 && slice4[1, 0] == 9 && slice4[2, 0] == 10);
 }
 -------
+)
 
 $(H3 $(LEGACY_LNAME2 Array, array, Index Operator Overloading))
 
@@ -841,6 +846,7 @@ $(H3 $(LEGACY_LNAME2 Slice, slice, Slice Operator Overloading))
 	$(P To overload $(D a[]), simply define $(D opIndex) with no parameters:
 	)
 
+$(RUNNABLE_EXAMPLE
 -----
 struct S
 {
@@ -850,13 +856,14 @@ struct S
         return impl[];
     }
 }
-void test()
+void main()
 {
     auto s = S([1,2,3]);
     auto t = s[]; // calls s.opIndex()
     assert(t == [1,2,3]);
 }
 -----
+)
 
 	$(P To overload array indexing of the form $(D a[)$(SLICE)$(D ,) ...$(D ]),
 	two steps are needed.  First, the expressions of the form $(SLICE) are
@@ -962,6 +969,7 @@ $(H3 $(LEGACY_LNAME2 Dollar, dollar, Dollar Operator Overloading))
 	understood by $(D opSlice) and $(D opIndex).
 	)
 
+$(RUNNABLE_EXAMPLE
 ------
 struct Rectangle
 {
@@ -986,7 +994,7 @@ struct Rectangle
     }
 }
 
-void test()
+void main()
 {
     auto r = Rectangle(10,20);
     int i = r[$-1, 0];    // same as: r.opIndex(r.opDollar!0, 0),
@@ -995,6 +1003,7 @@ void test()
                           // which is r.opIndex(0, r.height-1)
 }
 ------
+)
 
 	$(P As the above example shows, a different compile-time argument is
 	passed to $(D opDollar) depending on which argument it appears in. A
@@ -1028,6 +1037,7 @@ $(H2 $(LEGACY_LNAME2 Dispatch, dispatch, Forwarding))
 	to a template function named $(CODE opDispatch) for resolution.
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -1069,6 +1079,7 @@ void main()
     assert(d.foo == 8);
 }
 ---
+)
 
 $(H2 $(LEGACY_LNAME2 Old-Style, old-style, D1 style operator overloading))
 

--- a/spec/portability.dd
+++ b/spec/portability.dd
@@ -45,9 +45,11 @@ a + b + c
 	$(LI If size dependencies are inevitable, put a $(D static assert) in
 	the code to verify it:
 
+$(RUNNABLE_EXAMPLE
 -------
 static assert(int.sizeof == (int*).sizeof);
 -------
+)
 	)
 	)
 

--- a/spec/pragma.dd
+++ b/spec/pragma.dd
@@ -128,18 +128,24 @@ pragma(lib, "foo.lib");
         when the symbol is a function declaration or a variable declaration.
         For example this allows linking to a symbol which is a D keyword, which would normally
         be disallowed as a symbol name:
+
+$(RUNNABLE_EXAMPLE
 -----------------
 pragma(mangle, "body")
 extern(C) void body_func();
 -----------------
+)
     )
 
 
     $(DT $(LNAME2 msg, $(D msg)))
     $(DD Constructs a message from the arguments and prints to the standard error stream while compiling:
+
+$(RUNNABLE_EXAMPLE
 -----------------
 pragma(msg, "compiling...", 1, 1.0);
 -----------------
+)
     )
 
 

--- a/spec/property.dd
+++ b/spec/property.dd
@@ -105,6 +105,7 @@ Foo.init.b  // is 7
 	$(LI If $(D T) is a nested struct, the context pointer in $(D T.init)
 	is $(D null).)
 
+$(RUNNABLE_EXAMPLE
 ----------------
 void main()
 {
@@ -119,10 +120,12 @@ void main()
     s3.foo();       // Access violation
 }
 ----------------
+)
 
 	$(LI If $(D T) is a struct which has $(CODE @disable this();), $(D T.init)
 	might return a logically incorrect object.)
 
+$(RUNNABLE_EXAMPLE
 ----------------
 struct S
 {
@@ -141,6 +144,7 @@ void main()
     s3.check();     // Assertion failure.
 }
 ----------------
+)
     )
 )
 
@@ -155,15 +159,15 @@ $(SECTION3 $(LNAME2 stringof, .stringof Property),
 	For example:
 	)
 
+$(RUNNABLE_EXAMPLE
 ----------------
-module test;
 import std.stdio;
 
 struct Foo { }
 
 enum Enum { RED }
 
-typedef int myint;
+alias myint = int;
 
 void main()
 {
@@ -177,6 +181,7 @@ void main()
     writeln((5).stringof);         // "5"
 }
 ----------------
+)
 
 $(P $(B Note): Using $(D .stringof) for code generation is not recommended,
     as the internal representation of a type or expression can change between
@@ -197,6 +202,7 @@ $(SECTION3 $(LNAME2 sizeof, .sizeof Property),
 	there to be a $(I this) object:
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 struct S
 {
@@ -207,11 +213,12 @@ struct S
     }
 }
 
-void test()
+void main()
 {
     int x = S.a.sizeof; // sets x to 4
 }
 ---
+)
 
 	$(P $(CODE .sizeof) applied to a class object returns the size of
 	the class reference, not the class instantiation.)

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -86,6 +86,7 @@ $(GNAME ScopeStatement):
         local symbol declarations in the same function.
         )
 
+$(RUNNABLE_EXAMPLE
 --------------
 void func1(int x)
 {
@@ -110,6 +111,7 @@ void func1(int x)
     { t++;   }  // illegal, t is undefined
 }
 --------------
+)
 
 $(P
         The idea is to avoid bugs in complex functions caused by
@@ -786,6 +788,7 @@ $(H4 $(LNAME2 foreach_over_delegates, Foreach over Delegates))
 
 	$(P For example:)
 
+$(RUNNABLE_EXAMPLE
 --------------
 void main()
 {
@@ -813,6 +816,7 @@ void main()
     assert(result == [1, -2, 4, -8, 16, -32, 64, -128]);
 }
 --------------
+)
 
 	$(P $(B Note:) When $(I ForeachAggregate) is a delegate, the compiler
 	does not try to implement reverse traversal of the results returned by
@@ -843,6 +847,7 @@ $(P
         type.
 )
 
+$(RUNNABLE_EXAMPLE
 -----
 import std.stdio;
 import std.meta : AliasSeq;
@@ -857,6 +862,7 @@ void main()
     }
 }
 -----
+)
 
         $(P Prints:)
 
@@ -871,6 +877,7 @@ $(H4 $(LNAME2 foreach_ref_parameters, Foreach Ref Parameters))
         $(P $(D ref) can be used to update the original elements:
         )
 
+$(RUNNABLE_EXAMPLE
 --------------
 void test()
 {
@@ -886,6 +893,7 @@ void test()
     }
 }
 --------------
+)
 
         which would print:
 
@@ -950,6 +958,7 @@ $(GNAME UprExpression):
         is executed.
         )
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -967,6 +976,7 @@ void main()
     }
 }
 ---
+)
 
         $(P Prints:)
 
@@ -1545,6 +1555,7 @@ $(GNAME FinallyStatement):
         so that the entire exception history is retained.
     )
 
+$(RUNNABLE_EXAMPLE
 --------------
 import std.stdio;
 
@@ -1570,6 +1581,7 @@ int main()
     return 0;
 }
 --------------
+)
 
     prints:
 
@@ -1810,6 +1822,7 @@ $(GNAME MixinStatement):
         $(GLINK StatementList), and is compiled as such.
         )
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -1834,6 +1847,7 @@ void main()
     mixin("y =" ~ "4;");  // ok
 }
 ---
+)
 
 $(SPEC_SUBNAV_PREV_NEXT expression, Expressions, arrays, Arrays)
 )

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -167,11 +167,13 @@ $(H3 $(LNAME2 static_struct_init, Static Initialization of Structs))
         Initializers for statics must be evaluatable at compile time.
         Members not specified in the initializer list are default initialized.
 
+$(RUNNABLE_EXAMPLE
 ------
 struct S { int a; int b; int c; int d = 7;}
 static S x = { a:1, b:2};            // c is set to 0, d to 7
 static S z = { c:4, b:5, a:2 , d:5}; // z.a = 2, z.b = 5, z.c = 4, z.d = 5
 ------
+)
 
         C-style initialization, based on the order of the members in the
         struct declaration, is also supported:
@@ -203,10 +205,12 @@ $(H3 $(LNAME2 static_union_init, Static Initialization of Unions))
 
         Unions are initialized explicitly.
 
+$(RUNNABLE_EXAMPLE
 ------
 union U { int a; double b; }
 static U u = { b : 5.0 }; // u.b = 5.0
 ------
+)
 
         Other members of the union that overlay the initializer,
         but occupy more storage, have
@@ -303,6 +307,7 @@ $(SECTION3 $(LEGACY_LNAME2 ConstStruct, const-struct, Const, Immutable and Share
         $(CODE const), $(CODE immutable) or $(CODE shared).
         )
 
+        $(RUNNABLE_EXAMPLE
         ----
         const struct S { int a; int b = 2; }
 
@@ -314,6 +319,7 @@ $(SECTION3 $(LEGACY_LNAME2 ConstStruct, const-struct, Const, Immutable and Share
             t.a = 4;    // error, t.a is const
         }
         ----
+        )
 )
 
 $(SECTION3 $(LEGACY_LNAME2 Struct-Constructor, struct-constructor, Struct Constructors),
@@ -325,6 +331,7 @@ $(SECTION3 $(LEGACY_LNAME2 Struct-Constructor, struct-constructor, Struct Constr
         are default initialized to their $(CODE .init) value.
         )
 
+        $(RUNNABLE_EXAMPLE
         ------
         struct S
         {
@@ -347,6 +354,7 @@ $(SECTION3 $(LEGACY_LNAME2 Struct-Constructor, struct-constructor, Struct Constr
             auto b = S();  // same as auto b = S.init;
         }
         ------
+        )
 
 $(COMMENT
 $(P Inside a constructor, the first occurrence (in lexical order) of assignments
@@ -354,6 +362,7 @@ of the form $(CODE member = expression;) are handled differently than usual
 assignments. The first such assignment in lexical order is converted to a
 constructor call for the member's type. Example:)
 
+$(RUNNABLE_EXAMPLE
 ------
 import std.stdio;
 
@@ -380,6 +389,7 @@ void main(string[] args)
     // b.a = 10; does not compile here, A does not define opAssign(int).
 }
 ------
+)
 
 $(P The program above prints the line $(CODE "[= A.this(10) =]"). Anywhere else
 attempting to assign an integer to an object of type `A` would count as an
@@ -389,6 +399,7 @@ $(P Finding the first assignment in lexical order is flow-sensitive upon the
 `if` statement. Consider a change to struct `B` in the previous example as
 follows:)
 
+$(RUNNABLE_EXAMPLE
 ------
 struct B
 {
@@ -402,11 +413,13 @@ struct B
     }
 }
 ------
+)
 
 $(P This code issues a constructor call on each branch of the `if` statement.
 However, such flow sensitivity is limited. There is no static or dynamic
 analysis of coverage of the `if` statement. For example:)
 
+$(RUNNABLE_EXAMPLE
 ------
 struct B
 {
@@ -418,11 +431,13 @@ struct B
     }
 }
 ------
+)
 
 $(P Also, member assignments inside loops are never considered constructors,
 even if it can be determined statically that the loop executes at most once.
 Example:)
 
+$(RUNNABLE_EXAMPLE
 ------
 struct B
 {
@@ -433,6 +448,7 @@ struct B
     }
 }
 ------
+)
 
 $(P If an exception is thrown at any point from within a constructor,
 destructors are called for all members, in reverse lexical order of their
@@ -444,6 +460,7 @@ constructor will have their `.init` values upon destruction.)
         that specific qualifier.
         )
 
+        $(RUNNABLE_EXAMPLE
         ------
         struct S1
         {
@@ -482,11 +499,14 @@ constructor will have their `.init` values upon destruction.)
             immutable i2 = immutable S2(1);
         }
         ------
+        )
 
         $(P If struct constructor is annotated with $(D @disable) and has
         empty parameter, the struct is disabled construction without calling
         other constructor.
         )
+
+        $(RUNNABLE_EXAMPLE
         ------
         struct S
         {
@@ -504,6 +524,7 @@ constructor will have their `.init` values upon destruction.)
             S s = S(1);   // construction with calling constructor
         }
         ------
+        )
 )
 
 $(SECTION3 $(LEGACY_LNAME2 StructPostblit, struct-postblit, Struct Postblits),
@@ -533,6 +554,7 @@ $(GNAME Postblit):
         etc. For example:
         )
 
+        $(RUNNABLE_EXAMPLE
         ---
         struct S
         {
@@ -543,10 +565,12 @@ $(GNAME Postblit):
             }
         }
         ---
+        )
 
         $(P Disabling struct postblit makes the object not copyable.
         )
 
+        $(RUNNABLE_EXAMPLE
         ---
         struct T
         {
@@ -563,6 +587,7 @@ $(GNAME Postblit):
             S t = s; // error, S is not copyable
         }
         ---
+        )
 
         $(P Unions may not have fields that have postblits.)
 )
@@ -634,6 +659,7 @@ $(SECTION3 $(LEGACY_LNAME2 AssignOverload, assign-overload, Identity Assignment 
         is if the struct has a reference to a local buffer:
         )
 
+        $(RUNNABLE_EXAMPLE
         ---
         struct S
         {
@@ -652,6 +678,7 @@ $(SECTION3 $(LEGACY_LNAME2 AssignOverload, assign-overload, Identity Assignment 
             }
         }
         ---
+        )
 
         $(P Here, $(CODE S) has a temporary workspace $(CODE buf[]).
         The normal postblit
@@ -671,6 +698,7 @@ $(H2 $(LNAME2 nested, Nested Structs))
         It has access to the context of its enclosing scope
         (via an added hidden field).
 
+        $(RUNNABLE_EXAMPLE
         ---
         void foo()
         {
@@ -685,6 +713,7 @@ $(H2 $(LNAME2 nested, Nested Structs))
             s.bar(); // returns 11
         }
         ---
+        )
     )
 
     $(P A struct can be prevented from being nested by
@@ -692,6 +721,7 @@ $(H2 $(LNAME2 nested, Nested Structs))
         will not be able to access variables from its enclosing
         scope.
 
+        $(RUNNABLE_EXAMPLE
         ---
         void foo()
         {
@@ -706,6 +736,7 @@ $(H2 $(LNAME2 nested, Nested Structs))
             }
         }
         ---
+        )
     )
 
 $(H2 $(LNAME2 unions_and_special_memb_funct, Unions and Special Member Functions))

--- a/spec/template-mixin.dd
+++ b/spec/template-mixin.dd
@@ -41,6 +41,7 @@ $(GNAME QualifiedIdentifierList):
         template instantiations.
         )
 
+$(RUNNABLE_EXAMPLE
 ------
 mixin template Foo()
 {
@@ -54,7 +55,7 @@ struct Bar
     $(CODE_HIGHLIGHT mixin Foo;)
 }
 
-void test()
+void main()
 {
     writefln("x = %d", x);         // prints 5
     {
@@ -74,6 +75,7 @@ void test()
     writefln("x = %d", x);         // prints 5
 }
 ------
+)
 
         Mixins can be parameterized:
 
@@ -88,6 +90,7 @@ $(CODE_HIGHLIGHT mixin Foo!(int);)           // create x of type int
 
         Mixins can add virtual functions to a class:
 
+$(RUNNABLE_EXAMPLE
 ------
 mixin template Foo()
 {
@@ -104,7 +107,7 @@ class Code : Bar
     override void func() { writeln("Code.func()"); }
 }
 
-void test()
+void main()
 {
     Bar b = new Bar();
     b.func();      // calls Foo.func()
@@ -113,10 +116,12 @@ void test()
     b.func();      // calls Code.func()
 }
 ------
+)
 
         Mixins are evaluated in the scope of where they appear, not the scope
         of the template declaration:
 
+$(RUNNABLE_EXAMPLE
 ------
 int y = 3;
 
@@ -125,36 +130,42 @@ mixin template Foo()
     int abc() { return y; }
 }
 
-void test()
+void main()
 {
     int y = 8;
     $(CODE_HIGHLIGHT mixin Foo;) // local y is picked up, not global y
     assert(abc() == 8);
 }
 ------
+)
 
         Mixins can parameterize symbols using alias parameters:
 
+$(RUNNABLE_EXAMPLE
 ------
 mixin template Foo(alias b)
 {
     int abc() { return b; }
 }
 
-void test()
+void main()
 {
     int y = 8;
     $(CODE_HIGHLIGHT mixin Foo!(y);)
     assert(abc() == 8);
 }
 ------
+)
 
         This example uses a mixin to implement a generic Duff's device
         for an arbitrary statement (in this case, the arbitrary statement
         is in bold). A nested function is generated as well as a
         delegate literal, these can be inlined by the compiler:
 
+$(RUNNABLE_EXAMPLE
 ------
+import std.stdio : writeln;
+
 mixin template duffs_device(alias id1, alias id2, alias s)
 {
     void duff_loop()
@@ -181,7 +192,7 @@ mixin template duffs_device(alias id1, alias id2, alias s)
 
 void foo() { writeln("foo"); }
 
-void test()
+void main()
 {
     int i = 1;
     int j = 11;
@@ -190,6 +201,7 @@ void test()
     duff_loop();  // executes foo() 10 times
 }
 ------
+)
 
 $(H2 $(LNAME2 mixin_scope, Mixin Scope))
 
@@ -199,7 +211,10 @@ $(H2 $(LNAME2 mixin_scope, Mixin Scope))
         as a declaration in the surrounding scope, the surrounding declaration
         overrides the mixin one:
 
+$(RUNNABLE_EXAMPLE
 ------
+import std.stdio;
+
 int x = 3;
 
 mixin template Foo()
@@ -211,17 +226,19 @@ mixin template Foo()
 $(CODE_HIGHLIGHT mixin Foo;)
 int y = 3;
 
-void test()
+void main()
 {
     writefln("x = %d", x);  // prints 3
     writefln("y = %d", y);  // prints 3
 }
 ------
+)
 
         If two different mixins are put in the same scope, and each
         define a declaration with the same name, there is an ambiguity
         error when the declaration is referenced:
 
+$(RUNNABLE_EXAMPLE
 ------
 mixin template Foo()
 {
@@ -245,6 +262,7 @@ void test()
     func(1);               // error, func is ambiguous
 }
 ------
+)
         $(P The call to $(D func()) is ambiguous because
         Foo.func and Bar.func are in different scopes.
         )
@@ -252,7 +270,10 @@ void test()
         $(P If a mixin has an $(I Identifier), it can be used to
         disambiguate between conflicting symbols:
         )
+$(RUNNABLE_EXAMPLE
 ------
+import std.stdio;
+
 int x = 6;
 
 mixin template Foo()
@@ -281,9 +302,11 @@ void test()
     B.func();                  // calls Bar.func
 }
 ------
+)
         $(P Alias declarations can be used to overload together
         functions declared in different mixins:)
 
+$(RUNNABLE_EXAMPLE
 -----
 mixin template Foo()
 {
@@ -307,11 +330,13 @@ void main()
     func(1L); // calls F.func
 }
 -----
+)
 
 
         $(P A mixin has its own scope, even if a declaration is overridden
         by the enclosing one:)
 
+$(RUNNABLE_EXAMPLE
 ------
 int x = 4;
 
@@ -323,12 +348,13 @@ mixin template Foo()
 
 $(CODE_HIGHLIGHT mixin Foo;)
 
-void test()
+void main()
 {
     writefln("x = %d", x);         // prints 4
     writefln("bar() = %d", bar()); // prints 5
 }
 ------
+)
 
 $(SPEC_SUBNAV_PREV_NEXT template, Templates, contracts, Contract Programming)
 )

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -168,6 +168,7 @@ $(GNAME TemplateSingleArgument):
 
     $(P For example, a simple generic copy template would be:
 
+        $(RUNNABLE_EXAMPLE
         ------
         template TCopy(T)
         {
@@ -177,6 +178,7 @@ $(GNAME TemplateSingleArgument):
             }
         }
         ------
+        )
     )
 
     $(P To use the template, it must first be instantiated with a specific
@@ -367,6 +369,7 @@ $(GNAME TemplateThisParameter):
     $(P $(I TemplateThisParameter)s are used in member function templates
         to pick up the type of the $(I this) reference.
 
+        $(RUNNABLE_EXAMPLE
         ---
         import std.stdio;
 
@@ -388,6 +391,7 @@ $(GNAME TemplateThisParameter):
             s3.foo(3);
         }
         ---
+        )
     )
 
     $(P Prints:
@@ -404,6 +408,7 @@ immutable(S)
         class type. Typically you would return a base type, but this won't allow
         you to call or access derived properties of the type:
 
+        $(RUNNABLE_EXAMPLE
         ---
         interface Addable(T)
         {
@@ -427,11 +432,13 @@ immutable(S)
             list.add(1).remove(1);  // error: no 'remove' method for Addable!int
         }
         ---
+        )
     )
 
     $(P Here the method $(D add) returns the base type, which doesn't implement the
         $(D remove) method. The $(D template this) parameter can be used for this purpose:
 
+        $(RUNNABLE_EXAMPLE
         ---
         interface Addable(T)
         {
@@ -455,6 +462,7 @@ immutable(S)
             list.add(1).remove(1);  // ok
         }
         ---
+        )
     )
 
 $(H2 $(LNAME2 template_value_parameter, Template Value Parameters))
@@ -481,6 +489,7 @@ $(GNAME TemplateValueParameterDefault):
         associative array literals of template value arguments,
         or struct literals of template value arguments.
 
+        $(RUNNABLE_EXAMPLE
         -----
         template foo(string s)
         {
@@ -489,14 +498,17 @@ $(GNAME TemplateValueParameterDefault):
 
         void main()
         {
+            import std.stdio;
             writefln("%s", foo!("hello").bar()); // prints: hello betty
         }
         -----
+        )
     )
 
     $(P This example of template foo has a value parameter that
         is specialized for 10:
 
+        $(RUNNABLE_EXAMPLE
         ------
         template foo(U : int, int T : 10)
         {
@@ -508,6 +520,7 @@ $(GNAME TemplateValueParameterDefault):
             assert(foo!(int, 10).x == 10);
         }
         ------
+        )
     )
 
 
@@ -539,6 +552,7 @@ $(GNAME TemplateAliasParameterDefault):
     $(UL
         $(LI User-defined type names
 
+        $(RUNNABLE_EXAMPLE
         ------
         class Foo
         {
@@ -557,9 +571,11 @@ $(GNAME TemplateAliasParameterDefault):
         }
         ------
         )
+        )
 
         $(LI Global names
 
+        $(RUNNABLE_EXAMPLE
         ------
         shared int x;
 
@@ -578,9 +594,11 @@ $(GNAME TemplateAliasParameterDefault):
         }
         ------
         )
+        )
 
         $(LI Module names
 
+        $(RUNNABLE_EXAMPLE
         ------
         import std.string;
 
@@ -596,9 +614,11 @@ $(GNAME TemplateAliasParameterDefault):
         }
         ------
         )
+        )
 
         $(LI Template names
 
+        $(RUNNABLE_EXAMPLE
         ------
         shared int x;
 
@@ -619,9 +639,11 @@ $(GNAME TemplateAliasParameterDefault):
         }
         ------
         )
+        )
 
         $(LI Template instance names
 
+        $(RUNNABLE_EXAMPLE
         ------
         shared int x;
 
@@ -643,9 +665,11 @@ $(GNAME TemplateAliasParameterDefault):
         }
         ------
         )
+        )
 
         $(LI Literals
 
+        $(RUNNABLE_EXAMPLE
         ------
         template Foo(alias X, alias Y)
         {
@@ -655,10 +679,12 @@ $(GNAME TemplateAliasParameterDefault):
 
         void main()
         {
+            import std.stdio;
             alias foo = Foo!(3, "bar");
             writeln(foo.i, foo.s);  // prints 3bar
         }
         ------
+        )
         )
     )
 
@@ -667,6 +693,7 @@ $(H3 $(LNAME2 typed_alias_op, Typed alias parameters))
     $(P Alias parameters can also be typed.
         These parameters will accept symbols of that type:
 
+        $(RUNNABLE_EXAMPLE
         ------
         template Foo(alias int x) { }
         int x;
@@ -675,6 +702,7 @@ $(H3 $(LNAME2 typed_alias_op, Typed alias parameters))
         Foo!x;  // ok
         Foo!f;  // fails to instantiate
         ------
+        )
     )
 
 $(H3 $(LNAME2 alias_parameter_specialization, Specialization))
@@ -732,6 +760,7 @@ $(GNAME TemplateSequenceParameter):
     $(P An $(I AliasSeq) can be used as an argument list to instantiate
         another template, or as the list of parameters for a function.
 
+        $(RUNNABLE_EXAMPLE
         ---
         template print(args...)
         {
@@ -756,6 +785,7 @@ $(GNAME TemplateSequenceParameter):
             write!(int, char, double).write(1, 'a', 6.8); // prints: args are 1a6.8
         }
         ---
+        )
     )
 
     $(P The number of elements in an $(I AliasSeq) can be retrieved with
@@ -771,6 +801,7 @@ $(GNAME TemplateSequenceParameter):
     $(P Type sequences can be deduced from the trailing parameters
         of an implicitly instantiated function template:
 
+        $(RUNNABLE_EXAMPLE
         ---
         template print(T, Args...)
         {
@@ -787,6 +818,7 @@ $(GNAME TemplateSequenceParameter):
             print(1, 'a', 6.8);
         }
         ---
+        )
     )
 
     $(P prints:
@@ -801,6 +833,7 @@ a
     $(P Type sequences can also be deduced from the type of a delegate
         or function parameter list passed as a function argument:
 
+        $(RUNNABLE_EXAMPLE
         ----
         import std.stdio;
 
@@ -826,6 +859,7 @@ a
             writefln("%d", plus_two(6, 8)); // prints 16
         }
         ----
+        )
         See also: $(REF partial, std,functional)
     )
 
@@ -835,6 +869,7 @@ $(H3 $(LNAME2 variadic_template_specialization, Specialization))
         without a sequence parameter exactly match a template instantiation,
         the template without a $(I TemplateSequenceParameter) is selected.
 
+        $(RUNNABLE_EXAMPLE
         ----
         template Foo(T)         { pragma(msg, "1"); }   // #1
         template Foo(int n)     { pragma(msg, "2"); }   // #2
@@ -850,12 +885,14 @@ $(H3 $(LNAME2 variadic_template_specialization, Specialization))
 
         alias foo4 = Foo!(int, 3, std);  // instantiates #4
         ----
+        )
     )
 
 $(H2 $(LNAME2 template_parameter_def_values, Template Parameter Default Values))
 
     $(P Trailing template parameters can be given default values:
 
+        $(RUNNABLE_EXAMPLE
         ------
         template Foo(T, U = int) { ... }
         Foo!(uint,long); // instantiate Foo with T as uint, and U as long
@@ -864,6 +901,7 @@ $(H2 $(LNAME2 template_parameter_def_values, Template Parameter Default Values))
         template Foo(T, U = T*) { ... }
         Foo!(uint);      // instantiate Foo with T as uint, and U as uint*
         ------
+        )
     )
 
 $(H2 $(LNAME2 implicit_template_properties, Eponymous Templates))
@@ -873,6 +911,7 @@ $(H2 $(LNAME2 implicit_template_properties, Eponymous Templates))
         members include at least all the template parameters then these members
         are assumed to be referred to in a template instantiation:
 
+        $(RUNNABLE_EXAMPLE
         ------
         template foo(T)
         {
@@ -884,9 +923,11 @@ $(H2 $(LNAME2 implicit_template_properties, Eponymous Templates))
             foo!(int) = 6; // instead of foo!(int).foo
         }
         ------
+        )
 
         Using functions and more types than the template:
 
+        $(RUNNABLE_EXAMPLE
         ------
         template foo(S, T)
         {
@@ -901,11 +942,13 @@ $(H2 $(LNAME2 implicit_template_properties, Eponymous Templates))
             foo(1, 2); // foo!(int, int).foo(1, 2)
         }
         ------
+        )
 
         When the template parameters must be deduced, the eponymous members
         can't rely on a $(LINK2 version.html#StaticIfCondition, `static if`)
         condition since the deduction relies on how the in members are used:
 
+        $(RUNNABLE_EXAMPLE
         ------
         template foo(T)
         {
@@ -919,6 +962,7 @@ $(H2 $(LNAME2 implicit_template_properties, Eponymous Templates))
             foo!int(0); // Ok since no deduction necessary
         }
         ------
+        )
     )
 
 $(H2 $(LNAME2 template_ctors, Template Constructors))
@@ -1136,6 +1180,7 @@ $(H3 $(LNAME2 auto-ref-parameters, Function Templates with Auto Ref Parameters))
         if its corresponding argument is an lvalue, otherwise it becomes
         a value parameter:
 
+        $(RUNNABLE_EXAMPLE
         ---
         int foo(Args...)(auto ref Args args)
         {
@@ -1163,11 +1208,13 @@ $(H3 $(LNAME2 auto-ref-parameters, Function Templates with Auto Ref Parameters))
             r = foo(y, 6, y); // returns 26
         }
         ---
+        )
     )
 
     $(P Auto ref parameters can be combined with auto ref return
         attributes:
 
+        $(RUNNABLE_EXAMPLE
         ---
         auto ref min(T, U)(auto ref T lhs, auto ref U rhs)
         {
@@ -1186,6 +1233,7 @@ $(H3 $(LNAME2 auto-ref-parameters, Function Templates with Auto Ref Parameters))
             static assert(!__traits(compiles, min(y, 3) = 10));
         }
         ---
+        )
     )
 
 $(H2 $(LNAME2 nested-templates, Nested Templates))
@@ -1194,6 +1242,7 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
         instantiated functions will implicitly capture the context of the
         enclosing scope.
 
+        $(RUNNABLE_EXAMPLE
         ----
         class C
         {
@@ -1225,6 +1274,7 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
             assert(c.num == 10);
         }
         ----
+        )
     )
 
     $(P Above, $(D Foo!().foo) will work just the same as a member function
@@ -1236,6 +1286,7 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
         implicitly become nested in order to access runtime data of the given
         local symbol.
 
+        $(RUNNABLE_EXAMPLE
         ----
         template Foo(alias sym)
         {
@@ -1276,11 +1327,13 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
             assert(num == 10);  // OK
         }
         ----
+        )
     )
 
     $(P Not only functions, but also instantiated class and struct types can
         become nested via implicitly captured context.
 
+        $(RUNNABLE_EXAMPLE
         ----
         class C
         {
@@ -1301,7 +1354,9 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
             assert(n.foo() == 20);
         }
         ----
+        )
 
+        $(RUNNABLE_EXAMPLE
         ----
         void main()
         {
@@ -1315,11 +1370,13 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
             assert(s.foo() == 20);
         }
         ----
+        )
     )
 
     $(P A templated $(D struct) can become a nested $(D struct) if it
         is instantiated with a local symbol passed as an aliased argument:
 
+        $(RUNNABLE_EXAMPLE
         ---
         struct A(alias F)
         {
@@ -1336,6 +1393,7 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
             assert(a.fun(2) == 42);
         }
         ---
+        )
     )
 
     $(H3 $(LNAME2 nested_template_limitation, Limitation:))
@@ -1344,6 +1402,7 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
         example, non-static template member functions cannot take local symbol
         by using template alias parameter.
 
+        $(RUNNABLE_EXAMPLE
         ----
         class C
         {
@@ -1358,10 +1417,12 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
             c.foo!var();    // NG, foo!var requires two contexts, 'this' and 'main()'
         }
         ----
+        )
     )
 
     $(P But, if one context is indirectly accessible from other context, it is allowed.
 
+        $(RUNNABLE_EXAMPLE
         ----
         int sum(alias x, alias y)() { return x + y; }
 
@@ -1376,6 +1437,7 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
             nested();
         }
         ----
+        )
 
         Two local variables $(D a) and $(D b) are in different contexts, but
         outer context is indirectly accessible from innter context, so nested
@@ -1389,6 +1451,7 @@ $(H2 $(LNAME2 recursive_templates, Recursive Templates))
         effects, such as compile time evaluation of non-trivial functions.
         For example, a factorial template can be written:
 
+        $(RUNNABLE_EXAMPLE
         ------
         template factorial(int n : 1)
         {
@@ -1400,11 +1463,12 @@ $(H2 $(LNAME2 recursive_templates, Recursive Templates))
             enum { factorial = n* factorial!(n-1) }
         }
 
-        void test()
+        void main()
         {
             writefln("%s", factorial!(4)); // prints 24
         }
         ------
+        )
     )
 
 $(H2 $(LNAME2 template_constraints, Template Constraints))
@@ -1426,6 +1490,7 @@ $(GNAME Constraint):
     $(P For example, the following function template only
         matches with odd values of $(CODE N):
 
+        $(RUNNABLE_EXAMPLE
         ---
         void foo(int N)()
             if (N & 1)
@@ -1436,11 +1501,13 @@ $(GNAME Constraint):
         foo!(3)();  // OK, matches
         foo!(4)();  // Error, no match
         ---
+        )
     )
 
     $(P Template constraints can be used with aggregate types (structs, classes, unions).
         Constraints are effectively used with library module "std.traits":
 
+        $(RUNNABLE_EXAMPLE
         ---
         import std.traits;
 
@@ -1453,6 +1520,7 @@ $(GNAME Constraint):
         auto x = Bar!int;       // OK, int is an integral type
         auto y = Bar!double;    // Error, double does not satisfy constraint
         ---
+        )
     )
 
 $(H2 $(LNAME2 limitations, Limitations))
@@ -1461,6 +1529,7 @@ $(H2 $(LNAME2 limitations, Limitations))
         virtual functions to classes or interfaces.
         For example:
 
+        $(RUNNABLE_EXAMPLE
         ------
         class Foo
         {
@@ -1474,6 +1543,7 @@ $(H2 $(LNAME2 limitations, Limitations))
             }
         }
         ------
+        )
     )
 $(SPEC_SUBNAV_PREV_NEXT operatoroverloading, Operator Overloading, template-mixin, Template Mixins)
 )

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -89,6 +89,7 @@ $(H2 $(GNAME isArithmetic))
 	Otherwise, $(D false) is returned.
 	If there are no arguments, $(D false) is returned.)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -101,6 +102,7 @@ void main()
     writeln(__traits(isArithmetic, int*));
 }
 ---
+)
 
 	$(P Prints:)
 
@@ -149,6 +151,7 @@ $(H2 $(GNAME isAbstractClass))
 	Otherwise, $(D false) is returned.
 	If there are no arguments, $(D false) is returned.)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -163,6 +166,7 @@ void main()
     writeln(__traits(isAbstractClass, int*));
 }
 ---
+)
 
 	$(P Prints:)
 
@@ -205,6 +209,7 @@ $(H2 $(GNAME isVirtualMethod))
 	Final functions that don't override anything return false.
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -224,6 +229,7 @@ void main()
     writeln(__traits(isVirtualMethod, S.bar));  // false
 }
 ---
+)
 
 $(H2 $(GNAME isAbstractFunction))
 
@@ -231,6 +237,7 @@ $(H2 $(GNAME isAbstractFunction))
 	$(D true) is returned, otherwise $(D false).
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -256,6 +263,7 @@ void main()
     writeln(__traits(isAbstractFunction, AC.foo));  // true
 }
 ---
+)
 
 $(H2 $(GNAME isFinalFunction))
 
@@ -263,6 +271,7 @@ $(H2 $(GNAME isFinalFunction))
 	$(D true) is returned, otherwise $(D false).
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -290,6 +299,7 @@ void main()
     writeln(__traits(isFinalFunction, FC.foo)); // true
 }
 ---
+)
 
 $(H2 $(GNAME isOverrideFunction))
 
@@ -297,6 +307,7 @@ $(H2 $(GNAME isOverrideFunction))
 	$(D_KEYWORD override), $(D true) is returned, otherwise $(D false).
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -318,6 +329,7 @@ void main()
     writeln(__traits(isOverrideFunction, Foo.bar));  // false
 }
 ---
+)
 
 $(H2 $(GNAME isStaticFunction))
 
@@ -334,6 +346,7 @@ $(H2 $(GNAME isRef), $(GNAME isOut), $(GNAME isLazy))
 	or $(D_KEYWORD lazy), otherwise $(D false).
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 void fooref(ref int x)
 {
@@ -356,6 +369,7 @@ void foolazy(lazy int x)
     static assert(__traits(isLazy, x));
 }
 ---
+)
 
 $(H2 $(GNAME isTemplate))
 
@@ -363,12 +377,14 @@ $(H2 $(GNAME isTemplate))
 	otherwise $(D false).
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 void foo(T)(){}
 static assert(__traits(isTemplate,foo));
 static assert(!__traits(isTemplate,foo!int()));
 static assert(!__traits(isTemplate,"string"));
 ---
+)
 
 $(H2 $(GNAME hasMember))
 
@@ -379,6 +395,7 @@ $(H2 $(GNAME hasMember))
 	$(D true) is returned, otherwise $(D false).
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -397,6 +414,7 @@ void main()
     writeln(__traits(hasMember, int, "sizeof")); // true
 }
 ---
+)
 
 $(H2 $(GNAME identifier))
 
@@ -422,6 +440,7 @@ $(SECTION2 $(GNAME getAttributes),
         For more information, see: $(DDSUBLINK spec/attribute, uda, User Defined Attributes)
     )
 
+$(RUNNABLE_EXAMPLE
 ---
 @(3) int a;
 @("string", 7) int b;
@@ -433,6 +452,7 @@ pragma(msg, __traits(getAttributes, a));
 pragma(msg, __traits(getAttributes, b));
 pragma(msg, __traits(getAttributes, c));
 ---
+)
 
     $(P
         Prints:
@@ -462,6 +482,7 @@ $(SECTION2 $(GNAME getFunctionVariadicStyle),
 	$(TROW $(D "typesafe"), typesafe variadic function, array on stack, $(D void def(int[] ...)))
     )
 
+$(RUNNABLE_EXAMPLE
 ---
 import core.stdc.stdarg;
 
@@ -480,6 +501,7 @@ static assert(__traits(getFunctionVariadicStyle, typesafe) == "typesafe");
 static assert(__traits(getFunctionVariadicStyle, (int[] a...) {}) == "typesafe");
 static assert(__traits(getFunctionVariadicStyle, typeof(cstyle)) == "stdarg");
 ---
+)
 )
 
 $(SECTION2 $(GNAME getFunctionAttributes),
@@ -510,6 +532,7 @@ $(SECTION2 $(GNAME getFunctionAttributes),
 
     $(P For example:)
 
+$(RUNNABLE_EXAMPLE
 ---
 int sum(int x, int y) pure nothrow { return x + y; }
 
@@ -524,13 +547,16 @@ struct S
 // prints ("const", "@system")
 pragma(msg, __traits(getFunctionAttributes, S.test));
 ---
+)
 
     $(P Note that some attributes can be inferred. For example:)
 
+$(RUNNABLE_EXAMPLE
 ---
 // prints ("pure", "nothrow", "@nogc", "@trusted")
 pragma(msg, __traits(getFunctionAttributes, (int x) @trusted { return x * 2; }));
 ---
+)
 )
 
 $(H2 $(GNAME getLinkage))
@@ -552,6 +578,7 @@ $(H2 $(GNAME getLinkage))
 	$(LI $(D "System"))
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 extern (C) int fooc();
 alias aliasc = fooc;
@@ -559,6 +586,7 @@ alias aliasc = fooc;
 static assert(__traits(getLinkage, fooc) == "C");
 static assert(__traits(getLinkage, aliasc) == "C");
 ---
+)
 
 $(H2 $(GNAME getMember))
 
@@ -568,6 +596,7 @@ $(H2 $(GNAME getMember))
 	argument as an identifier.
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -588,6 +617,7 @@ void main()
     __traits(getMember, S, "my") = 2;  // ok
 }
 ---
+)
 
 $(H2 $(GNAME getOverloads))
 
@@ -597,6 +627,7 @@ $(H2 $(GNAME getOverloads))
 	The result is a tuple of all the overloads of that function.
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -623,6 +654,7 @@ void main()
     writeln(i);
 }
 ---
+)
 
 	$(P Prints:)
 
@@ -645,6 +677,7 @@ $(H2 $(GNAME getParameterStorageClasses))
 	It returns a tuple of strings representing the storage classes of that parameter.
     )
 
+$(RUNNABLE_EXAMPLE
 ---
 ref int foo(return ref const int* p, scope int* a, out int b, lazy int c);
 
@@ -655,6 +688,7 @@ static assert(__traits(getParameterStorageClasses, foo, 1)[0] == "scope");
 static assert(__traits(getParameterStorageClasses, foo, 2)[0] == "out");
 static assert(__traits(getParameterStorageClasses, typeof(&foo), 3)[0] == "lazy");
 ---
+)
 
 $(H2 $(GNAME getPointerBitmap))
 
@@ -668,6 +702,8 @@ $(H2 $(GNAME getPointerBitmap))
     For type T, there are $(D T.sizeof / size_t.sizeof) possible pointers represented
     by the bits of the array values.)
     $(P This array can be used by a precise GC to avoid false pointers.)
+
+$(RUNNABLE_EXAMPLE
 ---
 class C
 {
@@ -691,6 +727,7 @@ struct S
 static assert (__traits(getPointerBitmap, C) == [6*size_t.sizeof, 0b010100]);
 static assert (__traits(getPointerBitmap, S) == [7*size_t.sizeof, 0b0110110]);
 ---
+)
 
 
 $(H2 $(GNAME getProtection))
@@ -699,6 +736,7 @@ $(H2 $(GNAME getProtection))
 	The result is a string giving its protection level: "public", "private", "protected", "export", or "package".
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -719,6 +757,7 @@ void main()
     writeln(j);
 }
 ---
+)
 
 	$(P Prints:)
 
@@ -744,6 +783,7 @@ $(H2 $(GNAME getVirtualMethods))
 	It does not include final functions that do not override anything.
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -770,6 +810,7 @@ void main()
     writeln(i);
 }
 ---
+)
 
 	$(P Prints:)
 
@@ -799,6 +840,7 @@ $(H2 $(GNAME getUnitTests))
 		empty tuple.
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 module foo;
 
@@ -849,6 +891,7 @@ void main()
         test();
 }
 ---
+)
 
 	$(P By default, the above will print:)
 
@@ -895,6 +938,7 @@ $(H2 $(GNAME allMembers))
 	Builtin properties are not included.
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -913,6 +957,7 @@ void main()
     // ["__ctor", "__dtor", "foo", "toString", "toHash", "opCmp", "opEquals", "Monitor", "factory"]
 }
 ---
+)
 
 	$(P The order in which the strings appear in the result
 	is not defined.)
@@ -928,6 +973,7 @@ $(H2 $(GNAME derivedMembers))
 	Builtin properties are not included.
 	)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -945,6 +991,7 @@ void main()
     writeln(a);    // ["__ctor", "__dtor", "foo"]
 }
 ---
+)
 
 	$(P The order in which the strings appear in the result
 	is not defined.)
@@ -954,6 +1001,7 @@ $(H2 $(GNAME isSame))
 	$(P Takes two arguments and returns bool $(D true) if they
 	are the same symbol, $(D false) if not.)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -972,6 +1020,7 @@ void main()
     writeln(__traits(isSame, std, std)); // true
 }
 ---
+)
 
 	$(P If the two arguments are expressions made up of literals
 	or enums that evaluate to the same value, true is returned.)
@@ -987,6 +1036,7 @@ $(H2 $(GNAME compiles))
 
 	$(P If there are no arguments, the result is $(D false).)
 
+$(RUNNABLE_EXAMPLE
 ---
 import std.stdio;
 
@@ -1013,6 +1063,7 @@ void main()
     writeln(__traits(compiles, 1,2,3,int,long,3[1])); // false
 }
 ---
+)
 
 	$(P This is useful for:)
 
@@ -1045,6 +1096,7 @@ $(H2 $(LNAME2 specialkeywords, Special Keywords))
 
     $(P Example usage:)
 
+$(RUNNABLE_EXAMPLE
 -----
 module test;
 import std.stdio;
@@ -1062,6 +1114,7 @@ int main(string[] args)
     return 0;
 }
 -----
+)
 
 	$(P Assuming the file was at /example/test.d, this will output:)
 

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -94,6 +94,7 @@ $(SECTION3 $(LEGACY_LNAME2 Implicit Conversions, implicit-conversions, Implicit 
     For example:
     )
 
+$(RUNNABLE_EXAMPLE
 -------------------
 int i;
 
@@ -105,6 +106,7 @@ f = cast(Foo)i;  // OK
 f = 0;           // error
 f = Foo.E;       // OK
 -------------------
+)
 )
 
 
@@ -285,6 +287,7 @@ int (*fp)(int);  // fp is pointer to a function
     $(P A delegate is initialized analogously to function pointers:
     )
 
+$(RUNNABLE_EXAMPLE
 -------------------
 int func(int);
 fp = &func;   // fp points to func
@@ -297,6 +300,7 @@ OB o;
 dg = &o.member; // dg is a delegate to object o and
                 // member function member
 -------------------
+)
 
     $(P Delegates cannot be initialized with static member functions
     or non-member functions.

--- a/spec/unittest.dd
+++ b/spec/unittest.dd
@@ -44,6 +44,8 @@ unittest
     $(P For example, given a class $(D Sum) that is used to add two values, a unit
     test can be given:)
 
+$(RUNNABLE_EXAMPLE
+$(RUNNABLE_EXAMPLE_ARGS -main -unittest)
 ------
 class Sum
 {
@@ -57,6 +59,7 @@ class Sum
     }
 }
 ------
+)
 
 $(H4 $(LNAME2 attributes_unittest, Attributed Unittests))
 
@@ -64,6 +67,8 @@ $(P A unittest may be attributed with any of the global function attributes.
 Such unittests are useful in verifying the given attribute(s) on a template
 function:)
 
+$(RUNNABLE_EXAMPLE
+$(RUNNABLE_EXAMPLE_ARGS -main -unittest)
 ------
 void myFunc(T)(T[] data)
 {
@@ -78,6 +83,7 @@ void myFunc(T)(T[] data)
     assert(arr == [2,2,3]);
 }
 ------
+)
 
 $(P This unittest verifies that $(D myFunc) contains only $(D @safe), $(D
 nothrow) code. Although this can also be accomplished by attaching these
@@ -97,6 +103,8 @@ $(P Documented unittests allow the developer to deliver code examples to the use
 $(P If a declaration is followed by a documented unittest, the code in
     the unittest will be inserted in the $(B example) section of the declaration:)
 
+$(RUNNABLE_EXAMPLE
+$(RUNNABLE_EXAMPLE_ARGS -main -unittest)
 ------
 /// Math class
 class Math
@@ -118,6 +126,7 @@ unittest
     auto result = math.add(2, 2);
 }
 ------
+)
 
 $(P The above will generate the following documentation:)
 
@@ -145,6 +154,8 @@ $(P A unittest which is not documented, or is marked as private will not be
 $(P There can be multiple documented unittests and they can appear
     in any order. They will be attached to the last non-unittest declaration:)
 
+$(RUNNABLE_EXAMPLE
+$(RUNNABLE_EXAMPLE_ARGS -main -unittest)
 ------
 /// add function
 int add(int x, int y) { return x + y; }
@@ -173,6 +184,7 @@ unittest
     /** assert(add(4, 4) == 8); */
 }
 ------
+)
 
 $(P The above will generate the following documentation:)
 

--- a/spec/version.dd
+++ b/spec/version.dd
@@ -403,6 +403,7 @@ $(GNAME DebugCondition):
 	when the debug identifier matches $(I Identifier).
 	)
 
+$(RUNNABLE_EXAMPLE
 ------
 class Foo
 {
@@ -411,6 +412,7 @@ debug:
     int flag;
 }
 ------
+)
 
 
 $(H3 $(LNAME2 debug_specification, Debug Specification))
@@ -555,6 +557,8 @@ $(GNAME StaticAssert):
 	unsatisfied conditional.
 	)
 
+$(RUNNABLE_EXAMPLE
+$(RUNNABLE_EXAMPLE_ARGS -version=BAR)
 ------
 void foo()
 {
@@ -572,6 +576,7 @@ void foo()
     }
 }
 ------
+)
 
 	$(P $(I StaticAssert) is useful tool for drawing attention to conditional
 	configurations not supported in the code.


### PR DESCRIPTION
A combined PR instead of [the wave](https://github.com/dlang/dlang.org/pulls?utf8=%E2%9C%93&q=run-spec).

For convenience copy/pasted comment from https://github.com/dlang/dlang.org/pull/1753:

In general I was a quite liberate with adding `$(RUNNABLE_EXAMPLE)` as even playing with the compile error should be helpful to a reader.
In some cases
- I changed `test` -> `main` to allow execution
- As it's available as book, I try to add `import std.stdio` where it was missing (though it doesn't matter for dlang.org as `std.stdio` is always imported)
- Sometimes e.g. for unittests I added `$(RUNNABLE_EXAMPLE_ARGS ...)` - that's "new" way to clarify  arguments (there's also $(RUNNABLE_EXAMPLE_STDIN)`
- This isn't intended to be complete run, but I hope a good start with ~90% of the ones that are interesting to be runnable