### PR TITLE
Add MSP430, D_P16 version identifiers documentation

### DIFF
--- a/spec/version.dd
+++ b/spec/version.dd
@@ -279,6 +279,7 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
 	$(TROW $(ARGS $(D MIPS_EABI)) , $(ARGS The MIPS EABI))
 	$(TROW $(ARGS $(D MIPS_SoftFloat)) , $(ARGS The MIPS $(D soft-float) ABI))
 	$(TROW $(ARGS $(D MIPS_HardFloat)) , $(ARGS The MIPS $(D hard-float) ABI))
+	$(TROW $(ARGS $(D MSP430)) , $(ARGS The MSP430 architecture (including the MSP430X variants)))
 	$(TROW $(ARGS $(D NVPTX)) , $(ARGS The Nvidia Parallel Thread Execution (PTX) architecture, 32-bit))
 	$(TROW $(ARGS $(D NVPTX64)) , $(ARGS The Nvidia Parallel Thread Execution (PTX) architecture, 64-bit))
 	$(TROW $(ARGS $(D RISCV32)) , $(ARGS The RISC-V architecture, 32-bit))
@@ -308,7 +309,8 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
 	$(TROW $(ARGS $(D D_InlineAsm_X86_64)) , $(ARGS $(DDLINK spec/iasm, Inline Assembler, Inline assembler) for X86-64 is implemented))
 	$(TROW $(ARGS $(D D_LP64)) , $(ARGS $(B Pointers) are 64 bits
 		(command line switch $(DDSUBLINK dmd, switch-m64, $(TT -m64))). (Do not confuse this with C's LP64 model)))
-	$(TROW $(ARGS $(D D_X32)) , $(ARGS Pointers are 32 bits, but words are still 64 bits (x32 ABI) (This can be defined in parallel to $(D X86_64))))
+	$(TROW $(ARGS $(D D_X32)) , $(ARGS $(B Pointers) are 32 bits, but words are still 64 bits (x32 ABI) (This can be defined in parallel to $(D X86_64))))
+	$(TROW $(ARGS $(D D_P16)) , $(ARGS $(B Pointers) are 16 bits))
 	$(TROW $(ARGS $(D D_HardFloat)) , $(ARGS The target hardware has a floating point unit))
 	$(TROW $(ARGS $(D D_SoftFloat)) , $(ARGS The target hardware does not have a floating point unit))
 	$(TROW $(ARGS $(D D_PIC)) , $(ARGS Position Independent Code


### PR DESCRIPTION
The MSP430X should match with version(MSP430), since it's a small set of backwards compatible ISA extensions (with no mode change), and an MSP430X can be used as an MSP430. In fact, you can use the GCC options -mlarge and -msmall to change between 16-bit and 20-bit pointers (16-bit size_t, 32-bit size_t). The MSP430 and MSP430X proper can be diferentiated when really necessary by using version(D_P16).