### PR TITLE
Hide std.typetuple from the menu

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -79,6 +79,7 @@ MOD_EXCLUDES_PRERELEASE=$(addprefix --ex=, gc. rt. core.internal. core.stdc.conf
 	std.algorithm.internal std.c. std.concurrencybase std.internal. std.regex.internal.  \
 	std.windows.iunknown std.windows.registry etc.linux.memoryerror	\
 	std.experimental.ndslice.internal std.stdiobase \
+	std.typetuple \
 	tk. msvc_dmc msvc_lib \
 	ddmd.libmach ddmd.libmscoff ddmd.objc_glue \
 	ddmd.scanmach ddmd.scanmscoff)


### PR DESCRIPTION
Follow-up to https://github.com/dlang/dlang.org/pull/1701, https://github.com/dlang/phobos/pull/5484 and https://github.com/dlang/phobos/pull/5485

It's quite silly that this logic is here and isn't part of a file at Phobos.