### PR TITLE
Macros for emitting a contributors list as part of the changelog generation

### DIFF
--- a/changelog/changelog.ddoc
+++ b/changelog/changelog.ddoc
@@ -34,6 +34,13 @@ BUGSTITLE_TEXT_HEADER=$(BUGSTITLE $1, $+)
 BUGSTITLE_TEXT_BODY=$(BUGSTITLE $1, $+)
 BUGSTITLE_BUGZILLA=$(BUGSTITLE $1, $+)
 
+_= The following D_CONTRIBUTOR macros are emitted by the ../tools/changed.d script
+D_CONTRIBUTORS_HEADER=$(H3 Contributors to this release ($1))
+$(P A huge thanks goes to all the awesome people who made this release possible.)
+D_CONTRIBUTORS=$(UL $1)
+D_CONTRIBUTOR=$(LI $1)
+D_CONTRIBUTORS_FOOTER=
+
 
 BUGZILLA = <a href="https://issues.dlang.org/show_bug.cgi?id=$0">Bugzilla $0</a>
 CPPBUGZILLA = <a href="http://bugzilla.digitalmars.com/issues/show_bug.cgi?id=$0">Bugzilla $0</a>

--- a/posix.mak
+++ b/posix.mak
@@ -864,7 +864,7 @@ changelog/next-version: ${DMD_DIR}/VERSION
 	$(eval NEXT_VERSION:=$(shell changelog/next_version.sh ${DMD_DIR}/VERSION))
 
 changelog/pending.dd: changelog/next-version | ${STABLE_DMD} ../tools ../installer
-	[ -f changelog/pending.dd ] || $(STABLE_RDMD) $(TOOLS_DIR)/changed.d \
+	[ -f changelog/pending.dd ] || $(STABLE_RDMD) -version=Contributors_Lib $(TOOLS_DIR)/changed.d \
 		$(CHANGELOG_VERSION_LATEST) -o changelog/pending.dd --version "${NEXT_VERSION}" \
 		--date "To be released"
 


### PR DESCRIPTION
Version 1: https://github.com/dlang/dlang.org/pull/1949 patching the generated changelog file with `perl` and `sed`
Version 2: https://github.com/dlang/dlang.org/pull/1977 generate separate Ddoc macro files, suited for inclusion into the changelog (companion PR: https://github.com/dlang/tools/pull/273)
Version 3: (this PR) Let the changelog generation do the work and simply define the proper macros (companion PR: https://github.com/dlang/tools/pull/274)

...
distant future
...

Version 4: emit & store simple intermediate format from `changed.d`, e.g. YAML
Parse and convert the YAML to HTML as part of the dlang.org build process

(this needs to be merged before pulling https://github.com/dlang/tools/pull/274)