### PR TITLE
Clarify WithStatement scope resolution rules

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1413,6 +1413,69 @@ void main()
 }
 ---
 
+        $(P In nested $(I WithStatement)s, the inner-most scope takes precedence.  If
+        a symbol cannot be resolved at the inner-most scope, resolution is forwarded
+        incrementally up the scope hierarchy.)
+---
+import std.stdio;
+
+struct Foo
+{
+    void f() { writeln("Foo.f"); }
+}
+
+struct Bar
+{
+    void f() { writeln("Bar.f"); }
+}
+
+struct Baz
+{
+    // f() is not implemented
+}
+
+void f()
+{
+    writeln("f");
+}
+
+void main()
+{
+    Foo foo;
+    Bar bar;
+    Baz baz;
+
+    f();               // prints "f"
+
+    with(foo)
+    {
+        f();           // prints "Foo.f"
+
+        with(bar)
+        {
+            f();       // prints "Bar.f"
+
+            with(baz)
+            {
+                f();   // prints "Bar.f".  `Baz` does not implement `f()` so resolution is
+                       // forwarded to `with(bar)`'s scope
+            }
+        }
+        with(baz)
+        {
+            f();       // prints "Foo.f".  `Baz` does not implement `f()` so resolution is
+                       // forwarded to `with(foo)`'s scope
+        }
+    }
+    with(baz)
+    {
+        f();           // prints "f".  `Baz` does not implement `f()` so resolution is forwarded
+                       // to `main`'s scope. `f()` is not implemented in `main`'s scope, so
+                       // resolution is subsequently forward to module scope.
+    }
+}
+
+---
 
 $(H2 $(LEGACY_LNAME2 SynchronizedStatement, synchronized-statement, Synchronized Statement))
 

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1457,21 +1457,22 @@ void main()
 
             with(baz)
             {
-                f();   // prints "Bar.f".  `Baz` does not implement `f()` so resolution is
-                       // forwarded to `with(bar)`'s scope
+                f();   // prints "Bar.f".  `Baz` does not implement `f()` so
+                       // resolution is forwarded to `with(bar)`'s scope
             }
         }
         with(baz)
         {
-            f();       // prints "Foo.f".  `Baz` does not implement `f()` so resolution is
-                       // forwarded to `with(foo)`'s scope
+            f();       // prints "Foo.f".  `Baz` does not implement `f()` so
+                       // resolution is forwarded to `with(foo)`'s scope
         }
     }
     with(baz)
     {
-        f();           // prints "f".  `Baz` does not implement `f()` so resolution is forwarded
-                       // to `main`'s scope. `f()` is not implemented in `main`'s scope, so
-                       // resolution is subsequently forward to module scope.
+        f();           // prints "f".  `Baz` does not implement `f()` so
+                       // resolution is forwarded to `main`'s scope. `f()` is
+                       // not implemented in `main`'s scope, so resolution is
+                       // subsequently forward to module scope.
     }
 }
 


### PR DESCRIPTION
This PR was created in response to comments on https://github.com/dlang/dmd/pull/7356.  However, it is not dependent on that PR.  This PR is not introducing any new rules; it is only clarifying the existing implementation.

https://github.com/dlang/dmd/pull/7356 was submitted to bring `opDispatch` in compliance with these rules and the existing implementation.