### PR TITLE
Use dmd-nightly for prerelease docs

### DIFF
--- a/js/run.js
+++ b/js/run.js
@@ -66,6 +66,9 @@ function safeVar(data, path)
     return res;
 }
 
+// compile the examples on the prerelease pages with dmd-nightly
+var dmdCompilerBranch = location.href.indexOf("-prerelease/") >= 0 ? "dmd-nightly" : "dmd";
+
 var backends = {
   dpaste: {
     url: "https://dpaste.dzfl.pl/request/",
@@ -97,7 +100,8 @@ var backends = {
     contentType: "text/plain; charset=UTF-8",
     requestTransform: function(data) {
         return JSON.stringify({
-            source: data.code
+            source: data.code,
+            compiler: dmdCompilerBranch
         });
     },
     parseOutput: function(data, opts) {
@@ -414,7 +418,7 @@ function setupTextarea(el, opts)
         });
     });
     openInEditorBtn.click(function(){
-      var url = "https://run.dlang.io?source=" + encodeURIComponent(opts.transformOutput(editor.getValue()));
+      var url = "https://run.dlang.io?compiler=" + dmdCompilerBranch + "&source=" + encodeURIComponent(opts.transformOutput(editor.getValue()));
       window.open(url, "_blank");
     });
     return editor;


### PR DESCRIPTION
The DTour now allows to select the compiler (e.g. https://github.com/dlang-tour/core/pull/575, https://github.com/dlang-tour/core/pull/574, https://github.com/dlang-tour/core/issues/548).

This means that we can use `dmd-nightly` for the prerelease pages, e.g.

![image](https://user-images.githubusercontent.com/4370550/27966290-07b9b6c0-633f-11e7-8f6e-8c5d8718f6ac.png)

Details:
- The Docker images are built & updated daily
- There weren't many new symbols in Phobos since 2.074.0, but one is in `std.digest.crc`