### PR TITLE
adjust .pitch's width to avoid excessive hyphenation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1372,7 +1372,7 @@ body#Home #content > .intro .pitch
     font-size: large;
     font-weight: 300;
     margin: auto;
-    width: 21em;
+    width: 22em;
 }
 
 body#Home #content > .intro .download
@@ -1975,7 +1975,7 @@ the home page, intro pitch and your-code-here layed out vertically */
 
     body#Home #content > .intro .pitch
     {
-        max-width: 21em;
+        max-width: 22em;
         width: auto;
     }
 


### PR DESCRIPTION
Followup to #1765.

I don't know if it looks like this for everyone, but for me (Firefox, Ubuntu) the new text doesn't break nicely. Luckily, adding just 1em fixes it, and the box still fits in the layout.

Before/after:
![spectacle c11827](https://user-images.githubusercontent.com/9287500/27715766-baf45210-5d39-11e7-8d5d-5997118db214.png)
