### PR TITLE
Add an initial CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,24 @@
+# See also:
+# - https://github.com/blog/2392-introducing-code-owners
+# - https://help.github.com/articles/about-codeowners/
+
+# Each line is a file pattern followed by one or more owners (sorted alphabetically).
+# Please feel free to add yourself to a module or create a new mapping.
+# Ideally each module should have two or more owners.
+
+# Code owners are automatically requested for review
+# when someone opens a pull request that modifies code that they own.
+# Later matches take precedence.
+
+spec/* @andralex @WalterBright
+foundation.dd @andralex @acehreli @WalterBright
+
+posix.mak @andralex @CyberShadow @MartinNowak @wilzbach
+css/* @CyberShadow @MartinNowak @wilzbach
+js/* @CyberShadow @MartinNowak @wilzbach
+
+assert_writeln_magic.d @wilzbach
+orgs-using-d.d @wilzbach
+chm* @CyberShadow
+
+dpl-docs/ @s-ludwig


### PR DESCRIPTION
Similar to Phobos an attempt to define ownership and help contributors figuring out whom to ping. 

CC @andralex @WalterBright @acehreli @s-ludwig @CyberShadow @MartinNowak 

This is far from complete, but hopefully this files adapts gradually over time.
Or maybe you already have an improvement suggestion?