### PR TITLE
Document isDeprecated + mention isFuture

### DIFF
--- a/spec/grammar.dd
+++ b/spec/grammar.dd
@@ -470,6 +470,7 @@ $(GNAME TraitsKeyword):
     $(TRAITS_LINK2 isArithmetic)
     $(TRAITS_LINK2 isAssociativeArray)
     $(TRAITS_LINK2 isFinalClass)
+    $(TRAITS_LINK2 isFuture)
     $(TRAITS_LINK2 isDeprecated)
     $(TRAITS_LINK2 isPOD)
     $(TRAITS_LINK2 isNested)

--- a/spec/grammar.dd
+++ b/spec/grammar.dd
@@ -470,6 +470,7 @@ $(GNAME TraitsKeyword):
     $(TRAITS_LINK2 isArithmetic)
     $(TRAITS_LINK2 isAssociativeArray)
     $(TRAITS_LINK2 isFinalClass)
+    $(TRAITS_LINK2 isDeprecated)
     $(TRAITS_LINK2 isPOD)
     $(TRAITS_LINK2 isNested)
     $(TRAITS_LINK2 isFloating)

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -25,6 +25,7 @@ $(GNAME TraitsKeyword):
     $(GBLINK isPOD)
     $(GBLINK isNested)
     $(GBLINK isFuture)
+    $(GBLINK isDeprecated)
     $(GBLINK isFloating)
     $(GBLINK isIntegral)
     $(GBLINK isScalar)
@@ -200,6 +201,11 @@ $(H2 $(GNAME isFuture))
     $(P Takes one argument. It returns `true` if the argument is a symbol
     marked with the `@future` keyword, otherwise `false`. Currently, only
     functions and variable declarations have support for the `@future` keyword.)
+
+$(H2 $(GNAME isDeprecated))
+
+    $(P Takes one argument. It returns `true` if the argument is a symbol
+    marked with the `deprecated` keyword, otherwise `false`.)
 
 $(H2 $(GNAME isVirtualFunction))
 


### PR DESCRIPTION
As always these updates get "lost" or forgotten. We should stop merging things
without a dlang.org PR and also move into generating more parts of the
specification automatically.

https://github.com/dlang/dmd/pull/7178#issuecomment-334524503

See also: https://github.com/dlang/dlang.org/pull/1688