### PR TITLE
tone down spec heading/paragraph numbers a bit

### DIFF
--- a/spec/spec.ddoc
+++ b/spec/spec.ddoc
@@ -30,6 +30,12 @@ $(T style,
         counter-increment: p;
         content: counter(p) ". ";
     }
+    h1::before, h2::before, h3::before, h4::before, p::before
+    {
+        color: #999;
+        font-size: 80%;
+        margin-right: 0.25em;
+    }
 )
 
 SUBNAV_HEAD = $(DIVC head, $(H5 $1) $(TC p, $4, $(LINK2 $2, $3)))


### PR DESCRIPTION
Just a little visual tweak.

Exemplary before/after:
![spectacle cs7269](https://user-images.githubusercontent.com/9287500/30083497-e930c20a-928e-11e7-903a-ab31f356b7d8.png)
