### PR TITLE
Fix stable (remove ddmd/objc.d from the exclude list)

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -506,7 +506,7 @@ endif
 $G/docs.json : ${DMD_STABLE} ${DMD_STABLE_DIR} \
 			${DRUNTIME_STABLE_DIR} ${PHOBOS_STABLE_FILES_GENERATED} | dpl-docs
 	find ${DMD_STABLE_DIR}/src -name '*.d' | \
-		sed -e /mscoff/d -e /objc_glue.d/d -e /objc.d/d ${DMD_EXCLUDE}  \
+		sed -e /mscoff/d -e /objc_glue.d/d ${DMD_EXCLUDE}  \
 			> $G/.release-files.txt
 	find ${DRUNTIME_STABLE_DIR}/src -name '*.d' | \
 	  sed -e /unittest.d/d -e /gcstub/d >> $G/.release-files.txt


### PR DESCRIPTION
Cherry-picked eb71f714990a474718e1dd10463e873d8bea1f7d from https://github.com/dlang/dlang.org/pull/1830#issuecomment-316405165