### PR TITLE
Run CircleCi without network traffic

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -108,7 +108,7 @@ run_make()
     export PATH="$(pwd)/make:$PATH"
     make -v
 
-    make -f posix.mak RELEASE=1 release -j5 html dmd-release druntime-release phobos-release d-release.tag
+    make -f posix.mak -j$N RELEASE=1 DIFFABLE=1 release
 }
 
 case $1 in

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -108,7 +108,8 @@ run_make()
     export PATH="$(pwd)/make:$PATH"
     make -v
 
-    make -f posix.mak -j$N RELEASE=1 DIFFABLE=1 release
+    # -j1 is used for a better error log
+    make -f posix.mak -j1 RELEASE=1 DIFFABLE=1 release
 }
 
 case $1 in


### PR DESCRIPTION
Sometimes CircleCi fails randomly as it tries to access the `dmd` binary before it's built. I hope that it's due to `-j5`.

For a failing run, see e.g. https://circleci.com/gh/dlang/dlang.org/121

Also `release` defines all these target, so it's better to use the more generic target.
As an additional protection against faulty network, I added `DIFFABLE=1` too.