### PR TITLE
Drop the $(C_A) Ddoc workaround

### DIFF
--- a/areas-of-d-usage.dd
+++ b/areas-of-d-usage.dd
@@ -254,7 +254,6 @@ Macros:
     AREA_SECTION3=$(TC h3, area-section3, $1) $(AREA_SECTION_INLINE $+)
     COLON=:
     _= Single word inline CSS needs to be escaped _=
-    C_A=$1:$2;
     EXTRA_HEADERS=$(T style,
         .start-icons {
             text-align: center;
@@ -262,17 +261,17 @@ Macros:
             padding-top: 20px;
         }
         .start-icons-el > div {
-            $(C_A hyphens, none)
-            $(C_A margin, 0 -1em)
+            hyphens: none;
+            margin: 0 -1em;
             text-align: center;
         }
         .start-icons-el {
             vertical-align: top;
-            $(C_A display, inline-block)
+            display: inline-block;
             padding-right: 5%;
             padding-bottom: 20px;
             font-size: 1.2em;
-            $(C_A width, 100px)
+            width: 100px;
         }
         .start-icons i {
             font-size: 80px;
@@ -282,7 +281,7 @@ Macros:
             padding-top: 1.0em;
         }
         h2 a$(COLON)hover$(COLON)$(COLON)after {
-            $(C_A content, '' !important)
+            content: '' !important;
         }
         @media only screen and (min-width: 50em)
         {
@@ -291,10 +290,10 @@ Macros:
             }
         }
         .fa.article-icon, .fa.section-icon {
-            $(C_A float, left)
+            float: left;
             padding-right: 15px;
             font-size: 80px;
-            $(C_A width, 100px)
+            width: 100px;
             text-align: center;
             padding-bottom: 15px;
         }
@@ -302,16 +301,16 @@ Macros:
         {
             .fa.article-icon, .fa-section-icon {
                 font-size: 60px;
-                $(C_A width, 80px)
+                width: 80px;
             }
             #dman {
-                $(C_A height, 200px)
+                height: 200px;
             }
         }
         @media only screen and (max-width: 30em) {
             .page-contents {
-                $(C_A width, 80%)
-                $(C_A margin, 0 auto)
+                width: 80%;
+                margin: 0 auto;
                 margin-bottom: 1em;
             }
         }

--- a/contributors.dd
+++ b/contributors.dd
@@ -28,16 +28,15 @@ Macros:
     TITLE=Contributors ($(NR_D_CONTRIBUTORS))
     GH_REPO=$(LINK2 https://github.com/dlang/$1, $(D $1))
     D_CONTRIBUTOR=$(LI $1)
-    C_A=$1:$2;
     EXTRA_HEADERS=$(T style,
     #all-d-contributors {
         -moz-column-gap: 20px;
         -webkit-column-gap: 20px;
-        $(C_A column-gap, 20px)
+        column-gap: 20px;
         -moz-column-width: 11.5em;
         -webkit-column-width: 11.5em;
-        $(C_A column-width, 11.5em)
-        $(C_A list-style-type, none)
+        column-width: 11.5em;
+        list-style-type: none;
     }
     )
     _=

--- a/download.dd
+++ b/download.dd
@@ -267,12 +267,11 @@ Macros:
         </div>
         )
     )
-    C_A=$1:$2;
     EXTRA_HEADERS=$(T style,
         .download_paragraph > span {
             visibility: hidden;
             margin-left: 0.4em;
-            $(C_A font-size, 125%)
+            font-size: 125%;
         }
         .download_paragraph:hover > span {
             visibility: visible;

--- a/index.dd
+++ b/index.dd
@@ -698,8 +698,6 @@ Macros:
     TOUR=$(DIVC item, $(SECTION4 $(TC i, fa fa-$1 big-icon)$2, $3))
     WHY_D_ICON=$(TC i, fa fa-$1 why-d-icon)
     _=
-    _= Single word inline CSS needs to be escaped _=
-    C_A=$1:$2;
     META_DESCRIPTION=D is a general-purpose programming language with static typing, systems-level access, and C-like syntax.
     EXTRA_HEADERS=$(T style,
         .why-d-icon {

--- a/orgs-using-d.dd
+++ b/orgs-using-d.dd
@@ -269,15 +269,13 @@ Macros:
     DORGIMG=<a class="orgs-using-d-img-wrapper vcontainer-box" href="$1"><img class="vcontainer-element" src="$(ROOT_DIR)images/orgs-using-d/$2" /></a>
     DORG=$(DIVC orgs-using-d-cell, $(DORGIMG $2, $3) <h3 class="dont-highlight-link">$(LINK2 $2, $1)</h3> $(P $(DIVC orgs-using-d-desc, $4 ) $(DIVC orgs-using-d-uses donthyphenate, $5)))
 
-    _= Single word inline CSS needs to be escaped _=
-    C_A=$1:$2;
     EXTRA_HEADERS=$(T style,
         #content, #content h1 {
             text-align: center;
         }
         .orgs-using-d-cell {
-            $(C_A width, 250px)
-            $(C_A display, inline-block)
+            width: 250px;
+            display: inline-block;
             vertical-align: top;
             margin-bottom: 0.5em;
             padding-left: 25px;
@@ -285,14 +283,14 @@ Macros:
             padding-bottom: 10px;
         }
         .orgs-using-d h3 {
-           $(C_A margin, 0.4em)
+           margin: 0.4em;
            margin-left: 0;
            margin-right: 0;
            text-align: center;
         }
         .orgs-using-d-img-wrapper {
-            $(C_A width, 250px)
-            $(C_A height, 100px)
+            width: 250px;
+            height: 100px;
             padding-bottom: 10px;
             text-align: center;
         }


### PR DESCRIPTION
This is no longer needed as we now use the newest version of DMD to build the docs.