### PR TITLE
Use run.dlang.io for all examples

### DIFF
--- a/js/run.js
+++ b/js/run.js
@@ -99,10 +99,18 @@ var backends = {
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests
     contentType: "text/plain; charset=UTF-8",
     requestTransform: function(data) {
-        return JSON.stringify({
+        var req = {
             source: data.code,
             compiler: dmdCompilerBranch
-        });
+        }
+        // only send set attributes
+        if (data.stdin) {
+          req.stdin = data.stdin;
+        }
+        if (data.args) {
+          req.args = data.args;
+        }
+        return JSON.stringify(data);
     },
     parseOutput: function(data, opts) {
       var r = {};
@@ -231,11 +239,6 @@ function setupTextarea(el, opts)
     }, opts);
 
     var backend = backends[opts.backend || "tour"];
-    // only use DPaste if absolutely necessary (stdin or args provided)
-    // DPaste is very restrictive compared to the Dockerized DLang Tour backend
-    if (opts.args || opts.stdin) {
-      backend = backends.dpaste;
-    }
 
     if (!!opts.parent)
         var parent = opts.parent;


### PR DESCRIPTION
This can be merged once https://github.com/dlang-tour/core/pull/619 has been deployed.

At the moment we use DPaste only if absolutely necessary (e.g. examples contains stdin or args).
See also: https://github.com/dlang/dlang.org/pull/1799

https://github.com/dlang-tour/core/pull/619 adds support for the `args` and `stdin` parameter in the request object, s.t. we can finally migrate off DPaste.