### PR TITLE
Fix Issue 8006: Property Binary Assignment Operators (Spec Change)

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -553,7 +553,7 @@ $(H2 $(LNAME2 property-functions, Property Functions))
     )
 
     $(P Simple getter and setter properties can be written using $(RELATIVE_LINK2 pseudo-member, UFCS).
-    These can be enhanced with the additon of the $(D @property) attribute to the function, which
+    These can be enhanced with the addition of the $(D @property) attribute to the function, which
     adds the following behaviors:
     )
 
@@ -564,14 +564,13 @@ $(H2 $(LNAME2 property-functions, Property Functions))
     $(LI Binary assignments can be used with $(D @property) functions.  The binary assignment expression
     `e1.prop @= e2` is evaluated as follows:)
         $(UL
-            $(LI If the getter `@property` function returns by `ref` the binary assignment operation is applied
-            directly to the return value of the getter.)
-            $(LI If the getter `@property` function returns an aggregate that overloads the binary assignment
-            operator, the binary assignment operation is applied directly to the return value of the getter.)
-            $(LI If `e1` is a type, the binary assignment expression is lowered to `e1.prop = e1.prop @ e2`)
+            $(LI If the getter `@property` function returns an lvalue the binary assignment operator is applied
+            to the return value of the getter.)
+            $(LI If `e1` is a type, the binary assignment expression is lowered to `e1.prop(e1.prop() @ e2)`
+            ensuring the property getter and setter are each evaluated exactly once.)
             $(LI Otherwise, the binary assignment expression is lowered to
-            `((auto ref _e1) => _e1.prop = _e1.prop @ e2)(e1))`.  `e1` should only be evaluated once and never
-            copied.
+            `((auto ref _e1) => _e1.prop(_e1.prop() @ e2))(e1)`.  `e1` should only be evaluated once and never
+            copied. The property getter and setter must each be evaluated exactly once.)
         )
     $(LI For the expression $(D typeof(exp)) where $(D exp) is an $(D @property) function,
     the type is the return type of the function, rather than the type of the function.)

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -561,6 +561,17 @@ $(H2 $(LNAME2 property-functions, Property Functions))
     $(LI $(D @property) functions cannot be overloaded with non-$(D @property) functions with the same name.)
     $(LI $(D @property) functions can only have zero, one or two parameters.)
     $(LI $(D @property) functions cannot have variadic parameters.)
+    $(LI Binary assignments can be used with $(D @property) functions.  The binary assignment expression
+    `e1.prop @= e2` is evaluated as follows:)
+        $(UL
+            $(LI If the getter `@property` function returns by ref the binary assignment operation is applied
+            directly to the return value of the getter.)
+            $(LI If the getter `@property` function returns an aggregate that overloads teh binary assignment
+            operator, the binary assignment operation is applied directly to the return value of the getter.)
+            $(LI If `e1` is a type, the binary assignment expression is lowered to `e1.prop = e1.prop @ e2`)
+            $(LI Otherwise, the binary assignment expression is lowered to
+            `((auto ref _e1) => _e1.prop = _e1.prop @ e2)(e1))`
+        )
     $(LI For the expression $(D typeof(exp)) where $(D exp) is an $(D @property) function,
     the type is the return type of the function, rather than the type of the function.)
     $(LI For the expression $(D __traits(compiles, exp)) where $(D exp) is an $(D @property) function,
@@ -573,13 +584,14 @@ $(H2 $(LNAME2 property-functions, Property Functions))
 
     $(P A simple property would be:)
 
-
     ---
     struct Foo
     {
-        @property int data() { return m_data; } // read property
+        @property int data() { return m_data; }  // read @property function (a.k.a getter)
 
-        @property int data(int value) { return m_data = value; } // write property
+        @property int data(int value) { return m_data = value; } // write @property function (a.k.a setter)
+
+        @property ref int refData() { return m_data; } // ref getter with no accompanying setter
 
       private:
         int m_data;
@@ -594,6 +606,8 @@ $(H2 $(LNAME2 property-functions, Property Functions))
         Foo f;
 
         f.data = 3;        // same as f.data(3);
+        f.data += 3;       // same as f.data(f.data() + 3);
+        f.refData += 3;    // same as f.refData() += 3;
         return f.data + 3; // same as return f.data() + 3;
     }
     ---

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -564,13 +564,14 @@ $(H2 $(LNAME2 property-functions, Property Functions))
     $(LI Binary assignments can be used with $(D @property) functions.  The binary assignment expression
     `e1.prop @= e2` is evaluated as follows:)
         $(UL
-            $(LI If the getter `@property` function returns by ref the binary assignment operation is applied
+            $(LI If the getter `@property` function returns by `ref` the binary assignment operation is applied
             directly to the return value of the getter.)
-            $(LI If the getter `@property` function returns an aggregate that overloads teh binary assignment
+            $(LI If the getter `@property` function returns an aggregate that overloads the binary assignment
             operator, the binary assignment operation is applied directly to the return value of the getter.)
             $(LI If `e1` is a type, the binary assignment expression is lowered to `e1.prop = e1.prop @ e2`)
             $(LI Otherwise, the binary assignment expression is lowered to
-            `((auto ref _e1) => _e1.prop = _e1.prop @ e2)(e1))`
+            `((auto ref _e1) => _e1.prop = _e1.prop @ e2)(e1))`.  `e1` should only be evaluated once and never
+            copied.
         )
     $(LI For the expression $(D typeof(exp)) where $(D exp) is an $(D @property) function,
     the type is the return type of the function, rather than the type of the function.)


### PR DESCRIPTION
Spec change to accompany https://github.com/dlang/dmd/pull/7079

FYI: This does not address unary assignment operators (e.g. `s.x++`, `++s.x`).  I intend to implement that in a future pull request.