### PR TITLE
fix issue 17925 - Mention the old body keyword

### DIFF
--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -59,7 +59,7 @@ $(H2 $(LNAME2 pre_post_contracts, Pre and Post Contracts))
 	typical use of this would be in validating the parameters to a function. The post
 	contracts validate the result of the statement. The most typical use of this
 	would be in validating the return value of a function and of any side effects it has.
-	The syntax is:
+	The syntax is:)
 
 ------
 in
@@ -76,12 +76,11 @@ do
 }
 ------
 
-    The actual function body starts with <code>do</code>.
-    In the past, <code>body</code> was used, and could still be encountered in old code bases.
-    In the long term, <code>body</code> may be deprecated, but for now it's still allowed
+    $(P The actual function body starts with $(D do).
+    In the past, $(D body) was used, and could still be encountered in old code bases.
+    In the long term, $(D body) may be deprecated, but for now it's still allowed
     as a keyword in this context and as an identifier in the function body,
-    although <code>do</code> is preferred.
-)
+    although $(D do) is preferred.)
 
 	$(P By definition, if a pre contract fails, then the function received bad
 	parameters.

--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -76,7 +76,7 @@ do
 }
 ------
 
-    $(P Since $(LINK2 https://github.com/dlang/DIPs/blob/master/DIPs/DIP1003.md, DIP1003 has been applied) 
+    $(P Since $(LINK2 https://github.com/dlang/DIPs/blob/master/DIPs/DIP1003.md, DIP1003 has been applied)
     the actual function body starts with $(D do).
     In the past, $(D body) was used, and could still be encountered in old code bases.
     In the long term, $(D body) may be deprecated, but for now it's allowed

--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -76,11 +76,11 @@ do
 }
 ------
 
-    The actual function body starts with the <code>do</code> keyword. 
-    In the past, <code>body</code> was used and it will be still encountered in old code bases. 
-    On the long term, <code>body</code> could be completely unsupported but for now it's still allowed,
-    as a keyword in this context and as an identifier in the function body 
-    although <code>do</code> must be prefered.
+    The actual function body starts with <code>do</code>.
+    In the past, <code>body</code> was used, and could still be encountered in old code bases.
+    In the long term, <code>body</code> may be deprecated, but for now it's still allowed
+    as a keyword in this context and as an identifier in the function body,
+    although <code>do</code> is preferred.
 )
 
 	$(P By definition, if a pre contract fails, then the function received bad

--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -76,7 +76,8 @@ do
 }
 ------
 
-    $(P The actual function body starts with $(D do).
+    $(P Since $(LINK2 https://github.com/dlang/DIPs/blob/master/DIPs/DIP1003.md, DIP1003 has been applied) 
+    the actual function body starts with $(D do).
     In the past, $(D body) was used, and could still be encountered in old code bases.
     In the long term, $(D body) may be deprecated, but for now it's allowed
     as a keyword in this context and as an identifier in the function body,

--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -59,7 +59,7 @@ $(H2 $(LNAME2 pre_post_contracts, Pre and Post Contracts))
 	typical use of this would be in validating the parameters to a function. The post
 	contracts validate the result of the statement. The most typical use of this
 	would be in validating the return value of a function and of any side effects it has.
-	The syntax is:)
+	The syntax is:
 
 ------
 in
@@ -75,6 +75,14 @@ do
     ...code...
 }
 ------
+
+    The actual function body starts with the <code>do</code> keyword. 
+    In the past, <code>body</code> was used and it will be still encountered in old code bases. 
+    On the long term, <code>body</code> could be completely unsupported but for now it's still allowed,
+    as a keyword in this context and as an identifier in the function body 
+    although <code>do</code> must be prefered.
+)
+
 	$(P By definition, if a pre contract fails, then the function received bad
 	parameters.
 	An AssertError is thrown. If a post contract fails,

--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -78,7 +78,7 @@ do
 
     $(P The actual function body starts with $(D do).
     In the past, $(D body) was used, and could still be encountered in old code bases.
-    In the long term, $(D body) may be deprecated, but for now it's still allowed
+    In the long term, $(D body) may be deprecated, but for now it's allowed
     as a keyword in this context and as an identifier in the function body,
     although $(D do) is preferred.)
 


### PR DESCRIPTION
New comers might be confused by the specs, not matching the D code they can read here and there so a note about the syntax explains the situation.