### PR TITLE
Fix Issue 18081 - dlangspec.pdf: don't escape dollars in code examples

### DIFF
--- a/latex.ddoc
+++ b/latex.ddoc
@@ -67,7 +67,8 @@ DDOC_COMMENT=% $0
 DDOC_BLANKLINE = \par
 DDOC_KEYWORD=$0
 DDOC_UNDEFINED_MACRO = $(DDOC_COMMENT UNDEFINED MACRO: $1)
-DDOCCODE=$(D_CODE $0)
+DDOCCODE=\lstset{language=html}\begin{lstlisting}
+$0\end{lstlisting}\lstset{language=D}
 DDSUBLINK=$(LINK2 $1.html$(HASH)$2, $3)
 _=
 

--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -420,7 +420,7 @@ $(DD The macros section follows the same syntax as the $(B Params:) section.
  *	FOO =	now is the time for
  *		all good men
  *	BAR =	bar
- *	MAGENTA =   <font color="magenta">$(DOLLAR)0</font>
+ *	MAGENTA =   <font color="magenta">$0</font>
  */
 ------------------------------------
 
@@ -496,13 +496,13 @@ $(P
 
 $(P
     Text inside these sections will be escaped according to the rules described above,
-    then wrapped in a $(D $(DOLLAR)(DDOC_BACKQUOTED)) macro. By default, this macro expands
+    then wrapped in a `$(DDOC_BACKQUOTED)` macro. By default, this macro expands
     to be displayed as an inline text span, formatted as code.
 )
 
 $(P
     A literal backtick character can be output either as a non-paired $(BACKTICK) on a single
-    line or by using the `$(DOLLAR)(BACKTICK)` macro.
+    line or by using the `$(BACKTICK)` macro.
 )
 
 ---


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/4370550/34025554-bf96f6c4-e150-11e7-90b8-5970fa4e0ddc.png)


After:

![image](https://user-images.githubusercontent.com/4370550/34025551-b5332914-e150-11e7-84b8-8ce98cc5e0cb.png)

-----

Before:

![image](https://user-images.githubusercontent.com/4370550/34025569-d59c3c7c-e150-11e7-8104-7929ed75e603.png)


After:

![image](https://user-images.githubusercontent.com/4370550/34025609-03b172ee-e151-11e7-98eb-b156bbbca0da.png)

----

See also: https://github.com/dlang/dlang.org/pull/1983

