### PR TITLE
Bump currently archived version to 75

### DIFF
--- a/js/listanchors.js
+++ b/js/listanchors.js
@@ -93,7 +93,7 @@ function listanchors()
     function addVersionSelector() {
       // Latest version offered by the archive builds
       // This needs to be manually updated after new versions have been archived
-      var currentArchivedVersion = 74;
+      var currentArchivedVersion = 75;
       // build URLs for dlang.org: DDoc + Dox
       var ddocModuleURL = document.body.id.replace(/[.]/g, "_") + ".html";
       var ddoxModuleURL = document.body.id.replace(/[.]/g, "/") + ".html";


### PR DESCRIPTION
As I need to do this [manually](https://github.com/wilzbach/dlang.org-archives/commit/65d2e519acfe6f976f4c16460bd6b42dedf61bc1), it's better if I bump it once I have pushed  a snapshot to git.