### PR TITLE
Build a reproducible PDF on DAutoTest

### DIFF
--- a/latex.ddoc
+++ b/latex.ddoc
@@ -123,6 +123,7 @@ LAYOUT=
 _=
 
 LATEX=$0
+LATEX_NO_DATE=
 LCURL=$\{$
 LEGACY_LNAME2=$(LNAME2 $+)
 LI=\item $0
@@ -394,6 +395,9 @@ DDOC=% Copyright (c) 1999-$(YEAR) by Digital Mars
 \usepackage{longtable}
 \usepackage[T1]{fontenc}
 \usepackage{MnSymbol}
+
+% For reproducible builds, fix the date if run on DAutoTest (empty by default)
+$(LATEX_NO_DATE)
 
 \premulticols=50pt
 \multicolsep=0pt

--- a/nodatetime.ddoc
+++ b/nodatetime.ddoc
@@ -1,2 +1,5 @@
 GEN_DATETIME=(no date time)
+LATEX_NO_DATE=\pdfinfoomitdate=1
+\pdftrailerid{}
+\pdfsuppressptexinfo=-1
 _=

--- a/posix.mak
+++ b/posix.mak
@@ -531,8 +531,8 @@ $W/dlangspec.mobi : \
 $G/dlangspec-consolidated.d : $(SPEC_DD) ${STABLE_DMD}
 	$(STABLE_RDMD) --force ../tools/catdoc.d -o$@ $(SPEC_DD)
 
-$G/dlangspec.tex : $G/dlangspec-consolidated.d $(DMD) $(DDOC) latex.ddoc
-	$(DMD) -conf= -Df$@ $(DDOC) latex.ddoc $<
+$G/dlangspec.tex : $G/dlangspec-consolidated.d $(DMD) $(DDOC) latex.ddoc $(NODATETIME)
+	$(DMD) -conf= -Df$@ $(DDOC) latex.ddoc $(NODATETIME) $<
 
 # Run twice to fix multipage tables and \ref uses
 $W/dlangspec.pdf : $G/dlangspec.tex | $W


### PR DESCRIPTION
From https://github.com/dlang/dlang.org/pull/2017#issuecomment-352737769

> Maybe it's as simple as setting a few variables: https://tex.stackexchange.com/questions/229605/reproducible-latex-builds-compile-to-a-file-which-always-hashes-to-the-same-va

And it really was that simple and works:

```
> diff -s spec.pdf web/dlangspec.pdf
Files spec.pdf and web/dlangspec.pdf are identical
```

Of course, this needs to be merged first, before it will take effect on DAutoTest.