### PR TITLE
Store DMD into .generated instead of $(TMP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ Thumbs.db
 *.obj
 /chmgen
 *.o
-*.json
 
 # PDF / eBook
 dlangspec.d
@@ -35,13 +34,9 @@ css/cssmenu.css
 
 .dub/
 dpl-docs/dpl-docs
-modlist-release.ddoc
 
 /d.tag
 /.generated
-
-# DUB binaries
-/assert_writeln_magic
 
 # Generated changelogs
 changelog/*_pre.dd

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ Makefile
 css/cssmenu.css
 *.min.*
 
-deleteme.*
 .dub/
 dpl-docs/dpl-docs
 modlist-release.ddoc

--- a/posix.mak
+++ b/posix.mak
@@ -67,7 +67,7 @@ PHOBOS_STABLE_FILES_GENERATED := $(subst $(PHOBOS_STABLE_DIR), $(PHOBOS_STABLE_D
 # stable dub and dmd versions used to build dpl-docs
 DUB_VER=1.1.0
 STABLE_DMD_VER=2.072.2
-STABLE_DMD_ROOT=$(TMP)/.stable_dmd-$(STABLE_DMD_VER)
+STABLE_DMD_ROOT=$(GENERATED)/stable_dmd-$(STABLE_DMD_VER)
 STABLE_DMD_URL=http://downloads.dlang.org/releases/2.x/$(STABLE_DMD_VER)/dmd.$(STABLE_DMD_VER).$(OS).zip
 STABLE_DMD=$(STABLE_DMD_ROOT)/dmd2/$(OS)/$(if $(filter $(OS),osx),bin,bin$(MODEL))/dmd
 STABLE_DMD_CONF=$(STABLE_DMD).conf
@@ -579,11 +579,11 @@ dpl-docs: ${DUB} ${STABLE_DMD}
 
 ${STABLE_DMD}:
 	mkdir -p ${STABLE_DMD_ROOT}
-	TMPFILE=$$(mktemp deleteme.XXXXXXXX) && curl -fsSL ${STABLE_DMD_URL} > $${TMPFILE}.zip && \
-		unzip -qd ${STABLE_DMD_ROOT} $${TMPFILE}.zip && rm $${TMPFILE}.zip
+	TMPFILE=$$(mktemp deleteme.XXXXXXXX) && curl -fsSL ${STABLE_DMD_URL} > ${TMP}/$${TMPFILE}.zip && \
+		unzip -qd ${STABLE_DMD_ROOT} ${TMP}/$${TMPFILE}.zip && rm ${TMP}/$${TMPFILE}.zip
 
-${DUB}: ${DUB_DIR} ${STABLE_DMD}
-	cd ${DUB_DIR} && DMD="${STABLE_DMD}" ./build.sh
+${DUB}: | ${DUB_DIR} ${STABLE_DMD}
+	cd ${DUB_DIR} && DMD="$(abspath ${STABLE_DMD})" ./build.sh
 
 ################################################################################
 # chm help files


### PR DESCRIPTION
It's starting to get annoying that I have to re-download the stable_compiler after every reboot - even if that's not very often...