### PR TITLE
Revert "Use AliasSeq instead of static foreach for now"

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -223,8 +223,7 @@ $(RUNNABLE_EXAMPLE_STDIN 2 3 3 4 + * *)
 ----
 void main()
 {
-    import std.stdio, std.string,
-        std.algorithm, std.conv, std.meta;
+    import std.stdio, std.string, std.algorithm, std.conv;
 
     // Reduce the RPN expression using a stack
     readln.split.fold!((stack, op)
@@ -232,7 +231,7 @@ void main()
         switch (op)
         {
             // Generate operator switch cases statically
-            foreach (c; AliasSeq!('+', '-', '*', '/'))
+            static foreach (c; "+-*/")
                 case [c]:
                     return stack[0 .. $ - 2] ~
                         mixin("stack[$ - 2] " ~ c ~


### PR DESCRIPTION
This reverts commit bc93f7c0c7e7d734f635e580ec0797f72007434d.

Follow-up to #1848