### PR TITLE
Fix Issue 9958: Integer FloatSuffix is not a valid FloatLiteral

### DIFF
--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -793,6 +793,7 @@ $(GRAMMAR
 $(GNAME FloatLiteral):
     $(GLINK Float)
     $(GLINK Float) $(GLINK Suffix)
+    $(GLINK Integer) $(GLINK FloatSuffix)
     $(GLINK Integer) $(GLINK ImaginarySuffix)
     $(GLINK Integer) $(GLINK FloatSuffix) $(GLINK ImaginarySuffix)
     $(GLINK Integer) $(GLINK RealSuffix) $(GLINK ImaginarySuffix)


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=9958