### PR TITLE
Use full width for examples selector on mobile devices

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2173,6 +2173,10 @@ the home page, intro pitch and your-code-here layed out vertically */
     body#Home #content > .intro #your-code-here .tip {
         display: none;
     }
+
+    #your-code-here-select-example select {
+        width: 100%;
+    }
 }
 
 .decl_anchor {


### PR DESCRIPTION
Bigger viewpoint:
-----------------------

- the tip is still visible

![image](https://user-images.githubusercontent.com/4370550/27766287-bde1951c-5ecb-11e7-862a-e7b4f1b9c9fa.png)

Once the tip isn't visible anymore, use full width:
----------------------------------------------------------------

![image](https://user-images.githubusercontent.com/4370550/27766291-d9d094b2-5ecb-11e7-868f-4448cffde9bd.png)


Currently:

![image](https://user-images.githubusercontent.com/4370550/27766298-e84d48e6-5ecb-11e7-969b-ab734e1f1afa.png)


Smaller viewport
-----------------------

![image](https://user-images.githubusercontent.com/4370550/27766306-0b41faea-5ecc-11e7-8811-3c9588f46582.png)


Currently:


![image](https://user-images.githubusercontent.com/4370550/27766301-fbbf951e-5ecb-11e7-887f-368ecdb965b0.png)
