### PR TITLE
add back missing OSX dmg download

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -69,7 +69,7 @@ $(DIVC download_channels,
     )
 
     $(DOWNLOAD macOS, $(OSX), osx,
-        $(SBTN $(ARCH osx, tar.xz), tar.xz)
+        $(SBTN $(OSXDMG), dmg) $(SBTN $(ARCH osx, tar.xz), tar.xz)
     )
 
     $(DOWNLOAD Ubuntu/Debian, $(UBUNTU) &nbsp; $(DEBIAN), linux,


### PR DESCRIPTION
- fixup for 0a5ddef81c