### PR TITLE
fix issue 17848 - Example of floating point literals in the documenta…

### DIFF
--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -915,8 +915,6 @@ $(GNAME LeadingDecimal):
 ---------
 1f; // OK
 1.f; // forbidden
-1d; // OK
-1.d; // forbidden
 1.; // OK, int
 ---------
 

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -915,7 +915,7 @@ $(GNAME LeadingDecimal):
 ---------
 1f; // OK
 1.f; // forbidden
-1.; // OK, int
+1.; // OK, double
 ---------
 
 	$(P Complex literals are not tokens, but are assembled from


### PR DESCRIPTION
…tion is invalid

'd' is not a valid float suffix. It's not in the grammar, and dmd doesn't accept it. ~~Changing to 'L' suffix.~~