### PR TITLE
fix clone targets

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -381,10 +381,10 @@ dlangspec.verbatim.txt : $(DMD) verbatim.ddoc dlangspec-consolidated.d
 # Git rules
 ################################################################################
 
-$(PWD)/%-${LATEST} :
+../%-${LATEST} :
 	git clone -b v${LATEST} --depth=1 ${GIT_HOME}/$(notdir $*) $@
 
-$(PWD)/%-${DUB_VER} :
+../%-${DUB_VER} :
 	git clone --depth=1 -b v${DUB_VER} ${GIT_HOME}/$(notdir $*) $@
 
 ${DMD_DIR} ${DRUNTIME_DIR} ${PHOBOS_DIR} ${TOOLS_DIR} ${INSTALLER_DIR}:


### PR DESCRIPTION
- broken by 4129e45951 which changed target folders from
  ../druntime-2.074.1 to $PWD/druntime-2.074.1
- no need to make those targets absolute since the makefile will
  always run in the dlang.org root folder