### PR TITLE
Add example from the DLang Tour to the example roulette

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -161,6 +161,26 @@ void main()
 }
 ----
 )
+$(EXTRA_EXAMPLE_RUNNABLE Sort in-place across multiple arrays,
+----
+void main()
+{
+    import std.stdio : writefln;
+    import std.algorithm.sorting : sort;
+    import std.range : chain;
+
+    int[] arr1 = [4, 9, 7];
+    int[] arr2 = [5, 2, 1, 10];
+    int[] arr3 = [6, 8, 3];
+    // @nogc functions are guaranteed by the compiler
+    // to be without any GC allocation
+    () @nogc {
+        sort(chain(arr1, arr2, arr3));
+    }();
+    writefln("%s\n%s\n%s\n", arr1, arr2, arr3);
+}
+----
+)
 
 ) $(COMMENT your-code-here)
 ))) $(COMMENT intro, div, div)


### PR DESCRIPTION
Full credit for this example goes to @JackStouffer https://github.com/dlang-tour/english/pull/137 - I merely reformatted it and added `@nogc` to prove the point ;-)

While adding the example, I realized that the existing roulette mechanism was broken.

CC @CyberShadow @ZombineDev 