### PR TITLE
Bump docarchives to 2.078.0

### DIFF
--- a/js/listanchors.js
+++ b/js/listanchors.js
@@ -93,7 +93,7 @@ function listanchors()
     function addVersionSelector() {
       // Latest version offered by the archive builds
       // This needs to be manually updated after new versions have been archived
-      var currentArchivedVersion = 77;
+      var currentArchivedVersion = 78;
       // build URLs for dlang.org: DDoc + Dox
       var ddocModuleURL = document.body.id.replace(/[.]/g, "_") + ".html";
       var ddoxModuleURL = document.body.id.replace(/[.]/g, "/") + ".html";


### PR DESCRIPTION
See: https://github.com/wilzbach/dlang.org-archives/commit/f00b197d9ba5c31e7e6eedd0b0c14b1d59ae2ec6