### PR TITLE
Fix TABLE_10 macro

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -463,11 +463,11 @@ $(SUBNAV_TEMPLATE
 )
 _=
 
-TABLE_10=$(TABLE2 $1,$+)
+TABLE_10=$(TABLE2 $1, $+)
 TABLE_2COLS=$(TABLE2 $1, $+)
 TABLE_3COLS=$(TABLE2 $1, $+)
 TABLE_SPECIAL=$(TABLE2 $1,$+)
-TABLE2=$(T center, $(T table, $(T caption, $1)$+))
+TABLE2=$(T center, $(T table, $(T caption, $1)$(CONCAT $+)))
 TDX=$(TD $1)$(TDX $+)
 TH=<th scope="col">$0</th>
 THEAD=$(TR $(THX $1, $+))

--- a/macros.ddoc
+++ b/macros.ddoc
@@ -1,6 +1,7 @@
 _=Fundamental macros that apply to all generated formats
 
 ARGS = $0
+CONCAT = $1$(CONCAT $+)
 COMMA = ,
 COMMENT =
 DOLLAR = $

--- a/spec/const3.dd
+++ b/spec/const3.dd
@@ -459,7 +459,7 @@ other qualifier combinations than the ones shown is valid. The same information
 is shown below in tabular format:)
 
     $(TABLE_10 $(ARGS Implicit Conversion of Reference Types),
-    $(VERTROW from/to, $(I mutable), $(D const), $(D shared), $(D const shared), $(D inout), $(D const inout), $(D inout shared), $(D const inout shared), $(D immutable))
+    $(VERTROW from/to, $(I mutable), $(D const), $(D shared), $(D const shared), $(D inout), $(D const inout), $(D inout shared), $(D const inout shared), $(D immutable)),
     $(TROW $(I mutable),            $(YES), $(YES), $(NO),  $(NO),  $(NO),  $(NO),  $(NO),  $(NO),  $(NO) )
     $(TROW $(D const),              $(NO),  $(YES), $(NO),  $(NO),  $(NO),  $(NO),  $(NO),  $(NO),  $(NO) )
     $(TROW $(D const inout),        $(NO),  $(YES), $(NO),  $(NO),  $(NO),  $(YES), $(NO),  $(NO),  $(NO) )


### PR DESCRIPTION
I noticed a spurious comma at the top of the table in section http://dlang.org/spec/const3.html#implicit_qualifier_conversions. At first I thought it's a trivial oversight so I pushed https://github.com/dlang/dlang.org/commit/432b8dc44a20d12dbb4b512f65e4cf8788ab97da directly. But then I realized LaTeX does need separate arguments for the header and the body. This pull requests solves the problem the right way by defining and using a CONCAT macro that glues all of its arguments together.