### PR TITLE
Make the CT frontpage example runnable again

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -94,7 +94,7 @@ void main()
 }
 ----
 )
-$(EXTRA_EXAMPLE Sort an Array at Compile-Time,
+$(EXTRA_EXAMPLE_RUNNABLE Sort an Array at Compile-Time,
 ----
 void main()
 {


### PR DESCRIPTION
In https://github.com/dlang/dlang.org/pull/1763 `EXTRA_EXAMPLE` aren't runnable by default, but instead `EXTRA_EXAMPLE_RUNNABLE` are.
https://github.com/dlang/dlang.org/pull/1763 forgot to update the new CT sort example after a rebase.