### PR TITLE
Update mobile links for LDC

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -37,9 +37,8 @@ $(TABLEC download-compilers,
       $(UL
         $(LI $(LINK2 http://llvm.org/, LLVM)-based D compiler)
         $(LI Strong optimization)
-        $(LI Mobile support:
-          $(LINK2 https://github.com/smolt/ldc-iphone-dev/releases, iOS alpha),
-          $(LINK2 https://github.com/joakim-noah/android/releases, Android beta)
+        $(LI
+          $(LINK2 https://wiki.dlang.org/Build_D_for_Android, Android support)
         )
         $(LI Architectures: i386, amd64, armel, armhf, $(LINK2 https://wiki.dlang.org/Compilers#Comparison,others))
       )


### PR DESCRIPTION
Now that all my Android patches for ldc have been pushed upstream, I don't put out Android cross-compiler builds anymore, so better to link to the wiki page that shows how to use the official ldc release to build for Android.

As for iOS, Dan hasn't had time to work on it and it has fallen behind.  He'd like for someone else to pick up the torch, but in the meantime better not link to such an old build.