### PR TITLE
Fix Issue 17702 - codemirror hangs firefox for several seconds

### DIFF
--- a/js/run.js
+++ b/js/run.js
@@ -268,19 +268,27 @@ function setupTextarea(el, opts)
         return str;
     };
 
-    var editor = CodeMirror.fromTextArea(thisObj[0], {
-        lineNumbers: true,
-        tabSize: 4,
-        indentUnit: 4,
-        indentWithTabs: true,
-        mode: "text/x-d",
-        lineWrapping: true,
-        theme: "eclipse",
-        readOnly: false,
-        matchBrackets: true
-    });
+    var editor;
+    var code;
+    function initializeEditor(){
+      if (typeof editor !== "undefined")
+        return;
+      editor = CodeMirror.fromTextArea(thisObj[0], {
+          lineNumbers: true,
+          tabSize: 4,
+          indentUnit: 4,
+          indentWithTabs: true,
+          mode: "text/x-d",
+          lineWrapping: true,
+          theme: "eclipse",
+          readOnly: false,
+          matchBrackets: true
+      });
+      editor.setValue(prepareForMain());
+      code = $(editor.getWrapperElement());
+      code.css('display', 'none');
 
-    editor.setValue(prepareForMain());
+    }
 
     var height = function(diff) {
         var par = code != null ? code : parent.parent().children("div.d_code");
@@ -291,9 +299,6 @@ function setupTextarea(el, opts)
     var editBtn = parent.children(".editButton");
     var resetBtn = parent.children(".resetButton");
     var openInEditorBtn = parent.children(".openInEditorButton");
-
-    var code = $(editor.getWrapperElement());
-    code.css('display', 'none');
 
     var plainSourceCode = parent.parent().children("div.d_code");
 
@@ -351,6 +356,7 @@ function setupTextarea(el, opts)
     }
 
     editBtn.click(function(){
+        initializeEditor();
         resetBtn.css('display', 'inline-block');
         hideAllWindows();
         code.css('display', 'block');
@@ -370,6 +376,7 @@ function setupTextarea(el, opts)
         plainSourceCode.css('display', 'block');
     });
     runBtn.click(function(){
+        initializeEditor();
         resetBtn.css('display', 'inline-block');
         $(this).attr("disabled", true);
         var optArguments = {};


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/4370550/28747986-423a9188-74ac-11e7-9c75-39fcbab6d5d4.png)

![image](https://user-images.githubusercontent.com/4370550/28748046-a4893b90-74ad-11e7-82cc-7911f256ddde.png)


After:

![image](https://user-images.githubusercontent.com/4370550/28747987-4fe6293c-74ac-11e7-9ad9-5453fada8297.png)

![image](https://user-images.githubusercontent.com/4370550/28748014-2e216d2e-74ad-11e7-94b8-b444addbc3fb.png)

ParseHTML goes down from to 1.24s to 264ms

Once we managed to switch to Ddox, avoiding the JS tricks should be a lot easier.