### PR TITLE
Better wording for clarifying how @safe restricts pointers.

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2348,8 +2348,7 @@ $(H3 $(LNAME2 safe-functions, Safe Functions))
         $(UL
         $(LI No casting from a pointer type to any type other than $(CODE void*).)
         $(LI No casting from any non-pointer type to a pointer type.)
-        $(LI No modification of pointer values other than assignment from a
-        pointer of the same type.)
+        $(LI No pointer arithmetic (including pointer indexing).)
         $(LI Cannot access unions that have pointers or references overlapping
         with other types.)
         $(LI Calling any system functions.)


### PR DESCRIPTION
Followup to #2050.