### PR TITLE
Change the grammar spec page to reflect DIP1003

### DIFF
--- a/spec/grammar.dd
+++ b/spec/grammar.dd
@@ -1269,6 +1269,7 @@ $(GNAME OutStatement):
 
 $(GNAME BodyStatement):
     $(D body) $(GLINK BlockStatement)
+    $(D do) $(GLINK BlockStatement)
 )
 
 $(GRAMMAR


### PR DESCRIPTION
https://github.com/dlang/DIPs/blob/master/DIPs/DIP1003.md

As per https://github.com/dlang/dlang.org/pull/1818#pullrequestreview-49478344, I updated the grammar to reflect that either `body` _or_ `do` is now allowed as a marker for the function body.

I also submitted a PR for the spec page on contracts: https://github.com/dlang/dlang.org/pull/1828