### PR TITLE
Clarification on @property functions

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -559,7 +559,8 @@ $(H2 $(LNAME2 property-functions, Property Functions))
 
     $(UL
     $(LI $(D @property) functions cannot be overloaded with non-$(D @property) functions with the same name.)
-    $(LI $(D @property) functions can only have zero, one or two parameters.)
+    $(LI $(D @property) functions can only have zero or one parameter if they are non-static members.)
+    $(LI $(D @property) functions can only have one or two parameters if they are non-members.)
     $(LI $(D @property) functions cannot have variadic parameters.)
     $(LI For the expression $(D typeof(exp)) where $(D exp) is an $(D @property) function,
     the type is the return type of the function, rather than the type of the function.)


### PR DESCRIPTION
[This question](https://stackoverflow.com/questions/44887077/d-properties-with-two-arguments) on stackoverflow and my personal struggling with the sentence suggests to add clarification.
I've done some tests with static member functions.
```d
@property bool parity(int x) { return x & 1; }
@property void parity(ref int x, bool p) { (x |= 1) &= p; }
```
work well. For static member functions like these
```d
struct Test
{
  static:
    @property bool parity(int x) { return x & 1; }
    @property void parity(ref int x, bool p) { (x |= 1) &= p; }
    
    void test()
    {
        int x = 1;
        bool p = parity(x); // (1)
        int y = 2;
        parity(y, p); // (2)
    }
}
```
the `@property` has no effect: Replace `(1)` and `(2)` by `bool p = x.parity;` and `y.parity = p;` respectively, you get the error *no property 'parity' for type 'int'*.

I don't know if this is intensional or a bug.