### PR TITLE
"d-apt" deb package name

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -147,7 +147,7 @@ $(DOWNLOAD $(HOMEBREW), Homebrew, $(CONSOLE brew install dmd))
 $(DOWNLOAD $(UBUNTU) $(DEBIAN), Ubuntu/Debian, $(LINK2 http://d-apt.sourceforge.net/, APT repository)
 $(CONSOLE sudo wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
 sudo apt-get update && sudo apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
-sudo apt-get update && sudo apt-get install dmd-bin)
+sudo apt-get update && sudo apt-get install dmd-compiler)
 )
 
 $(DOWNLOAD $(OPENSUSE), OpenSUSE Tumbleweed, $(CONSOLE sudo zypper install dmd))


### PR DESCRIPTION
Update to the new "dmd-compiler" deb package name.