### PR TITLE
Show all contributors of the upcoming release

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -733,12 +733,25 @@ LOOSE_CHANGELOG_FILES:=$(wildcard $(DMD_DIR)/changelog/*.dd) \
 changelog/next-version: ${DMD_DIR}/VERSION
 	$(eval NEXT_VERSION:=$(shell changelog/next_version.sh ${DMD_DIR}/VERSION))
 
-changelog/pending.dd: changelog/next-version | ${STABLE_DMD} ../tools ../installer
-	[ -f changelog/pending.dd ] || $(STABLE_RDMD) $(TOOLS_DIR)/changed.d \
-		$(CHANGELOG_VERSION_LATEST) -o changelog/pending.dd --version "${NEXT_VERSION}" \
-		--date "To be released" --nightly
+changelog/pending.dd: $(TOOLS_DIR)/contributors.d $(TOOLS_DIR)/changed.d $(LOOSE_CHANGELOG_FILES) changelog/next-version | ${STABLE_DMD} $(TOOLS_DIR) $(INSTALLER_DIR)
+	$(STABLE_RDMD) $(TOOLS_DIR)/changed.d $(CHANGELOG_VERSION_LATEST) -o $@ \
+	--version "${NEXT_VERSION} (upcoming)" --date "To be released" --nightly
+	perl -i -0pe 's/[)][^)]*\$$[(]CHANGELOG/\$$(H3 Contributors to this release (\$$(NR_CONTRIBUTORS)))\n\$$(INTRO_CONTRIBUTORS)\n\$$(UL\nCONTRIBUTORS_TAG\n)\n)\n\$$(CHANGELOG/sg' $@
+	$(STABLE_RDMD) $< --format=ddoc "v$(LATEST)..master" > $G/contributors_ddoc
+	contributors=$$(cat $G/contributors_ddoc | sed ':a;N;$$!ba;s/\n/\\n/g' | sed 's/\$$/\\$$/g') && \
+		sed "s/CONTRIBUTORS_TAG/$${contributors}/" -i $@
+	sed "s/Macros:/Macros:\n    D_CONTRIBUTOR=\$$(LI \$$1)/" -i $@
+	sed "s/Macros:/Macros:\n    NR_CONTRIBUTORS=$$(cat $G/contributors_ddoc | wc -l)/" -i $@
+	sed "s/Macros:/Macros:\n    INTRO_CONTRIBUTORS=A huge thanks goes to all the awesome people who made this release possible./" -i $@
 
 pending_changelog: $(LOOSE_CHANGELOG_FILES) changelog/pending.dd html
 	@echo "Please open file:///$(shell pwd)/web/changelog/pending.html in your browser"
+
+################################################################################
+# List all contributors to the upcoming release
+################################################################################
+
+contributors: $(TOOLS_DIR)/contributors.d | $(STABLE_RDMD)
+	$(STABLE_RDMD) $< --format=name "v$(LATEST)..master"
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)


### PR DESCRIPTION
An initial start at showing this information in the generated changelog.

![image](https://user-images.githubusercontent.com/4370550/33791725-c41eae7c-dc90-11e7-9136-4338e1c9751a.png)
...

This is proof of concept as I would prefer to go without the ugly perl replace hack, i.e. by having clearer templates in the changelog generator (https://github.com/dlang/tools/pull/252).
OTOH this is ready now, works and can be shown on the next changelog. We can always improve it once https://github.com/dlang/tools/pull/252 is in.

This currently only adds the list of contributors to the pending changelog file, but as the changelog generation will be changed soon (e.g. https://github.com/dlang/dlang.org/pull/1907), imho it's better to start small.