### PR TITLE
Only use DPaste as backend if absolutely necessary (example as STDIN or ARGS)

### DIFF
--- a/js/run.js
+++ b/js/run.js
@@ -209,8 +209,10 @@ $(document).ready(function()
     $('textarea[class=d_code]').each(function(index) {
         var parent = $(this).parent();
         var outputDiv = parent.children("div.d_code_output");
+        var hasStdin = parent.children(".inputButton").length > 0;
+        var hasArgs  = parent.children(".argsButton").length > 0;
         setupTextarea(this, {parent: parent, outputDiv: outputDiv,
-                        stdin: true, args: true});
+                        stdin: hasStdin, args: hasArgs});
     });
 });
 
@@ -224,7 +226,12 @@ function setupTextarea(el, opts)
         transformOutput: function(out) { return out }
     }, opts);
 
-    var backend = backends[opts.backend || "dpaste"];
+    var backend = backends[opts.backend || "tour"];
+    // only use DPaste if absolutely necessary (stdin or args provided)
+    // DPaste is very restrictive compared to the Dockerized DLang Tour backend
+    if (opts.args || opts.stdin) {
+      backend = backends.dpaste;
+    }
 
     if (!!opts.parent)
         var parent = opts.parent;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4370550/27864941-e4ec0292-6190-11e7-9dbc-1a6b0030e27c.png)

I didn't account for the fact that DPaste would throw errors with the new invocation example.
Let's use the DTour then whenever possible.

The tour works fine: https://is.gd/DTFINJ

For reference STDIN/ARGS support for the tour is already in the queue: https://github.com/dlang-tour/core-rdmd/pull/9