### PR TITLE
Add a simple overview of all contributors

### DIFF
--- a/contributors.dd
+++ b/contributors.dd
@@ -1,0 +1,17 @@
+Ddoc
+
+$(D_S $(TITLE),
+
+$(P
+A list of all the awesome people that made D possible.
+)
+
+$(UL
+    $(D_CONTRIBUTORS)
+)
+
+)
+
+Macros:
+    TITLE=Contributors ($(NR_D_CONTRIBUTORS))
+    D_CONTRIBUTOR=$(LI $1)

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -249,7 +249,8 @@ $(SUBMENU_MANUAL
     $(SUBMENU_LINK_DIVIDER https://github.com/dlang, GitHub)
     $(SUBMENU_LINK $(ROOT_DIR)bugstats.html, Issues)
     $(SUBMENU_LINK https://wiki.dlang.org/Get_involved, Get involved)
-    $(SUBMENU_LINK_DIVIDER $(ROOT_DIR)foundation.html, Foundation)
+    $(SUBMENU_LINK_DIVIDER $(ROOT_DIR)contributors.html, Contributors)
+    $(SUBMENU_LINK $(ROOT_DIR)foundation.html, Foundation)
     $(SUBMENU_LINK $(ROOT_DIR)donate.html, Donate)
 )
 NAVIGATION_DOCUMENTATION=

--- a/posix.mak
+++ b/posix.mak
@@ -347,7 +347,7 @@ endif
 PAGES_ROOT=$(SPEC_ROOT) 404 acknowledgements areas-of-d-usage \
 	articles ascii-table bugstats builtin \
 	$(CHANGELOG_FILES) code_coverage community comparison concepts \
-	const-faq cppcontracts cpptod ctarguments ctod donate \
+	const-faq contributors cppcontracts cpptod ctarguments ctod donate \
 	D1toD2 d-array-article d-floating-point deprecate dlangupb-scholarship dll-linux dmd \
 	dmd-freebsd dmd-linux dmd-osx dmd-windows documentation download dstyle \
 	exception-safe faq forum-template foundation gpg_keys glossary \
@@ -461,6 +461,9 @@ $W/spec/%.html : spec/%.dd $(SPEC_DDOC) $(DMD)
 
 $W/404.html : 404.dd $(DDOC) $(DMD)
 	$(DMD) -conf= -c -o- -Df$@ $(DDOC) errorpage.ddoc $<
+
+$(DOC_OUTPUT_DIR)/contributors.html: contributors.dd $G/contributors.ddoc $(DDOC) $(DMD)
+	$(DMD) -conf= -c -o- -Df$@ $(DDOC) $(word 2, $^) $<
 
 $W/%.html : %.dd $(DDOC) $(DMD)
 	$(DMD) -conf= -c -o- -Df$@ $(DDOC) $<
@@ -884,5 +887,17 @@ changelog/pending.dd: changelog/next-version | ${STABLE_DMD} ../tools ../install
 
 pending_changelog: $(LOOSE_CHANGELOG_FILES) changelog/pending.dd html
 	@echo "Please open file:///$(shell pwd)/web/changelog/pending.html in your browser"
+
+################################################################################
+# Contributors listing: A list of all the awesome who made D possible
+################################################################################
+
+$G/contributors.dd:  | $(STABLE_RDMD) $(TOOLS_DIR) $(INSTALLER_DIR)
+	@$(STABLE_RDMD) $(TOOLS_DIR)/contributors.d --format=ddoc "master" > $@
+
+$G/contributors.ddoc: $G/contributors.dd
+	@echo "NR_D_CONTRIBUTORS=$$(wc -l < $<)" > $@
+	@echo "D_CONTRIBUTORS=" >> $@
+	@cat $< >> $@
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)


### PR DESCRIPTION
Add initial list of all contributors. This is just as a start to explore options on how we could utilize this information from the git log.

Depends on https://github.com/dlang/tools/pull/253