### PR TITLE
Fix JavaScript example roulette

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -28,8 +28,7 @@ $(DIVC intro, $(DIV, $(DIV,
                 $(P Upon approval it will be showcased here on a random schedule.)
             )
         )
-        $(DIVID your-code-here-default,
-$(RUNNABLE_EXAMPLE
+$(EXTRA_EXAMPLE
 $(RUNNABLE_EXAMPLE_STDIN
 The D programming language
 Modern convenience.
@@ -98,8 +97,14 @@ void main()
 ----
 )
 
+) $(COMMENT your-code-here)
+))) $(COMMENT intro, div, div)
+
+$(COMMENT
+Picking the frontpage example after the page has loaded leads to reflows
+and re-rendering. Hence, we pick the example as soon as possible
 )
-)))
+<script src="$(ROOT_DIR)js/example_roulette.js"></script>
 
 $(DIVC more,
 

--- a/js/dlang.js
+++ b/js/dlang.js
@@ -58,14 +58,6 @@
             $('#search-query input').focus();
         });
 
-        // [your code here] rotation for index.html
-        var $examples = $('.your-code-here-extra .d_code');
-        if ($examples.length) {
-            var n = Math.floor(Math.random() * ($examples.length+1));
-            if (n)
-                $('#your-code-here-default .d_code').replaceWith($examples[n-1]);
-        }
-
         // Insert the show/hide button if the contents section exists
         $('.page-contents-header').append('<span><a href="javascript:void(0);">[hide]</a></span>');
 

--- a/js/example_roulette.js
+++ b/js/example_roulette.js
@@ -1,0 +1,116 @@
+/**
+Picking the frontpage example after the page has loaded leads to reflows
+and re-rendering. Hence, we pick the example as soon as possible
+
+Copyright: 1999-2017 by D Language Foundation
+License:   http://boost.org/LICENSE_1_0.txt, Boost License 1.0
+*/
+
+/**
+Prepares the DOM layout of a runnable code example.
+Sibling nodes for program arguments (.runnable-examples-args)
+and stdin (.runnable-examples-stdin) are detected.
+The parent node has usually the class runnable-examples.
+pre = element containing the code example
+*/
+function buildRunnableExampleLayout(pre) {
+    var parent = pre.parentNode;
+
+    // helper method to construct a button in vanilla JavaScript
+    function createButton(className, value) {
+        var btn = document.createElement("input");
+        btn.type = "button";
+        btn.className = className;
+        btn.value = value;
+        return btn;
+    }
+
+    // helper method to construct an overlay in vanilla JavaScript
+    // typically overlays are output, args, stdin and the editor instance
+    function createOverlay(className, title, type, value) {
+        var el = document.createElement("div");
+        el.className = className;
+        var titleEl = document.createElement("span");
+        titleEl.className = "d_code_title";
+        titleEl.innerText = title;
+        el.appendChild(titleEl);
+        el.appendChild(document.createElement("br"));
+        var inner = document.createElement(type);
+        inner.className = className;
+        inner.value = value;
+        el.appendChild(inner);
+        return el;
+    }
+
+    // check whether args has been defined (RUNNABLE_EXAMPLE_ARGS macro in Ddoc)
+    var args = findFirst(parent.children, function(e){ return e.className === "runnable-examples-args";});
+    if (typeof args !== "undefined") { args = args.innerText; }
+
+    // check whether stdin has been defined (RUNNABLE_EXAMPLE_STDIN macro in Ddoc)
+    var stdin = findFirst(parent.children, function(e){ return e.className === "runnable-examples-stdin";});
+    if (typeof stdin !== "undefined") { stdin = stdin.innerText; }
+
+    // wraps the <pre> code box in a <div> element
+    // this rewrapping is needed for the editor framework
+    var dCode = document.createElement("div");
+    dCode.className = "d_code";
+    dCode.append(pre);
+
+    // create the CodeMirror editor overlay
+    var el = document.createElement("div");
+    el.style.display = "block";
+    el.className = "d_run_code";
+    // code box (CodeMirror will be loaded into this element)
+    var dCodeText = document.createElement("textarea");
+    dCodeText.className = "d_code";
+    dCodeText.style.display = "none";
+    el.appendChild(dCodeText);
+
+    // create optional stdin overlay
+    if (stdin) { el.appendChild(createOverlay("d_code_stdin", "Input", "textarea", stdin)); }
+
+    // create optional args overlay
+    if (args) { el.appendChild(createOverlay("d_code_stdin", "Command line arguments", "textarea", args)); }
+
+    // create main output overlay
+    el.appendChild(createOverlay("d_code_output", "Application output", "pre", "Running..."));
+
+    // user interaction buttons
+    el.appendChild(createButton("editButton", "Edit"));
+    if (stdin) { el.appendChild(createButton("inputButton", "Input")); }
+    if (args) { el.appendChild(createButton("argsButton", "Args")); }
+    el.appendChild(createButton("runButton", "Run"));
+    el.appendChild(createButton("resetButton", "Reset"));
+
+    // replace the <pre> element with its enhanced wrapper div
+    var root = document.createElement("div");
+    root.appendChild(dCode);
+    root.appendChild(el);
+    parent.appendChild(root);
+    return root;
+}
+/**
+Searches any object for the first hit.
+Params:
+    el = object to filter
+    fn = function to be applied as filter
+Returns: first hit, `undefined` otherwise
+*/
+function findFirst(el, fn) {
+    return Array.prototype.filter.call(el, fn)[0];
+}
+
+(function() {
+// randomly pick one example and bootstrap the runnable editor
+var examples = document.getElementsByClassName('your-code-here-extra');
+var rouletteIndex = Math.floor(Math.random() * examples.length);
+var rouletteChild = examples[rouletteIndex];
+
+// step 1: select the .runnable-example <div>
+var rouletteChildNode = findFirst(rouletteChild.children, function(e) { return e.className.indexOf("runnable-example") != -1; });
+// step 2: select the first <pre> element (of the .runnable-example <div>)
+var el = findFirst(rouletteChildNode.children, function(e) { return e.nodeName == "PRE";});
+// step 3: Construct runnable example layout within the <pre> element
+buildRunnableExampleLayout(el);
+rouletteChild.style.display = "block";
+})();

--- a/js/run.js
+++ b/js/run.js
@@ -127,38 +127,11 @@ $(document).ready(function()
     {
         var root = $(this);
         var el = root.children("pre");
-        var stripedText = el.text().replace(/\s/gm,'');
-
-        var stdin = root.children(".runnable-examples-stdin").text();
-        var args = root.children(".runnable-examples-args").text();
-
-        // only show stdin or args if they are set
-        if (stdin.length > 0)
-        {
-            stdin = '<div class="d_code_stdin"><span class="d_code_title">Standard input</span><br>'
-                  + '<textarea class="d_code_stdin">'+stdin+'</textarea></div>';
+        // only build the example if this hasn't been done before
+        // (e.g. the front page examples are built before to avoid reflows)
+        if (el.length > 0) {
+          buildRunnableExampleLayout(el[0]);
         }
-        if (args.length > 0)
-        {
-            args = '<div class="d_code_args"><span class="d_code_title">Command line arguments</span><br>'
-                + '<textarea class="d_code_args">'+args+'</textarea></div>';
-        }
-
-        var currentExample = el;
-        var orig = currentExample.html();
-
-        currentExample.replaceWith(
-            '<div class="d_code"><pre class="d_code">'+orig+'</pre></div>'
-            + '<div class="d_run_code">'
-            + '<textarea class="d_code" style="display: none;"></textarea>'
-            + stdin + args
-            + '<div class="d_code_output"><span class="d_code_title">Application output</span><br><pre class="d_code_output" readonly>Running...</pre></div>'
-            + '<input type="button" class="editButton" value="Edit">'
-            + (args.length > 0 ? '<input type="button" class="argsButton" value="Args">' : '')
-            + (stdin.length > 0 ? '<input type="button" class="inputButton" value="Input">' : '')
-            + '<input type="button" class="runButton" value="Run">'
-            + '<input type="button" class="resetButton" value="Reset"></div>'
-        );
     });
 
     $('textarea[class=d_code]').each(function(index) {

--- a/posix.mak
+++ b/posix.mak
@@ -157,7 +157,7 @@ IMAGES=favicon.ico $(ORGS_USING_D) $(addprefix images/, \
 
 JAVASCRIPT=$(addsuffix .js, $(addprefix js/, \
 	codemirror-compressed dlang ddox listanchors platform-downloads run \
-	run_examples show_contributors jquery-1.7.2.min))
+	run_examples show_contributors jquery-1.7.2.min example_roulette))
 
 STYLES=$(addsuffix .css, $(addprefix css/, \
 	style print codemirror ddox))


### PR DESCRIPTION
As discussed [here](https://github.com/dlang/dlang.org/pull/1755#issuecomment-310029805), to avoid page reflows, we should pick an example ASAP and render its HTML.

Unfortunately this required quite a bit of work as the original code heavily used jQuery for which we don't want to wait until it's loaded. I am not really happy with it, but I guess that's the necessary evil if we want to avoid the ugly page redraws (and don't have a server to do the selection).

> I think it would be nice to have a drop down, like on the golang page. I remember back some time ago when I wanted to show one particular example to a friend that I had to reload the page a couple of times to get to it.

That was fairly trivial to add and requiring a title for an example and reduces the manual checking from @CyberShadow ;-)

The example selector still needs styling, hence I am marking this as "Needs work" for now.