### PR TITLE
Fix Issue 18067 - Benchmark example is broken on the frontpage

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -162,7 +162,8 @@ $(EXTRA_EXAMPLE_RUNNABLE Initialize an Array in parallel,
 ----
 void main()
 {
-    import std.datetime, std.math, std.parallelism, std.stdio;
+    import std.datetime.stopwatch : benchmark;
+    import std.math, std.parallelism, std.stdio;
 
     auto logs = new double[100_000];
     auto bm = benchmark!({
@@ -172,8 +173,8 @@ void main()
         foreach (i, ref elem; logs.parallel)
             elem = log(1.0 + i);
     })(100); // number of executions of each tested function
-    writefln("Linear init: %s msecs", bm[0].msecs);
-    writefln("Parallel init: %s msecs", bm[1].msecs);
+    writefln("Linear init: %s msecs", bm[0].total!"msecs");
+    writefln("Parallel init: %s msecs", bm[1].total!"msecs");
 }
 ----
 )


### PR DESCRIPTION
I recently (-> https://github.com/dlang-tour/core-exec/pull/12) fixed the automatic Docker image deployment toolchain for run.dlang.io, which means that DMD 2.077(.1) is available for the first time since a couple of days.

So let's better fix our examples sooner than later.

Note that the examples which depend on `stdin` also don't work, because of DPaste's poor availability.
The docker image used for the Dlang-Tour already [supports `stdin` input](https://github.com/dlang-tour/core-exec/blob/master/entrypoint.sh#L22).
They just need to passed to Docker image [here](https://github.com/dlang-tour/core/blob/master/source/exec/docker.d#L127).