### PR TITLE
Fix Issue 18032 - [Home] Print hex dump example doesn't run

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -127,10 +127,10 @@ $(EXTRA_EXAMPLE_RUNNABLE Print hex dump,
 ----
 void main()
 {
-    import std.algorithm, std.stdio, std.file;
-    enum cols = 16;
-    // Split file into 16-byte chunks per row
-    thisExePath.File("rb").byChunk(cols).each!(chunk =>
+    import std.algorithm, std.stdio, std.file, std.range;
+    enum cols = 14;
+    // Split file into 14-byte chunks per row
+    thisExePath.File("rb").byChunk(cols).take(20).each!(chunk =>
         // Use range formatting to format the
         // hexadecimal part and align the text part
         writefln!"%(%02X %)%*s  %s"(


### PR DESCRIPTION
I also increased the output limit at the DTour server (see e.g. https://github.com/dlang-tour/core-exec/pull/11), but imho it doesn't make sense to dump everything to the user anyhow.
I reduced it to 14 columns because I had issues with scrolling.