### PR TITLE
[TRIVIAL] [PDF] Tweak empty lines to avoid listings bug

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -219,7 +219,6 @@ struct S
     int b;    // placed at offset 4
     long c;   // placed at offset 8
 }
-
 auto sz = S.sizeof;  // 16
 --------
 
@@ -240,7 +239,6 @@ struct S
     int b;    // placed at offset 1
     long c;   // placed at offset 5
 }
-
 auto sz = S.sizeof;  // 16
 --------
 
@@ -256,7 +254,6 @@ align (2) struct S
     int b;    // placed at offset 1
     long c;   // placed at offset 5
 }
-
 auto sz = S.sizeof;  // 14
 --------
 
@@ -271,7 +268,6 @@ struct S
     byte b;   // placed at offset 4
     short c;  // placed at offset 8
 }
-
 auto sz = S.sizeof;  // 12
 --------
 


### PR DESCRIPTION
Package listings has a bug whereby sometimes it generates invalid LaTeX code when a listing straddles a page boundary. I could not find a fix for it yet, so from time to time the text needs tweaking. Any helpful info, please lmk.