### PR TITLE
Automatically select the first Ddox entry instead of searching on Google

### DIFF
--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -29,7 +29,6 @@ html(lang='en-US')
     link(rel='stylesheet', href='https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css')
     link(rel='shortcut icon', href='#{root_dir}favicon.ico')
     script(src='https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js', type='text/javascript')
-    script(type="text/javascript", src="#{root_dir}js/ddox.js")
     meta(name='viewport', content='width=device-width, initial-scale=1.0, minimum-scale=0.1, maximum-scale=10.0')
 
   body.std(id='#{info.node.moduleName}')
@@ -232,6 +231,7 @@ html(lang='en-US')
     script(type='text/javascript', src='#{root_dir}js/run_examples.js')
     script(type='text/javascript', src='#{root_dir}js/dlang.js')
     script(type='text/javascript', src='#{root_dir}js/listanchors.js')
+    script(type="text/javascript", src="#{root_dir}js/ddox.js")
     script(type='text/javascript').
       jQuery(document).ready(listanchors);
       setupDdox();

--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -114,7 +114,7 @@ html(lang='en-US')
             a.expand-toggle(href="#{root_dir}search.html", title="Search")
               span Search
             #search-box
-              form(method='get', action='https://google.com/search')
+              form(method='get', action='https://google.com/search', autocomplete='off')
                 input#domains(type='hidden', name='domains', value='dlang.org')
                 |             
                 input#sourceid(type='hidden', name='sourceid', value='google-search')

--- a/js/ddox.js
+++ b/js/ddox.js
@@ -128,3 +128,13 @@ function performSymbolSearch(maxlen)
 
 	$('#symbolSearchResults').show();
 }
+
+$(function(){
+  $("#search-box form").on("submit", function(e) {
+    var searchResults = $('#symbolSearchResults').children();
+    if (searchResults.length > 0) {
+      window.location = searchResults.first().find("a").attr("href");
+      e.preventDefault();
+    }
+  });
+});


### PR DESCRIPTION
This is quite uninituive and I observed people fighting with this.

Changelog:

- Turn off auto-complete for Ddox search box
- Move ddox.js to page bottom
- Go to first entry of Ddox search on enter instead of Google search