### PR TITLE
Disable cache for CircleCi

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,6 @@ dependencies:
     - ./circleci.sh install-deps
     - ./circleci.sh install-make
     - ./circleci.sh setup-repos
-  cache_directories:
-    - "~/dlang"
 
 test:
   override:

--- a/circleci.sh
+++ b/circleci.sh
@@ -77,6 +77,8 @@ setup_repos()
     # Merge upstream branch with changes, s.t. we check with the latest changes
     if [ -n "${CIRCLE_PR_NUMBER:-}" ]; then
         local current_branch=$(git rev-parse --abbrev-ref HEAD)
+        # work around weird CircleCi bug, see https://github.com/dlang/dlang.org/pull/1952
+        git remote remove upstream || true
         git config user.name dummyuser
         git config user.email dummyuser@dummyserver.com
         git remote add upstream https://github.com/dlang/dlang.org.git


### PR DESCRIPTION
Looks like this is the reason for CircleCI failing at https://github.com/dlang/dlang.org/pull/1945

```
+ git remote add upstream https://github.com/dlang/dlang.org.git
fatal: remote upstream already exists.
```