### PR TITLE
[TRIVIAL] [PDF] Fix table Overloadable Index Unary Operators

### DIFF
--- a/latex.ddoc
+++ b/latex.ddoc
@@ -260,6 +260,7 @@ SINGLEQUOTE=`$0'
 SMALL=\small{$0}
 SPEC_S=$(LAYOUT , $1, $(ARGS $+))
 SUB=\textsubscript{$0}
+SUBSCRIPT=\textsubscript{$0}
 SUP=\textsuperscript{$0}
 _=
 

--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -106,27 +106,27 @@ $(H3 $(LNAME2 index_unary_operators, Overloading Index Unary Operators))
 	$(TABLE2 Overloadable Index Unary Operators,
 	$(THEAD $(I op), $(I rewrite))
 	$(TROW
-	$(D -)$(I a)$(D [$(ARGUMENTS)]),
-	$(ARGS $(I a)$(D .opIndexUnary!("-")$(LPAREN)$(ARGUMENTS)$(RPAREN))))
+	$(D -)$(I a)`[`$(ARGUMENTS)`]`,
+	$(ARGS $(I a)`.opIndexUnary!("-")$(LPAREN)`$(ARGUMENTS)`$(RPAREN)`))
 	$(TROW
-	$(D +)$(I a)$(D [$(ARGUMENTS)]),
-	$(I a)$(D .opIndexUnary!("+")$(LPAREN)$(ARGUMENTS)$(RPAREN))
+	$(D +)$(I a)`[`$(ARGUMENTS)`]`,
+	$(I a)$(D .opIndexUnary!("+")$(LPAREN))$(ARGUMENTS)`$(RPAREN)`
 	)
 	$(TROW
-	$(D ~)$(I a)$(D [$(ARGUMENTS)]),
-	$(I a)$(D .opIndexUnary!("~")$(LPAREN)$(ARGUMENTS)$(RPAREN))
+	`~`$(I a)`[`$(ARGUMENTS)`]`,
+	$(I a)$(D .opIndexUnary!("~")$(LPAREN))$(ARGUMENTS)`$(RPAREN)`
 	)
 	$(TROW
-	$(D *)$(I a)$(D [$(ARGUMENTS)]),
-	$(I a)$(D .opIndexUnary!("*")$(LPAREN)$(ARGUMENTS)$(RPAREN))
+	`*`$(I a)`[`$(ARGUMENTS)`]`,
+	$(I a)$(D .opIndexUnary!("*")$(LPAREN))$(ARGUMENTS)`$(RPAREN)`
 	)
 	$(TROW
-	$(D ++)$(I a)$(D [$(ARGUMENTS)]),
-	$(I a)$(D .opIndexUnary!("++")$(LPAREN)$(ARGUMENTS)$(RPAREN))
+	`++`$(I a)`[`$(ARGUMENTS)`]`,
+	$(I a)`.opIndexUnary!("++")$(LPAREN)`$(ARGUMENTS)`$(RPAREN)`
 	)
 	$(TROW
-	$(D --)$(I a)$(D [$(ARGUMENTS)]),
-	$(I a)$(D .opIndexUnary!("--")$(LPAREN)$(ARGUMENTS)$(RPAREN))
+	`--`$(I a)`[`$(ARGUMENTS)`]`,
+	$(I a)`.opIndexUnary!("--")$(LPAREN)`$(ARGUMENTS)`$(RPAREN)`
 	)
 	)
 


### PR DESCRIPTION
before: 
![a](https://user-images.githubusercontent.com/566679/33917778-163eac1c-df7e-11e7-96c5-bc62c00ea1e6.png)
