### PR TITLE
Add a version chooser to DDoc pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1770,7 +1770,7 @@ div.openInEditorButton {
 #your-code-here-select-example {
     padding-bottom: 0.3em;
 }
-#your-code-here-select-example select {
+.fa-select select {
     background: white;
     border: 1px solid #CCC;
     border-radius: 4px;
@@ -1780,6 +1780,11 @@ div.openInEditorButton {
     -moz-appearance: none;
     appearance: none;
     max-width: 100%;
+}
+.fa-select::after {
+   font-family: FontAwesome;
+   content: "\f0d7";
+   margin-left: -15px;
 }
 /* Runnable-examples css -end */
 

--- a/css/style.css
+++ b/css/style.css
@@ -2226,3 +2226,19 @@ dt.d_decl:hover .decl_anchor {
     text-decoration: none;
     color: #333;
 }
+
+/**
+ * Version select box
+ */
+.version-changer-container {
+    float: right;
+    margin-top: -4em;
+}
+@media only screen and (max-width:40em)
+{
+    .version-changer-container {
+        margin-top: -2em;
+        float: none;
+        text-align: right;
+    }
+}

--- a/index.dd
+++ b/index.dd
@@ -20,7 +20,7 @@ $(DIVC intro, $(DIV, $(DIV,
         )
     )
     $(DIVID your-code-here,
-        $(DIVID your-code-here-select-example)
+        $(DIVCID fa-select, your-code-here-select-example,)
         $(DIVC tip,
             $(LINK2 https://forum.dlang.org/newpost/general?subject=%5Byour+code+here%5D, your code here)
             $(DIV,
@@ -159,10 +159,6 @@ $(SCRIPT
     });
     var selEl = document.getElementById("your-code-here-select-example");
     selEl.appendChild(sel);
-    var caret = document.createElement("i");
-    caret.className = "fa fa-caret-down";
-    caret.style.marginLeft = "-15px";
-    selEl.appendChild(caret);
     })();
 )
 

--- a/js/listanchors.js
+++ b/js/listanchors.js
@@ -88,6 +88,69 @@ function listanchors()
         id += key;
         var e = document.getElementById(id);
         e.innerHTML = newText;
+
+    }
+    function addVersionSelector() {
+      // Latest version offered by the archive builds
+      // This needs to be manually updated after new versions have been archived
+      var currentArchivedVersion = 74;
+      // build URLs for dlang.org: DDoc + Dox
+      var ddocModuleURL = document.body.id.replace(/[.]/g, "_") + ".html";
+      var ddoxModuleURL = document.body.id.replace(/[.]/g, "/") + ".html";
+
+      // build list of versions available in the docarchives
+      var archivedVersions = [];
+      while (currentArchivedVersion >= 66) {
+        archivedVersions.push("2.0" + currentArchivedVersion--);
+      }
+      archivedVersions = archivedVersions.map(function(e) {
+          return {
+            name: e,
+            url: "https://docarchives.dlang.io/v" + e + ".0/phobos/" + ddocModuleURL,
+            selected: false,
+          };
+      });
+
+      var rootURL = location.href.split(/\/(phobos|library)(-prerelease)?/)[0]
+      var onlineVersions = [{
+        name: "master",
+        url: rootURL + "/phobos-prerelease/" + ddocModuleURL,
+      },{
+        name: "master (ddox)",
+        url: rootURL + "/library-prerelease/" + ddoxModuleURL,
+      },{
+        name: "stable",
+        url: rootURL + "/phobos/" + ddocModuleURL,
+      },{
+        name: "stable (ddox)",
+        url: rootURL + "/library/" + ddoxModuleURL,
+      }];
+
+      // set the current URL as selected
+      var currentURL = location.href.split(/[#?]/)[0];
+      onlineVersions.forEach(function(v, i) {
+        onlineVersions[i].selected = v.url === currentURL;
+      });
+      // Don't show the option chooser if the page hasn't been recognized
+      // For example, Ddox symbol pages are currently not supported
+      if (onlineVersions.filter(function(v){return v.selected}).length === 0)
+        return;
+
+      // build select box of all versions and append to current DOM
+      var versions = onlineVersions.concat(archivedVersions);
+      var options = versions.map(function(e, i){
+        return "<option value='" + i + "'" + (e.selected ? "selected" : "") + ">" + e.name + "</option>";
+      });
+      $("h1").after("<div class='version-changer-container fa-select'><select id='version-changer'>" + options.join("") + "</select></div>");
+      // attach event listener to select box -> change URL
+      $("#version-changer").change(function(){
+        var selected = parseInt($(this).find("option:selected").val());
+        var option = versions[selected];
+        if (!option.selected) {
+          window.location.href = option.url;
+        }
+      });
     }
     addAnchors();
+    addVersionSelector();
 }

--- a/std_navbar-prerelease.ddoc
+++ b/std_navbar-prerelease.ddoc
@@ -3,8 +3,6 @@ $(SUBNAV_TEMPLATE
     $(DIVC head,
         $(H2 Library Reference)
         $(P $(SPANC smallprint, pre-release version $(SPANC separator, $(BR))
-            switch to $(LINK2 ../phobos/index.html, $(LATEST)). $(BR)
-            $(LINK2 ../library-prerelease/index.html, preview) beta library reference.
             )
         )
         $(P $(LINK2 index.html, overview))

--- a/std_navbar-release.ddoc
+++ b/std_navbar-release.ddoc
@@ -3,9 +3,6 @@ $(SUBNAV_TEMPLATE
     $(DIVC head,
         $(H2 Library Reference)
         $(P $(SPANC smallprint, version $(LATEST) $(SPANC separator, $(BR))
-            switch to
-            $(LINK2 ../phobos-prerelease/index.html, pre-release). $(BR)
-            $(LINK2 ../library/index.html, preview) beta library reference.
             )
         )
         $(P $(LINK2 index.html, overview))


### PR DESCRIPTION
From the [NG](http://forum.dlang.org/post/niuatqnkrygvunacwjti@forum.dlang.org):

> IMO there should be a link under the "switch to pre-release." link in the current docs.
> Maybe replace it with a dropdown to select the version from 2.066 to pre-release?

CC @JackStouffer @CyberShadow 


![image](https://user-images.githubusercontent.com/4370550/27890522-7750bf26-61f3-11e7-936c-997f7abc09fc.png)

![image](https://user-images.githubusercontent.com/4370550/27890526-7e9a85be-61f3-11e7-90ec-12eefaf43410.png)

![image](https://user-images.githubusercontent.com/4370550/27890567-c14d5044-61f3-11e7-9da7-84436d490d60.png)

It's not perfect yet (e.g. I need to detect the current version automatically and add the same for the Ddox build), but I wanted to get your opinion on this before I invest more work.