### PR TITLE
Fix Issue 18082 - Ubuntu/Debian repository installation should mention dub

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -183,7 +183,7 @@ $(DOWNLOAD_OTHER $(HOMEBREW), Homebrew, $(CONSOLE brew install dmd))
 $(DOWNLOAD_OTHER $(UBUNTU) $(DEBIAN), Ubuntu/Debian, $(LINK2 http://d-apt.sourceforge.net/, APT repository)
 $(CONSOLE sudo wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
 sudo apt-get update && sudo apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
-sudo apt-get update && sudo apt-get install dmd-compiler)
+sudo apt-get update && sudo apt-get install dmd-compiler dub)
 )
 
 $(DOWNLOAD_OTHER $(OPENSUSE), OpenSUSE Tumbleweed, $(CONSOLE sudo zypper install dmd))


### PR DESCRIPTION
As we are already at the topic:
- there's an [internal discussion](https://github.com/orgs/dlang-community/teams/all/discussions/2) going on about moving the d-apt repository to dlang-community
- it was discussed on the [NG](http://forum.dlang.org/post/mailman.704.1512753538.9493.digitalmars-d-announce@puremagic.com) that `rdmd` will be moved into `dmd-compiler`
- even though DMD is now fully open source since May this year, no one has yet stepped up & submitted the package to Debian upstream

CC @leandro-lucarella-sociomantic @jordisayol 