### PR TITLE
fix border-radius for "Why D?" boxes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1458,7 +1458,8 @@ body#Home .whyd .section > div
 {
     border: 1px solid #E6E6E6;
     border-left: none;
-    border-radius: 4px;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
     padding: 1.5em;
 }
 body#Home .whyd .section > div > *:first-child


### PR DESCRIPTION
Just noticed this little defect. I guess it has been like this from the start. Wasn't meant that way.

Before/after (zoomed in):
![spectacle n12854](https://user-images.githubusercontent.com/9287500/27924342-39fc17ae-6281-11e7-9000-bc6d1fd9525b.png)
