### PR TITLE
[Hotfix] - Fix DBlog regex

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -393,7 +393,7 @@ dlangspec.verbatim.txt : $(DMD) verbatim.ddoc dlangspec-consolidated.d
 $G/dblog_latest.ddoc:
 	@echo "Receiving the latest DBlog article. Disable with DIFFABLE=1"
 	curl -s --retry 3 --retry-delay 5 http://blog.dlang.org | grep -m1 'entry-title' | \
-		sed -E 's/^.*<a href="(.+)" rel="bookmark">([^<]+)<\/a>.*<time class="updated" datetime="[^"]+">([^<]*)<\/time>.*Author *<\/span><a [^>]+>([^<]+)<\/a>.*/DBLOG_LATEST_TITLE=\2|DBLOG_LATEST_LINK=\1|DBLOG_LATEST_DATE=\3|DBLOG_LATEST_AUTHOR=\4/' | \
+		sed -E 's/^.*<a href="(.+)" rel="bookmark">([^<]+)<\/a>.*<time.*datetime="[^"]+">([^<]*)<\/time>.*Author *<\/span><a [^>]+>([^<]+)<\/a>.*/DBLOG_LATEST_TITLE=\2|DBLOG_LATEST_LINK=\1|DBLOG_LATEST_DATE=\3|DBLOG_LATEST_AUTHOR=\4/' | \
 		tr '|' '\n' > $@
 
 $G/twid_latest.ddoc:


### PR DESCRIPTION
Noticed that our frontpage got broken:

![image](https://user-images.githubusercontent.com/4370550/27967274-b7efa218-6342-11e7-822a-d6bd885a115c.png)


This will make the regex more error-tolerant - apparently the last time the article got edited and I wrongly made this part of the regex.

I will directly merge this as a hotfix frontpage. We can always talk later about better approaches.