### PR TITLE
Remove wrong changelog entry

### DIFF
--- a/changelog/2.075.0.dd
+++ b/changelog/2.075.0.dd
@@ -426,7 +426,6 @@ $(BUGSTITLE DMD Compiler bugs,
 
 $(LI $(BUGZILLA 7016): local import does not create -deps dependency)
 $(LI $(BUGZILLA 13331): naked asm functions are broken when compiling with -profile)
-$(LI $(BUGZILLA 14246): RAII - proper destruction of partially constructed objects/structs)
 $(LI $(BUGZILLA 15896): private ignored when import bindings are used)
 $(LI $(BUGZILLA 15945): sizeof on an invalid type seems to compile.)
 $(LI $(BUGZILLA 16244): compiler ICE on complex `typeof$(LPAREN)$(RPAREN)` for method arg type)


### PR DESCRIPTION
The fix for [ssue 14246](https://issues.dlang.org/show_bug.cgi?id=14246) was reverted, it is not included in 2.075.0
(see bugzilla page for details), and the issue has been reopened.