### PR TITLE
Repair ddmd -> dmd transition

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -58,9 +58,6 @@ PHOBOS_LATEST_DIR=${PHOBOS_DIR}-${LATEST}
 $(shell [ ! -d $(DMD_DIR) ] && git clone --depth=1 ${GIT_HOME}/dmd $(DMD_DIR))
 $(shell [ ! -d $(DRUNTIME_DIR) ] && git clone --depth=1 ${GIT_HOME}/druntime $(DRUNTIME_DIR))
 
-# Keep during the ddmd -> dmd transition
-DMD_SRC_NAME=$(shell if [ -d $(DMD_DIR)/src/ddmd ] ; then echo "ddmd" ; else echo "dmd"; fi)
-
 ################################################################################
 # Automatically generated directories
 GENERATED=.generated
@@ -93,14 +90,17 @@ STABLE_RDMD=$(STABLE_DMD_BIN_ROOT)/rdmd --compiler=$(STABLE_DMD) -conf=$(STABLE_
 DUB=$(STABLE_DMD_BIN_ROOT)/dub
 
 # exclude lists
+# keep the ddmd excludes during the ddmd -> dmd transition
 MOD_EXCLUDES_PRERELEASE=$(addprefix --ex=, gc. rt. core.internal. core.stdc.config core.sys.	\
 	std.algorithm.internal std.c. std.concurrencybase std.internal. std.regex.internal.  \
 	std.windows.iunknown std.windows.registry etc.linux.memoryerror	\
 	std.experimental.ndslice.internal std.stdiobase \
 	std.typetuple \
 	tk. msvc_dmc msvc_lib \
-	$(DMD_SRC_NAME).libmach $(DMD_SRC_NAME).libmscoff $(DMD_SRC_NAME).objc_glue \
-	$(DMD_SRC_NAME).scanmach $(DMD_SRC_NAME).scanmscoff)
+	ddmd.libmach ddmd.libmscoff ddmd.objc_glue \
+	ddmd.scanmach ddmd.scanmscoff \
+	dmd.libmach dmd.libmscoff dmd.objc_glue \
+	dmd.scanmach dmd.scanmscoff)
 
 MOD_EXCLUDES_LATEST=$(MOD_EXCLUDES_PRERELEASE)
 
@@ -294,18 +294,22 @@ ${GENERATED}/${LATEST}.ddoc :
 
 ${GENERATED}/modlist-${LATEST}.ddoc : modlist.d ${STABLE_DMD} $(DRUNTIME_LATEST_DIR) $(PHOBOS_LATEST_DIR) $(DMD_LATEST_DIR)
 	mkdir -p $(dir $@)
+	# Keep during the ddmd -> dmd transition
+	DMD_SRC_NAME=$$(if [ -d $(DMD_LATEST_DIR)/src/ddmd ] ; then echo "ddmd" ; else echo "dmd"; fi) && \
 	$(STABLE_RDMD) modlist.d $(DRUNTIME_LATEST_DIR) $(PHOBOS_LATEST_DIR) $(DMD_LATEST_DIR) $(MOD_EXCLUDES_LATEST) \
-		$(addprefix --dump , object std etc core $(DMD_SRC_NAME)) >$@
+		$(addprefix --dump , object std etc core) --dump "$${DMD_SRC_NAME}" >$@
 
 ${GENERATED}/modlist-release.ddoc : modlist.d ${STABLE_DMD} $(DRUNTIME_DIR) $(PHOBOS_DIR) $(DMD_DIR)
 	mkdir -p $(dir $@)
+	DMD_SRC_NAME=$$(if [ -d $(DMD_DIR)/src/ddmd ] ; then echo "ddmd" ; else echo "dmd"; fi) && \
 	$(STABLE_RDMD) modlist.d $(DRUNTIME_DIR) $(PHOBOS_DIR) $(DMD_DIR) $(MOD_EXCLUDES_RELEASE) \
-		$(addprefix --dump , object std etc core $(DMD_SRC_NAME)) >$@
+		$(addprefix --dump , object std etc core) --dump "$${DMD_SRC_NAME}" >$@
 
 ${GENERATED}/modlist-prerelease.ddoc : modlist.d ${STABLE_DMD} $(DRUNTIME_DIR) $(PHOBOS_DIR) $(DMD_DIR)
 	mkdir -p $(dir $@)
+	DMD_SRC_NAME=$$(if [ -d $(DMD_DIR)/src/ddmd ] ; then echo "ddmd" ; else echo "dmd"; fi) && \
 	$(STABLE_RDMD) modlist.d $(DRUNTIME_DIR) $(PHOBOS_DIR) $(DMD_DIR) $(MOD_EXCLUDES_PRERELEASE) \
-		$(addprefix --dump , object std etc core $(DMD_SRC_NAME)) >$@
+		$(addprefix --dump , object std etc core) --dump "$${DMD_SRC_NAME}" >$@
 
 # Run "make -j rebase" for rebasing all dox in parallel!
 rebase: rebase-dlang rebase-dmd rebase-druntime rebase-phobos


### PR DESCRIPTION
Required for https://github.com/dlang/dmd/pull/7135

One of the various Makefile changes broke the transition stage.
The idea is that once we switch to `dmd`, `stable` (aka `latest` is still at `ddmd`), the best way to check for this is querying directly in the respective target.
For the excludes list duplicates are no problem.