### PR TITLE
Add macros for replacement with _pending

### DIFF
--- a/changelog/changelog.ddoc
+++ b/changelog/changelog.ddoc
@@ -24,6 +24,7 @@ $(SMALL released $1, $2)
 $4
 )
 
+_= Should be removed once https://github.com/dlang/tools/pull/252 is merged
 NIGHTLY_VERSION=
 $(DIVC version,
 $(P
@@ -32,6 +33,17 @@ $(SMALL $1)
 )
 $4
 )
+
+_= The following CHANGELOG_SEP_ macros are emitted by the ../tools/changed.d script
+CHANGELOG_SEP_HEADER_TEXT_NONEMPTY=$(BR)$(BIG $(RELATIVE_LINK2 bugfix-list, List of all bug fixes and enhancements in D $(VER).))
+CHANGELOG_SEP_HEADER_TEXT=$(HR)
+CHANGELOG_SEP_TEXT_BUGZILLA=$(BR)$(BIG $(LNAME2 bugfix-list, List of all bug fixes and enhancements in D $(VER):))
+CHANGELOG_SEP_NO_TEXT_BUGZILLA=$(BR)$(BIG List of all bug fixes and enhancements in D $(VER).)
+
+BUGSTITLE_TEXT_HEADER=$(BUGSTITLE $1, $+)
+BUGSTITLE_TEXT_BODY=$(BUGSTITLE $1, $+)
+BUGSTITLE_BUGZILLA=$(BUGSTITLE $1, $+)
+
 
 BUGZILLA = <a href="https://issues.dlang.org/show_bug.cgi?id=$0">Bugzilla $0</a>
 CPPBUGZILLA = <a href="http://bugzilla.digitalmars.com/issues/show_bug.cgi?id=$0">Bugzilla $0</a>

--- a/changelog/pending.ddoc
+++ b/changelog/pending.ddoc
@@ -1,0 +1,9 @@
+VERSION=
+$(DIVC version,
+$(P
+$(B $(LARGE $(LINK2 http://nightlies.dlang.org, Download D nightlies)))$(BR)
+$(SMALL $1)
+)
+$3
+)
+CHANGELOG_SEP_HEADER_TEXT_NONEMPTY=$(BR)$(BIG $(RELATIVE_LINK2 bugfix-list, List of all upcoming bug fixes and enhancements in D $(VER).))

--- a/posix.mak
+++ b/posix.mak
@@ -727,6 +727,24 @@ test: $(ASSERT_WRITELN_BIN)_test test/next_version.sh all
 
 ################################################################################
 # Changelog generation
+# --------------------
+#
+#  The changelog generation consists of two parts:
+#
+#  1) Closed Bugzilla issues since the latest release
+#    - The git log messages after the ${LATEST} release are parsed
+#    - From these git commit messages, referenced Bugzilla issues are extracted
+#    - The status of these issues is checked against the Bugzilla instance (https://issues.dlang.org)
+#
+#    See also: https://github.com/dlang-bots/dlang-bot#bugzilla
+#
+#  2) Full-text messages
+#     - In all dlang repos, a `changelog` folder exists and can be used to add
+#     	small, detailed changelog messages (see e.g. https://github.com/dlang/phobos/tree/master/changelog)
+#     - The changelog generation script searches for all Ddoc files within the `changelog` folders
+#     	and adds them to the generated changelog
+#
+# The changelog script is at https://github.com/dlang/tools/blob/master/changed.d
 ################################################################################
 LOOSE_CHANGELOG_FILES:=$(wildcard $(DMD_DIR)/changelog/*.dd) \
 				$(wildcard $(DRUNTIME_DIR)/changelog/*.dd) \

--- a/posix.mak
+++ b/posix.mak
@@ -211,6 +211,7 @@ STD_DDOC_PRERELEASE=$(addsuffix .ddoc, macros html dlang.org ${GENERATED}/${LATE
 SPEC_DDOC=${DDOC} spec/spec.ddoc
 CHANGELOG_DDOC=${DDOC} changelog/changelog.ddoc $(NODATETIME)
 CHANGELOG_PRE_DDOC=${CHANGELOG_DDOC} changelog/prerelease.ddoc
+CHANGELOG_PENDING_DDOC=${CHANGELOG_DDOC} changelog/pending.ddoc
 
 PREMADE=appendices.html articles.html fetch-issue-cnt.php howtos.html	\
 language-reference.html robots.txt .htaccess .dpl_rewrite_map.txt	\
@@ -337,6 +338,9 @@ rsync-only :
 
 $(DOC_OUTPUT_DIR)/changelog/%.html : changelog/%_pre.dd $(CHANGELOG_PRE_DDOC) $(DMD)
 	$(DMD) -conf= -c -o- -Df$@ $(CHANGELOG_PRE_DDOC) $<
+
+$(DOC_OUTPUT_DIR)/changelog/pending.html : changelog/pending.dd $(CHANGELOG_PENDING_DDOC) $(DMD)
+	$(DMD) -conf= -c -o- -Df$@ $(CHANGELOG_PENDING_DDOC) $<
 
 $(DOC_OUTPUT_DIR)/changelog/%.html : changelog/%.dd $(CHANGELOG_DDOC) $(DMD)
 	$(DMD) -conf= -c -o- -Df$@ $(CHANGELOG_DDOC) $<


### PR DESCRIPTION
See https://github.com/dlang/dlang.org/pull/1821#issuecomment-315603750 and https://github.com/dlang/tools/pull/251#issuecomment-315604776

Step 1) Add new macros
- as suggested no-hardcoded difference is generated by the changelog script
- similarly to `prerelease.ddoc`, a ddoc file is used to overwrite the definitions

Step 2) Replace full text with macros at the `change.d` tool (https://github.com/dlang/tools/pull/252)

Step 3) Add option to parse `BUGSTITLE_TEXT_BODY` and generate a "incremental" changelog