### PR TITLE
Remove duplicate css rule

### DIFF
--- a/changelog/changelog.ddoc
+++ b/changelog/changelog.ddoc
@@ -63,7 +63,7 @@ DRUNTIMEPR = $(PULL_REQUEST druntime,$1)
 PHOBOSPR = $(PULL_REQUEST phobos,$1)
 _=
 
-CHANGELOG_VERSION = $(LI <a id="$1" href="$1.html">$1</a><span class="hide-from-nav"> ($2, $3)</span>)
+CHANGELOG_VERSION = $(LI <a id="$1" href="$1.html">$1</a><span class="subnav-duplicate"> ($2, $3)</span>)
 _=BEGIN_GENERATED_CHANGELOG_VERSIONS
 CHANGELOG_VERSIONS =
     $(CHANGELOG_VERSION 2.074.1, May 30, 2017)

--- a/css/style.css
+++ b/css/style.css
@@ -454,11 +454,6 @@ in the narrow layouts without JS. */
     text-decoration: underline;
 }
 
-.subnav .hide-from-nav
-{
-    display: none;
-}
-
 /* hierarchy tree lines */
 
 body.std .subnav ul ul ul


### PR DESCRIPTION
There's was an existing one defined as:

```css
.subnav .subnav-duplicate
{
    display: none;
}
```