### PR TITLE
Fix DUB single package syntax

### DIFF
--- a/assert_writeln_magic.d
+++ b/assert_writeln_magic.d
@@ -1,6 +1,5 @@
 #!/usr/bin/env dub
-/++
-dub.sdl:
+/++ dub.sdl:
 dependency "libdparse" version="0.7.0-beta.7"
 name "assert_writeln_magic"
 +/


### PR DESCRIPTION
Apparently newer DUB versions got more strict regarding the single package format...