### PR TITLE
[LaTeX] Use lstlisting instead of tt for CONSOLE

### DIFF
--- a/latex.ddoc
+++ b/latex.ddoc
@@ -37,7 +37,8 @@ CODE_PERCENT=\verb|%|
 CODE_PIPE=\lstinline^|^
 CODE_RCURL=\verb|}|
 COMMA=,
-CONSOLE=$(TT $0)
+CONSOLE=\lstset{language=bash}\begin{lstlisting}
+$0\end{lstlisting}\lstset{language=D}
 CPPCODE=\lstset{language=C++}\lstinline|$0|\lstset{language=D}
 CROSS=$\times$
 _=

--- a/spec/betterc.dd
+++ b/spec/betterc.dd
@@ -26,7 +26,7 @@ extern(C) void main()
 ---
 
 $(CONSOLE
-> dmd -betterC hello.d $(AMP)$(AMP) ./hello
+> dmd -betterC hello.d && ./hello
 Hello betterC
 )
 

--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -89,7 +89,7 @@ void main()
 
 $(CONSOLE
 > g++ -c foo.cpp
-> dmd bar.d foo.o -L-lstdc++ $(ANDAND) ./bar
+> dmd bar.d foo.o -L-lstdc++ && ./bar
 i = 1
 j = 2
 k = 3
@@ -154,7 +154,7 @@ void bar()
 
 $(CONSOLE
 > dmd -c foo.d
-> g++ bar.cpp foo.o -lphobos2 -pthread -o bar $(ANDAND) ./bar
+> g++ bar.cpp foo.o -lphobos2 -pthread -o bar && ./bar
 i = 6
 j = 7
 k = 8
@@ -307,7 +307,7 @@ $(P Compiling, linking, and running produces the output:)
 
 $(CONSOLE
 > g++ base.cpp
-> dmd main.d base.o $(ANDAND) ./main
+> dmd main.d base.o && ./main
 5
 20
 a = 1
@@ -370,7 +370,7 @@ int callE(E *e)
 
 $(CONSOLE
 > dmd -c base.d
-> g++ klass.cpp base.o -lphobos2 -pthread -o klass $(ANDAND) ./klass
+> g++ klass.cpp base.o -lphobos2 -pthread -o klass && ./klass
 i = 11
 j = 12
 k = 13
@@ -491,7 +491,7 @@ $(P Compiling, linking, and running produces the output:)
 
 $(CONSOLE
 > g++ -c template.cpp
-> dmd main.d template.o -L-lstdc++ $(ANDAND) ./main
+> dmd main.d template.o -L-lstdc++ && ./main
 A
 B
 C
@@ -915,4 +915,3 @@ $(SPEC_SUBNAV_PREV_NEXT interfaceToC, Interfacing to C, objc_interface, Interfac
 Macros:
     CHAPTER=33
     TITLE=Interfacing to C++
-    ANDAND=$(AMP)$(AMP)


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/4370550/33921586-194602e2-dfc5-11e7-935a-1a076ba8db17.png)

or 

![image](https://user-images.githubusercontent.com/4370550/33921599-29b5c130-dfc5-11e7-9758-21afd6126bdc.png)


After:


![image](https://user-images.githubusercontent.com/4370550/33921614-4b594ad2-dfc5-11e7-8d3d-865d4372bdcf.png)


or: 

![image](https://user-images.githubusercontent.com/4370550/33921627-68b08050-dfc5-11e7-97c2-19bfdf64c2ad.png)

(yellow coloring comes from Okular)