### PR TITLE
Use .tar.xz balls if supported

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -574,11 +574,16 @@ dpl-docs: ${DUB} ${STABLE_DMD}
 	DFLAGS="$(DPL_DOCS_DFLAGS)" ${DUB} build --root=${DPL_DOCS_PATH} \
 		--compiler=${STABLE_DMD}
 
+# .tar.xz's archives are smaller (and don't need a temporary dir) -> prefer if available
 ${STABLE_DMD_ROOT}/.downloaded:
-	mkdir -p ${STABLE_DMD_ROOT}
-	TMPFILE=$$(mktemp ${TMP}/dmd-download-deleteme.XXXXXXXX) && curl -fsSL ${STABLE_DMD_URL} > $${TMPFILE}.zip && \
-		unzip -qd ${STABLE_DMD_ROOT} $${TMPFILE}.zip && rm $${TMPFILE}.zip
-	touch $@
+	@mkdir -p $(dir $@)
+	@if command -v xz >/dev/null 2>&1 ; then \
+		curl -fSL --retry 3 $(subst .zip,.tar.xz,$(STABLE_DMD_URL)) | tar -Jxf - -C $(dir $@); \
+	else \
+		TMPFILE=$$(mktemp deleteme.XXXXXXXX) && curl -fsSL ${STABLE_DMD_URL} > ${TMP}/$${TMPFILE}.zip && \
+			unzip -qd ${STABLE_DMD_ROOT} ${TMP}/$${TMPFILE}.zip && rm ${TMP}/$${TMPFILE}.zip; \
+	fi
+	@touch $@
 
 ${STABLE_DMD} ${STABLE_RDMD} ${DUB}: ${STABLE_DMD_ROOT}/.downloaded
 


### PR DESCRIPTION
Discussion from https://github.com/dlang/dlang.org/pull/1844

> me: The `tar.xz` balls has about half the size of the zip archive and apart from making the CI generate less traffic on the AWS bucket, it's quite noticeably faster on slower connections.
If there's consensus about this, I would propose to do the same for the DMD bootstrapping.

> @CyberShadow: I wonder, how likely is it that `xz` won't be available on users' machines (and it would be too onerous to install it)?

> me: I thought about the same, but then I guessed that if I didn't include the fallback, chances of complaint / rejection would be high. I actually think that `zip` is less frequent than xz-utils