### PR TITLE
[EASY] [PDF] Define D as a distinct language for the listings package

### DIFF
--- a/latex.ddoc
+++ b/latex.ddoc
@@ -38,14 +38,14 @@ CODE_PIPE=\lstinline^|^
 CODE_RCURL=\verb|}|
 COMMA=,
 CONSOLE=$(TT $0)
-CPPCODE=\lstset{language=C++}\lstinline|$0|\lstset{language=C++}
+CPPCODE=\lstset{language=C++}\lstinline|$0|\lstset{language=D}
 CROSS=$\times$
 _=
 
 CPPLISTING=\lstset{language=C++}
 \begin{lstlisting}
 $0\end{lstlisting}
-\lstset{language=C++}
+\lstset{language=D}
 _=
 
 D=\lstinline|$0|
@@ -390,36 +390,28 @@ DDOC=% Copyright (c) 1999-$(YEAR) by Digital Mars
 \hypersetup{pdftitle={D Programming Language Specification}}
 \hypersetup{colorlinks=true,linkcolor=blue,urlcolor=Blue}
 
-\def\commentstyle{%
-  \color{OliveGreen}%
-  \textsl%
+% D language definition for the listings package
+\lstdefinelanguage{D}[ANSI]{C++}{basicstyle={\ttfamily}, basewidth={0.5em,0.5em}, breakatwhitespace=true, columns=fullflexible, commentstyle=\color{OliveGreen}\textsl, escapeinside={/*[}{]*/}, fontadjust=true, keepspaces=true, keywordstyle=\color{NavyBlue}, linewidth=\textwidth, morecomment=[n]{/+}{+/}, morekeywords={
+    @disable, @property,
+    @safe, @system, @trusted, abstract, alias, align, asm, assert,
+    auto, body, bool, break, byte, case, cast, catch, cdouble,
+    cent, cfloat, char, class, const, continue, creal, dchar,
+    debug, default, delegate, delete, deprecated, do, double,
+    else, enum, export, extern, false, final, finally, float, for,
+    foreach, foreach_reverse, function, goto, idouble, if, ifloat,
+    immutable, import, in, inout, int, interface, invariant,
+    ireal, is, lazy, long, mixin, module, new, nothrow, null, out,
+    override, package, pragma, private, protected, public, real,
+    ref, return, scope, shared, short, static, struct, super,
+    switch, synchronized, template, this, throw, true, try,
+    typedef, typeid, typeof, ubyte, ucent, uint, ulong, union,
+    unittest, ushort, version, void, volatile, wchar, while,
+    with, \#!, macro, pure, __FILE__, __FILE_FULL_PATH__, __MODULE__,
+    __LINE__, __FUNCTION__, __PRETTY_FUNCTION__, __gshared, __traits,
+    __vector, __parameters},stringstyle=\color{BrickRed},
 }
-
-\newcommand\ccbox[1]{\mbox{\cc{#1}}}
-
-\lstset{language=C++,basicstyle=\ttfamily,escapeinside={/*[}{]*/}}
-\lstset{commentstyle=\commentstyle,morecomment=[n]{/+}{+/}}
-\lstset{stringstyle=\color{BrickRed},keywordstyle=\color{NavyBlue}}
-\lstset{basewidth={0.5em,0.5em},fontadjust=true}
-\lstset{linewidth=\textwidth}
-\lstset{morekeywords={@disable,   @property,
-        @safe, @system, @trusted, abstract, alias, align, asm, assert,
-        auto,  body, bool,  break, byte,  case, cast,  catch, cdouble,
-        cent,  cfloat,  char, class,  const,  continue, creal,  dchar,
-        debug,  default,  delegate,  delete, deprecated,  do,  double,
-        else, enum, export, extern, false, final, finally, float, for,
-        foreach, foreach_reverse, function, goto, idouble, if, ifloat,
-        immutable,  import,  in,  inout,  int,  interface,  invariant,
-        ireal, is, lazy, long, mixin, module, new, nothrow, null, out,
-        override, package,  pragma, private, protected,  public, real,
-        ref,  return,  scope, shared,  short,  static, struct,  super,
-        switch,  synchronized,  template,   this,  throw,  true,  try,
-        typedef,  typeid, typeof,  ubyte, ucent,  uint,  ulong, union,
-        unittest,  ushort,  version,  void,  volatile,  wchar,  while,
-        with,\#!, macro, pure, __FILE__,__FILE_FULL_PATH__,__MODULE__,
-        __LINE__,__FUNCTION__,__PRETTY_FUNCTION__,__gshared, __traits,
-        __vector, __parameters}}
-\lstset{morecomment=[n]{/+}{+/}}
+% Default language is D, if changed locally it should be restored.
+\lstset{language=D}
 
 % Nice line breaks.
 % See http://www.bollchen.de/blog/2011/04/good-looking-line-breaks-with-the-listings-package/


### PR DESCRIPTION
The listings LaTeX package allows code formatting and highlighting in various languages. Previously we hacked the D language keywords on top of listings' C++ definition. This PR defines D as a distinct language.