### PR TITLE
Remove Kindle link from the spec (until it's updated)

### DIFF
--- a/spec/spec.dd
+++ b/spec/spec.dd
@@ -5,9 +5,13 @@ $(TOC Table of Contents,
 	For more information see $(AHTTP dlang.org, dlang.org).)
 
 	$(NOT_EBOOK $(P This is also available as a
-	$(LINK2 $(ROOT_DIR)dlangspec.pdf, PDF document), a
-        $(LINK2 $(ROOT_DIR)dlangspec.mobi, Mobi ebook) or as a
-        $(AMAZONLINK B005CCQPKK, Kindle ebook).))
+	$(LINK2 $(ROOT_DIR)dlangspec.pdf, PDF document) or as a
+        $(LINK2 $(ROOT_DIR)dlangspec.mobi, Mobi ebook).
+        $(COMMENT uncomment this once the Kindle ebook has been updated
+            or as a
+            $(AMAZONLINK B005CCQPKK, Kindle ebook).
+        )
+    ))
 
 	$(TOC_LISTING $(ITEMIZE
 		$(A intro.html, Introduction),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4370550/34263073-9088ce3e-e66e-11e7-97ed-a342fa9ae0f1.png)

This has been discussed with @andralex and @WalterBright.
Unfortunately AFAICT only @WalterBright is able to update the book at Amazon, so he suggested to remove the link until he has time to do so.