### PR TITLE
Hide the resetButton by default for Phobos examples

### DIFF
--- a/js/run_examples.js
+++ b/js/run_examples.js
@@ -80,7 +80,7 @@ $(document).ready(function()
                     + '<div class="d_example_buttons">'
           + '<div class="editButton"><i class="fa fa-edit" aria-hidden="true"></i> Edit</div>'
           + '<div class="runButton"><i class="fa fa-play" aria-hidden="true"></i> Run</div>'
-          + '<div class="resetButton"><i class="fa fa-undo " aria-hidden="true"></i> Reset</div>'
+          + '<div class="resetButton" style="display:none"><i class="fa fa-undo " aria-hidden="true"></i> Reset</div>'
           + '<div class="openInEditorButton" title="Open in an external editor"><i class="fa fa-external-link" aria-hidden="true"></i></div>'
                     + '</div>'
                     + '<div class="d_code_output"><span class="d_code_title">Application output</span><br><pre class="d_code_output" readonly>Running...</pre>'


### PR DESCRIPTION
> BTW, I noticed something a little weird - the "Reset" button is visible by default, but it goes away after you click it once.

If all PRs could be as simple as this one ;-)