### PR TITLE
Use CLI flags instead of environment variables for dspec_tester.d

### DIFF
--- a/dspec_tester.d
+++ b/dspec_tester.d
@@ -50,6 +50,8 @@ int main(string[] args)
         return 1;
     }
 
+    stderr.writefln("DMD: %s", config.dmdBinPath);
+
     // Find all examples in the specification
     auto r = regex(`SPEC_RUNNABLE_EXAMPLE\n\s*---+\n[^-]*---+\n\s*\)`, "s");
     foreach (file; specDir.dirEntries("*.dd", SpanMode.depth).parallel(1))
@@ -88,11 +90,12 @@ Returns: the exit code of the compiler invocation.
 */
 auto compileAndCheck(R)(R buffer)
 {
-    import std.process;
+    import std.process : pipeProcess, Redirect, wait;
+    import std.process : EnvConfig = Config;
     import std.uni : isWhite;
 
     auto pipes = pipeProcess([config.dmdBinPath, "-c", "-o-", "-"],
-            Redirect.stdin | Redirect.stdout | Redirect.stderr);
+            Redirect.all, null, EnvConfig.newEnv);
 
     static mainRegex = regex(`(void|int)\s+main`);
     const hasMain = !buffer.matchFirst(mainRegex).empty;

--- a/dspec_tester.d
+++ b/dspec_tester.d
@@ -39,6 +39,7 @@ int main(string[] args)
     auto helpInformation = getopt(
         args,
         "l|lines", "Show the line numbers on errors", &config.printLineNumbers,
+        "compiler", "D compiler to use", &config.dmdBinPath,
     );
 
     if (helpInformation.helpWanted)

--- a/posix.mak
+++ b/posix.mak
@@ -589,7 +589,7 @@ ${DMD_DIR}/VERSION : ${DMD_DIR}
 ################################################################################
 
 $(DMD) : ${DMD_DIR}
-	${MAKE} --directory=${DMD_DIR}/src -f posix.mak AUTO_BOOTSTRAP=1
+	${MAKE} --directory=${DMD_DIR}/src -f posix.mak AUTO_BOOTSTRAP=1 all
 
 $(DMD_LATEST) : ${DMD_LATEST_DIR}
 	${MAKE} --directory=${DMD_LATEST_DIR}/src -f posix.mak AUTO_BOOTSTRAP=1
@@ -842,7 +842,10 @@ $(PHOBOS_LATEST_FILES_GENERATED): $(PHOBOS_LATEST_DIR_GENERATED)/%: $(PHOBOS_LAT
 
 test_dspec: dspec_tester.d $(STABLE_DMD) $(DMD)
 	@echo "Test the D Language specification"
-	$(STABLE_RDMD) $< --compiler=$(DMD)
+	env
+	cat $(DMD).conf
+	$(DMD) --version
+	$(STABLE_DMD) -run $< --compiler=$(DMD)
 
 test: $(ASSERT_WRITELN_BIN)_test test_dspec test/next_version.sh all
 	@echo "Searching for trailing whitespace"

--- a/posix.mak
+++ b/posix.mak
@@ -840,9 +840,9 @@ $(PHOBOS_LATEST_FILES_GENERATED): $(PHOBOS_LATEST_DIR_GENERATED)/%: $(PHOBOS_LAT
 # Style tests
 ################################################################################
 
-test_dspec: dspec_tester.d $(STABLE_DMD)
+test_dspec: dspec_tester.d $(STABLE_DMD) $(DMD)
 	@echo "Test the D Language specification"
-	$(STABLE_RDMD) $< --compiler=$(DMD_LATEST)
+	$(STABLE_RDMD) $< --compiler=$(DMD)
 
 test: $(ASSERT_WRITELN_BIN)_test test_dspec test/next_version.sh all
 	@echo "Searching for trailing whitespace"

--- a/posix.mak
+++ b/posix.mak
@@ -841,9 +841,8 @@ $(PHOBOS_LATEST_FILES_GENERATED): $(PHOBOS_LATEST_DIR_GENERATED)/%: $(PHOBOS_LAT
 ################################################################################
 
 test_dspec: dspec_tester.d $(STABLE_DMD)
-	# Temporarily allows failures, see https://github.com/dlang/dlang.org/pull/2006
 	@echo "Test the D Language specification"
-	-DMD=$(DMD_LATEST) $(STABLE_RDMD) $<
+	$(STABLE_RDMD) $< --compiler=$(DMD_LATEST)
 
 test: $(ASSERT_WRITELN_BIN)_test test_dspec test/next_version.sh all
 	@echo "Searching for trailing whitespace"


### PR DESCRIPTION
Trying to address https://github.com/dlang/tools/pull/275#issuecomment-352183720