### PR TITLE
No shallow clones for the latest repos (if not existent)

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -580,7 +580,7 @@ $G/%-${LATEST} :
 
 # Clone all main D repositories
 ${DMD_DIR} ${DRUNTIME_DIR} ${PHOBOS_DIR} ${TOOLS_DIR} ${INSTALLER_DIR}:
-	git clone --depth=1 ${GIT_HOME}/$(notdir $(@F)) $@
+	git clone ${GIT_HOME}/$(notdir $(@F)) $@
 
 ${DMD_DIR}/VERSION : ${DMD_DIR}
 


### PR DESCRIPTION
- These repositories are used for the contribution script
- DMD, Druntime and Phobos are already there anyhow
- tools and installer are really small

Also if someone does this locally, it's better to do a full clone as they can directly work on it.

I'm interested if this adds a few more names...