### PR TITLE
compute next version from ../dmd/VERSION

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ dpl-docs/dpl-docs
 
 # Generated changelogs
 changelog/*_pre.dd
+changelog/pending.dd

--- a/changelog/next_version.sh
+++ b/changelog/next_version.sh
@@ -2,6 +2,8 @@
 
 set -ueo pipefail
 
+# cd and pwd to account for relative paths/symlinks. See also:
+# https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 VERSION=$(cat "${1:-$DIR/../../dmd/VERSION}")

--- a/changelog/next_version.sh
+++ b/changelog/next_version.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -ueo pipefail
+
+VERSION=$(cat "$1")
+# v2.076.1-b1 -> 2.076.1
+VERSION=${VERSION:1:7}
+# 2.076.1 -> (2 076 1)
+PARTS=(${VERSION//./ })
+# use 10#076 prefix to read octal as base10 int
+PARTS[1]=0$((10#${PARTS[1]} + 1))
+PARTS[2]=0
+# 2 077 0 -> 2.077.0
+echo "${PARTS[0]}.${PARTS[1]}.${PARTS[2]}"

--- a/changelog/next_version.sh
+++ b/changelog/next_version.sh
@@ -2,7 +2,9 @@
 
 set -ueo pipefail
 
-VERSION=$(cat "$1")
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+VERSION=$(cat "${1:-$DIR/../../dmd/VERSION}")
 # v2.076.1-b1 -> 2.076.1
 VERSION=${VERSION:1:7}
 # 2.076.1 -> (2 076 1)

--- a/posix.mak
+++ b/posix.mak
@@ -28,7 +28,8 @@ ifeq (,${LATEST})
 LATEST:=$(shell cat VERSION)
 endif
 # Next major DMD release
-NEXT_VERSION:=$(shell bash -c 'version=$$(cat VERSION);a=($${version//./ });a[1]="10\#$${a[1]}";((a[1]++)); a[2]=0; echo $${a[0]}.0$${a[1]}.$${a[2]};' )
+# use 10#076 to read zero prefixed int as base 10
+NEXT_VERSION:=$(shell bash -c 'version=$$(cat VERSION);a=($${version//./ }); a[1]=0$$((10\#$${a[1]} + 1)); a[2]=0; echo $${a[0]}.$${a[1]}.$${a[2]};' )
 
 # DLang directories
 DMD_DIR=../dmd

--- a/posix.mak
+++ b/posix.mak
@@ -709,7 +709,7 @@ $(PHOBOS_LATEST_FILES_GENERATED): $(PHOBOS_LATEST_DIR_GENERATED)/%: $(PHOBOS_LAT
 # Style tests
 ################################################################################
 
-test: $(ASSERT_WRITELN_BIN)_test all
+test: $(ASSERT_WRITELN_BIN)_test test/next_version.sh all
 	@echo "Searching for trailing whitespace"
 	@grep -n '[[:blank:]]$$' $$(find . -type f -name "*.dd") ; test $$? -eq 1
 	@echo "Searching for undefined macros"
@@ -718,6 +718,8 @@ test: $(ASSERT_WRITELN_BIN)_test all
 	@grep -rn '[$$](' $$(find $(DOC_OUTPUT_DIR)/phobos-prerelease -type f -name "*.html") ; test $$? -eq 1
 	@echo "Executing assert_writeln_magic tests"
 	$<
+	@echo "Executing next_version tests"
+	test/next_version.sh
 
 ################################################################################
 # Changelog generation

--- a/posix.mak
+++ b/posix.mak
@@ -230,7 +230,7 @@ SPEC_DD=$(addsuffix .dd,$(SPEC_ROOT))
 
 CHANGELOG_FILES=$(basename $(subst _pre.dd,.dd,$(wildcard changelog/*.dd)))
 ifndef RELEASE
-CHANGELOG_FILES+=changelog/${NEXT_VERSION}_pre
+CHANGELOG_FILES+=changelog/pending
 endif
 
 # Website root filenames. They have extension .dd in the source
@@ -731,11 +731,12 @@ CHANGELOG_FILES=$(wildcard $(DMD_DIR)/changelog/*.dd) \
 changelog/next-version: ${DMD_DIR}/VERSION
 	$(eval NEXT_VERSION:=$(shell changelog/next_version.sh ${DMD_DIR}/VERSION))
 
-changelog/pending: | ${STABLE_DMD} ../tools ../installer
-	[ -f changelog/${NEXT_VERSION}_pre.dd ] || $(STABLE_RDMD) $(TOOLS_DIR)/changed.d $(CHANGELOG_VERSION_LATEST) -o $@ \
-		--version "${NEXT_VERSION}"
+changelog/pending.dd: changelog/next-version | ${STABLE_DMD} ../tools ../installer
+	[ -f changelog/pending.dd ] || $(STABLE_RDMD) $(TOOLS_DIR)/changed.d \
+		$(CHANGELOG_VERSION_LATEST) -o changelog/pending.dd --version "${NEXT_VERSION}" \
+		--date "To be released" --nightly
 
-pending_changelog: $(CHANGELOG_FILES) changelog/pending html
-	@echo "Please open file:///$(shell pwd)/web/changelog/${NEXT_VERSION}_pre.html in your browser"
+pending_changelog: $(CHANGELOG_FILES) changelog/pending.dd html
+	@echo "Please open file:///$(shell pwd)/web/changelog/pending.html in your browser"
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)

--- a/posix.mak
+++ b/posix.mak
@@ -27,9 +27,17 @@ PWD=$(shell pwd)
 ifeq (,${LATEST})
 LATEST:=$(shell cat VERSION)
 endif
+
 # Next major DMD release
+define NEXT_VERSION_SH
+version=$$(cat VERSION)
+a=($${version//./ })
 # use 10#076 to read zero prefixed int as base 10
-NEXT_VERSION:=$(shell bash -c 'version=$$(cat VERSION);a=($${version//./ }); a[1]=0$$((10\#$${a[1]} + 1)); a[2]=0; echo $${a[0]}.$${a[1]}.$${a[2]};' )
+a[1]=0$$((10#$${a[1]} + 1))
+a[2]=0
+echo $${a[0]}.$${a[1]}.$${a[2]}
+endef
+NEXT_VERSION:=$(shell bash -c '${NEXT_VERSION_SH}')
 
 # DLang directories
 DMD_DIR=../dmd

--- a/test/next_version.sh
+++ b/test/next_version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Test changelog/next_version.sh
+
+set -ueo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+NV="$DIR/../changelog/next_version.sh"
+
+TMPFILE=$(mktemp deleteme.XXXXXXXX)
+cleanup() {
+    rm -rf "$TMPFILE";
+}
+trap cleanup EXIT
+
+versions=( \
+    "2.077.0|2.078.0"
+    "2.077.1|2.078.0"
+    "2.077.1-beta|2.078.0"
+    "2.077.1-master.abcdefg|2.078.0"
+    "3.81.1|3.082.0"
+)
+
+for version in "${versions[@]}" ; do
+    version_latest="$(echo "$version" | cut -d'|' -f 1)"
+    version_next="$(echo "$version" | cut -d'|' -f 2)"
+    echo "v$version_latest" > "$TMPFILE"
+    echo "Testing: $version_latest (expecting: $version_next)"
+    version_real=$("$NV" "$TMPFILE")
+    if [ "$version_real" != "$version_next" ] ; then
+        echo "Comparison failed. Received $version_real (expected $version_next)"
+        exit 1
+    fi
+done


### PR DESCRIPTION
Extracted from https://github.com/dlang/dlang.org/pull/1907, s.t. we can move forward bit by bit.

Moving the `next_version` computation to a script seemed like sth. that could easily be a separate PR, s.t. the complexity of #1907 is reduced.

For now I kept things simple and used `changelog/pending.dd` instead of `changelog/${NEXT_VERSION}_pre.dd` (as Martin will do in #1907 too). As this page isn't linked to anywhere we can use any name and not using the version in the filename makes things easier as we now (1) don't depend on `../dmd/VERSION` and thus cloning `dmd` every time and (2) don't need to call the `next_version.sh` on every Make invocation.