### PR TITLE
Use _pending for the latest changelog entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ modlist-release.ddoc
 /assert_writeln_magic
 
 # Generated changelogs
-changelog/*_pre.dd
+changelog/*_pending.dd

--- a/changelog/changelog.ddoc
+++ b/changelog/changelog.ddoc
@@ -63,10 +63,12 @@ PHOBOSPR = $(PULL_REQUEST phobos,$1)
 _=
 
 CHANGELOG_VERSION = $(LI <a id="$1" href="$1.html">$1</a><span class="hide-from-nav"> ($2, $3)</span>)
-CHANGELOG_VERSION_PRE = $(LI <a id="$1" href="$1_pre.html">$1</a><span class="hide-from-nav"> ($+)</span>)
+CHANGELOG_VERSION_PRE = $(LI <a id="$1_pre" href="$1_pre.html">$1</a><span class="hide-from-nav"> ($+)</span>)
+CHANGELOG_VERSION_PENDING = $(LI <a id="$1_pending" href="$1_pending.html">Nightlies</a><span class="hide-from-nav"> ($+)</span>)
 _=BEGIN_GENERATED_CHANGELOG_VERSIONS
 CHANGELOG_VERSIONS =
-    $(CHANGELOG_VERSION_PRE 2.075.0, not yet released)
+    $(CHANGELOG_VERSION_PENDING 2.075.0, not yet released)
+    $(CHANGELOG_VERSION_PRE 2.075.0, to be released)
     $(CHANGELOG_VERSION 2.074.1, May 30, 2017)
     $(CHANGELOG_VERSION 2.074.0, Apr 10, 2017)
     $(CHANGELOG_VERSION 2.073.2, Mar 09, 2017)

--- a/changelog/update_nav.sh
+++ b/changelog/update_nav.sh
@@ -25,6 +25,8 @@ done
 for ver in "${all_vers[@]}"; do
     if [[ "$ver" = *_pre.dd ]]; then
         sed -i "s|VER=[0-9\.][0-9\.]*|VER=${ver%_pre.dd}|" "$ver"
+    elif [[ "$ver" = *_pending.dd ]]; then
+        sed -i "s|VER=[0-9\.][0-9\.]*|VER=${ver%_pending.dd}|" "$ver"
     else
         sed -i "s|VER=[0-9\.][0-9\.]*|VER=${ver%.dd}|" "$ver"
     fi
@@ -35,14 +37,18 @@ IFS=$'\n'
 rev_all_vers=($(sort --reverse <<<"${all_vers[*]}"))
 rev_rel_vers=($(sort --reverse <<<"${rel_vers[*]}"))
 rev_pre_vers=($(ls -- *_pre.dd | sort --reverse))
+rev_pending_vers=($(ls -- *_pending.dd | sort --reverse))
 unset IFS
 
 # update index of all changlogs
 sed -i '/BEGIN_GENERATED_CHANGELOG_VERSIONS/,/END_GENERATED_CHANGELOG_VERSIONS/d' changelog.ddoc
 echo '_=BEGIN_GENERATED_CHANGELOG_VERSIONS' >> changelog.ddoc
 echo 'CHANGELOG_VERSIONS =' >> changelog.ddoc
+for ver in "${rev_pending_vers[@]}"; do
+    echo "    \$(CHANGELOG_VERSION_PENDING ${ver%_pending.dd}, not yet released)" >> changelog.ddoc
+done
 for ver in "${rev_pre_vers[@]}"; do
-    echo "    \$(CHANGELOG_VERSION_PRE ${ver%_pre.dd}, not yet released)" >> changelog.ddoc
+    echo "    \$(CHANGELOG_VERSION_PRE ${ver%_pre.dd}, to be released)" >> changelog.ddoc
 done
 for ver in "${rev_rel_vers[@]}"; do
     echo "    \$(CHANGELOG_VERSION ${ver%.dd})" >> changelog.ddoc

--- a/posix.mak
+++ b/posix.mak
@@ -198,8 +198,8 @@ SPEC_ROOT=$(addprefix spec/, \
 	abi simd)
 SPEC_DD=$(addsuffix .dd,$(SPEC_ROOT))
 
-CHANGELOG_FILES=changelog/${NEXT_VERSION}_pre \
-				$(basename $(subst _pre.dd,.dd,$(wildcard changelog/*.dd))) \
+CHANGELOG_FILES=changelog/${NEXT_VERSION}_pending \
+				$(basename $(wildcard changelog/*.dd))
 
 # Website root filenames. They have extension .dd in the source
 # and .html in the generated HTML. Save for the expansion of
@@ -654,15 +654,15 @@ test: $(ASSERT_WRITELN_BIN)_test all
 # Changelog generation
 ################################################################################
 
-changelog/${NEXT_VERSION}_pre.dd: | ${STABLE_DMD} ../tools ../installer
+changelog/${NEXT_VERSION}_pending.dd: | ${STABLE_DMD} ../tools ../installer
 	$(STABLE_RDMD) $(TOOLS_DIR)/changed.d $(CHANGELOG_VERSION_MASTER) -o $@ \
-	--version "${NEXT_VERSION} (upcoming)" --date "To be released" --nightly
+	--version "${NEXT_VERSION} (pending)" --date "Pending" --nightly
 
-changelog/${NEXT_VERSION}.dd: | ${STABLE_DMD} ../tools ../installer
+changelog/${NEXT_VERSION}_pre.dd: | ${STABLE_DMD} ../tools ../installer
 	$(STABLE_RDMD) $(TOOLS_DIR)/changed.d $(CHANGELOG_VERSION_STABLE) -o $@ \
 		--version "${NEXT_VERSION}"
 
-pending_changelog: changelog/${NEXT_VERSION}.dd html
-	@echo "Please open file:///$(shell pwd)/web/changelog/${NEXT_VERSION}_pre.html in your browser"
+pending_changelog: changelog/${NEXT_VERSION}_pending.dd html
+	@echo "Please open file:///$(shell pwd)/web/changelog/${NEXT_VERSION}_pending.html in your browser"
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)


### PR DESCRIPTION
Regarding https://github.com/dlang/dlang.org/pull/1814#issuecomment-313988447

A simple solution is to use `_pending` for the automatically generated changelog. (@MartinNowak) doesn't seem to use the Makefile target here anyways.

Regarding the changelog menu: I wasn't really sure how we should handle the case when a prerelease is progress, so I simply renamed them "Nightlies" as this actually is exactly what the page depicts.

CC @CyberShadow 