### PR TITLE
Update download.dd

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -150,6 +150,8 @@ sudo apt-get update && sudo apt-get -y --allow-unauthenticated install --reinsta
 sudo apt-get update && sudo apt-get install dmd-bin)
 )
 
+$(DOWNLOAD $(OPENSUSE), OpenSUSE Tumbleweed, $(CONSOLE sudo zypper install dmd))
+
 $(H2 Other Downloads)
 
 $(UL


### PR DESCRIPTION
Append installation instructions for OpenSUSE Tumbleweed (rolling release distribution of OpenSUSE). I'm not sure if this is applicable for other versions of OpenSUSE. I'm assuming for the stable release (OpenSUSE 42.3) you would need to add a development repository, but I haven't confirmed.

If dmd is not available in the basic repos of stable releases, then users would probably need to add the dlang:devel repo pertaining to their release version:

https://software.opensuse.org/download.html?project=devel%3Alanguages%3AD&package=dlang-tools