### PR TITLE
Temporarily fix the example roulette

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -50,6 +50,7 @@ void main()
 }
 ----
 )
+)
 $(EXTRA_EXAMPLE
 $(RUNNABLE_EXAMPLE_STDIN 2.4 plus 2.4 equals 5 for sufficiently large values of 2.)
 ----
@@ -71,7 +72,6 @@ void main()
         .each!writeln;
 }
 ----
-)
 )
 $(EXTRA_EXAMPLE
 $(RUNNABLE_EXAMPLE_STDIN

--- a/js/dlang.js
+++ b/js/dlang.js
@@ -59,11 +59,11 @@
         });
 
         // [your code here] rotation for index.html
-        var $examples = $('.your-code-here-extra > pre');
+        var $examples = $('.your-code-here-extra .d_code');
         if ($examples.length) {
             var n = Math.floor(Math.random() * ($examples.length+1));
             if (n)
-                $('#your-code-here-default > pre').replaceWith($examples[n-1]);
+                $('#your-code-here-default .d_code').replaceWith($examples[n-1]);
         }
 
         // Insert the show/hide button if the contents section exists


### PR DESCRIPTION
From https://github.com/dlang/dlang.org/pull/1757#issuecomment-310889979

> OK, so, as I understand, this PR does three things right now:
> Fix the JS roulette
> IMO these should be separate PRs, or at least commits

Well #1757 removes this bit completely (hence no separate commit), but as the discussion seems to take a bit longer, there's no reason why we couldn't fix the roulette in the meantime.