### PR TITLE
Fix the changelog for the Fiber's guard page.

### DIFF
--- a/changelog/2.075.0_pre.dd
+++ b/changelog/2.075.0_pre.dd
@@ -165,9 +165,7 @@ The feature already existing for Windows' fiber implementation is now added to
 the systems using mmap to allocate fibers' stacks: After (or before) the last
 page used for the Fiber's stack, the page is allocate which is protected for
 any kind of access. This will cause system to trap immediately on the fiber's
-stack overflow. If in debugger session, one can inspect contents of the memory
-before or after stack pointer and it can be seen if it contains END OF FIBER
-string pattern.
+stack overflow.
 )
 )
 


### PR DESCRIPTION
During the review of GitHub dlang/druntime#1698, the "END OF FIBER" marker data
was removed to avoid dirtying the guard page. Hence, the corresponding
comment in the release notes doesn't apply anymore.

See dlang/druntime#1821