### PR TITLE
Remove legacy Ddox pretty printing

### DIFF
--- a/dpl-docs/source/app.d
+++ b/dpl-docs/source/app.d
@@ -16,7 +16,5 @@ int main(string[] args)
 	environment["GIT_TARGET"] = git_target;
 	environment["NO_EXACT_SOURCE_CODE_LINKS"] = noExactSourceCodeLinks ? "1" : "0";
 	setLogFormat(FileLogger.Format.plain);
-	if (args.length > 1 && args[1] != "filter")
-	    args ~= "--html-style=pretty";
 	return ddoxMain(args);
 }


### PR DESCRIPTION
Time to remove this in an individual PR.
Introduced in https://github.com/dlang/dlang.org/pull/1891 to facilite the
transition to Ddox 0.16