### PR TITLE
Remove image tags from the generated PDF spec

### DIFF
--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -20,7 +20,7 @@ $(SPEC_S Contract Programming,
 	$(LI handling of contract inheritance)
 	)
 
-<img src="../images/d4.gif" style="max-width:100%" alt="Contracts make D bug resistant" border="0">
+$(HTMLTAG3V img, src="../images/d4.gif" style="max-width:100%" alt="Contracts make D bug resistant" border="0")
 
 	$(P The idea of a contract is simple - it's just an expression that must evaluate to true.
 	If it does not, the contract is broken, and by definition, the program has a bug in it.


### PR DESCRIPTION
Saw this by accident:

![image](https://user-images.githubusercontent.com/4370550/27774393-c33bd9d4-5f91-11e7-8423-4dbfb87c78f6.png)

In general, the PDF spec has rotten quite a bit and is in serious need of cleanup.