### PR TITLE
gray download/install info symbol

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -276,6 +276,9 @@ Macros:
         .download_paragraph:hover > span {
             visibility: visible;
         }
+        .download_paragraph a > i.fa {
+            color: #999;
+        }
     )
     DOWNLOAD_OTHER =
     $(DIV,


### PR DESCRIPTION
- cause red looks more like an alert