### PR TITLE
Add compatibility index for modules

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2243,3 +2243,27 @@ dt.d_decl:hover .decl_anchor {
         text-align: right;
     }
 }
+
+
+/**
+ * Messages boxes.
+ */
+.message-box {
+    padding: 1em 1em 1em 1em;
+    border-radius: 5px;
+}
+.message-box, .message-box a {
+    color: white;
+}
+.message-box-red {
+    background-color: #D60027;
+}
+.message-box-gray {
+    background-color: #797979;
+}
+.message-box-orange {
+    background-color:  #EC5315;
+}
+.message-box-green {
+    background-color: #4EBA0F;
+}

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -39,6 +39,13 @@ COMMON_SCRIPTS_DLANG =
     $(SCRIPTLOAD $(STATIC js/run.js))
 _=
 
+COMPATIBILITY_BOX_DEPRECATED = $(MESSAGE_BOX red, $(B Deprecated) - $0)
+COMPATIBILITY_BOX_SUPERSEDED = $(MESSAGE_BOX gray, $(B Obsolete) - $0)
+COMPATIBILITY_BOX_OBSOLETE = $(MESSAGE_BOX gray, $(B Obsolete) - $0)
+COMPATIBILITY_BOX_OUTDATED = $(MESSAGE_BOX gray, $(B Obsolete) - $0)
+COMPATIBILITY_BOX_EXPERIMENTAL = $(MESSAGE_BOX orange, $(B Experimental) - $0)
+_=
+
 CONSOLE=$(TC pre, console notranslate, $0)
 COPYRIGHT_FOUNDATION=Copyright &copy; 1999-$(YEAR) by the $(LINK2 $(ROOT_DIR)foundation.html, D Language Foundation)
 CPPCODE=$(TC pre, cppcode notranslate, $0)
@@ -205,6 +212,7 @@ MENU = <li><a href='$1'><span>$+</span></a></li>
 MENU_W_SUBMENU = <li class='expand-container'><a class='expand-toggle' href='#'><span>$0</span></a>
 MENU_W_SUBMENU_LINK = <li class='expand-container'><a class='expand-toggle' href='$1'><span>$+</span></a>
 MENU_W_SUBMENU_END = </li>
+MESSAGE_BOX = $(DIVC message-box message-box-$1, $+)
 META_KEYWORDS=D programming language
 META_DESCRIPTION=D Programming Language
 MODDEFFILE=$(TC pre, moddeffile notranslate, $0)


### PR DESCRIPTION
After [my intent](https://github.com/dlang/phobos/pull/5488) to move outdated modules to undeaD failed, here's [the suggested way](https://github.com/dlang/phobos/pull/5488#issuecomment-309288716) of documenting old modules.

> Great, I think starting with documentation should be the official way of implementing all deprecations.

tl;dr: This generalizes the deprecation warnings (and makes them look nicer than for [std.xml](https://dlang.org/phobos/std_xml.html)).

[As suggested](https://github.com/dlang/phobos/pull/5488#issuecomment-309288716) this is heavily inspired by the way NodeJS [marks their modules](https://nodejs.org/api/assert.html), but why not learn from successful ideas?

The overview page:

![image](https://user-images.githubusercontent.com/4370550/27651099-6c742e10-5c37-11e7-8a74-54f099f05081.png)

In practice:

Deprecated
---------------

```
$(COMPATIBILITY_BOX_0)
```

![image](https://user-images.githubusercontent.com/4370550/27651161-94a8d08e-5c37-11e7-91c2-0af4ecc88d42.png)

Experimental
-----------------

```
$(COMPATIBILITY_BOX_1)
```

![image](https://user-images.githubusercontent.com/4370550/27651181-a9693c66-5c37-11e7-9b9e-faccd316c924.png)


Stable
---------

```
$(COMPATIBILITY_BOX_2)
```

![image](https://user-images.githubusercontent.com/4370550/27651192-b86e3fae-5c37-11e7-9e68-acccd2cdf951.png)

And all in one:
-------------------

![image](https://user-images.githubusercontent.com/4370550/27651118-7ea0479a-5c37-11e7-9677-30b63c7c9e99.png)

CC @MartinNowak @CyberShadow @andralex @JackStouffer 