### PR TITLE
Add attributes ordering to the DStyle

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -342,6 +342,9 @@ $(LISTSECTION Attributes,
          matching attributes (`@nogc`, `@safe`, `pure`, `nothrow`).)
     $(LI $(I Templated) functions should $(B not) be annotated with attributes
          as the compiler can infer them.)
+    $(LI Attributes should be listed in alphabetical ordering, e.g. `const @nogc nothrow pure @safe`
+        (the ordering should ignore the leading `@`).
+    )
     $(LI $(B Every) $(I unittest) should be annotated
          (e.g. `pure nothrow @nogc @safe unittest { ... }`)
          to ensure the existence of attributes on the templated function.)


### PR DESCRIPTION
As discussed in https://github.com/dlang/phobos/pull/5529#issuecomment-312391460

>> FWIW at some point we might want to agree on an idiomatic ordering on the attributes 
> Alpha