### PR TITLE
add D_AVX and D_AVX2 to version identifier docs

### DIFF
--- a/spec/version.dd
+++ b/spec/version.dd
@@ -314,6 +314,8 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
 	$(TROW $(ARGS $(D D_PIC)) , $(ARGS Position Independent Code
 		(command line switch $(DDSUBLINK dmd-linux, switch-fPIC, $(TT -fPIC))) is being generated))
 	$(TROW $(ARGS $(D D_SIMD)) , $(ARGS $(DDLINK spec/simd, simd, Vector extensions) (via $(D __simd)) are supported))
+	$(TROW $(ARGS $(D D_AVX)) , $(ARGS AVX Vector instructions are supported))
+	$(TROW $(ARGS $(D D_AVX2)) , $(ARGS AVX2 Vector instructions are supported))
 	$(TROW $(ARGS $(D D_Version2)) , $(ARGS This is a D version 2 compiler))
 	$(TROW $(ARGS $(D D_NoBoundsChecks)) , $(ARGS Array bounds checks are disabled
 		(command line switch $(DDSUBLINK dmd, switch-boundscheck, $(TT -boundscheck=off)))))
@@ -586,4 +588,3 @@ $(SPEC_SUBNAV_PREV_NEXT contracts, Contract Programming, traits, Traits)
 
 Macros:
 	TITLE=Conditional Compilation
-


### PR DESCRIPTION
also see https://github.com/dlang/dmd/pull/6977

Arguably the D_ prefix doesn't make much sense here, but that's how it was done for D_AVX and there is little point in changing that.