### PR TITLE
Reserve version prefix Std for Phobos

### DIFF
--- a/spec/version.dd
+++ b/spec/version.dd
@@ -326,6 +326,7 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
 	$(TROW $(ARGS $(D D_NoBoundsChecks)) , $(ARGS Array bounds checks are disabled
 		(command line switch $(DDSUBLINK dmd, switch-boundscheck, $(TT -boundscheck=off)))))
 	$(TROW $(ARGS $(D D_ObjectiveC)) , $(ARGS The target supports interfacing with Objective-C))
+	$(TROW $(ARGS $(D Std)) , $(ARGS Define when building the standard library))
 	$(TROW $(ARGS $(D unittest)) , $(ARGS $(DDLINK spec/unittest, Unit Tests, Unit tests) are enabled
 		(command line switch $(DDSUBLINK dmd, switch-unittest, $(TT -unittest)))))
 	$(TROW $(ARGS $(D assert)) , $(ARGS Checks are being emitted for $(GLINK2 expression, AssertExpression)s))


### PR DESCRIPTION
Per https://github.com/dlang/phobos/pull/5927#issuecomment-352014910

Below the spec states:

> all identifiers derived from the ones listed above by appending any character(s) are reserved. This	 	the ones listed above by appending any character(s) are reserved