### PR TITLE
changelog/2.076.0.dd: Fix trailing whitespace

### DIFF
--- a/changelog/2.076.0.dd
+++ b/changelog/2.076.0.dd
@@ -63,7 +63,7 @@ static foreach(i; 0 .. 10)
 
     // a `static foreach` body does not introduce a nested scope
     // (similar to `static if`).
-    
+
     // The following mixin declaration is at module scope:
     mixin(`enum x` ~ to!string(i) ~ ` = i;`); // declares 10 variables x0, x1, ..., x9
 }
@@ -87,7 +87,7 @@ void main()
 
     // `static foreach` has both declaration and statement forms
     // (similar to `static if`).
-    
+
     static foreach(x; iota(3).map!(i => tuple(text("x", i), i)))
     {
         // generates three local variables x0, x1 and x2.
@@ -98,7 +98,7 @@ void main()
             writeln(mixin(x[0]));
         }
     }
-    
+
     writeln(x0," ",x1," ",x2); // first runtime output
 }
 ---
@@ -201,7 +201,7 @@ static foreach(i; 0 .. 10)
 
     // a `static foreach` body does not introduce a nested scope
     // (similar to `static if`).
-    
+
     // The following mixin declaration is at module scope:
     mixin(`enum x` ~ to!string(i) ~ ` = i;`); // declares 10 variables x0, x1, ..., x9
 }
@@ -225,7 +225,7 @@ void main()
 
     // `static foreach` has both declaration and statement forms
     // (similar to `static if`).
-    
+
     static foreach(x; iota(3).map!(i => tuple(text("x", i), i)))
     {
         // generates three local variables x0, x1 and x2.
@@ -236,7 +236,7 @@ void main()
             writeln(mixin(x[0]));
         }
     }
-    
+
     writeln(x0," ",x1," ",x2); // first runtime output
 }
 ---


### PR DESCRIPTION
Needed to unbreak dlang.org tests.