### PR TITLE
Define Core as reserved version identifier

### DIFF
--- a/spec/version.dd
+++ b/spec/version.dd
@@ -328,6 +328,7 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
         $(TROW $(ARGS $(D D_NoBoundsChecks)) , $(ARGS Array bounds checks are disabled
                 (command line switch $(DDSUBLINK dmd, switch-boundscheck, $(TT -boundscheck=off)))))
         $(TROW $(ARGS $(D D_ObjectiveC)) , $(ARGS The target supports interfacing with Objective-C))
+        $(TROW $(ARGS $(D Core)) , $(ARGS Defined when building the standard runtime))
         $(TROW $(ARGS $(D Std)) , $(ARGS Define when building the standard library))
         $(TROW $(ARGS $(D unittest)) , $(ARGS $(DDLINK spec/unittest, Unit Tests, Unit tests) are enabled
                 (command line switch $(DDSUBLINK dmd, switch-unittest, $(TT -unittest)))))


### PR DESCRIPTION
[DRuntime already defined `CoreDdoc`](https://github.com/dlang/druntime/blob/master/posix.mak#L66). Let's formalize this similar too `Std` (-> https://github.com/dlang/dlang.org/pull/1999).