### PR TITLE
Bump stable DMD and DUB version

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -186,7 +186,7 @@ endif
 ################################################################################
 
 # stable dub and dmd versions used to build dpl-docs
-STABLE_DMD_VER=2.072.2
+STABLE_DMD_VER=2.077.1
 STABLE_DMD_ROOT=$(GENERATED)/stable_dmd-$(STABLE_DMD_VER)
 STABLE_DMD_URL=http://downloads.dlang.org/releases/2.x/$(STABLE_DMD_VER)/dmd.$(STABLE_DMD_VER).$(OS).zip
 STABLE_DMD_BIN_ROOT=$(STABLE_DMD_ROOT)/dmd2/$(OS)/$(if $(filter $(OS),osx),bin,bin$(MODEL))


### PR DESCRIPTION
With DUB 1.6.0 (part of the DMD 2.077.0 release), DUB will retry
downloads from the DUB registry and alternatively use fallback mirrors.