### PR TITLE
Show runtime docs in the menu on dlang.org (prerelease docs only)

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -199,12 +199,11 @@ DUB=$(STABLE_DMD_BIN_ROOT)/dub
 
 # exclude lists
 MOD_EXCLUDES_PRERELEASE=$(addprefix --ex=, \
-	gc. core.internal. core.stdc.config core.sys. \
-	std.algorithm.internal std.c. std.concurrencybase std.internal. std.regex.internal. \
-	std.windows.iunknown std.windows.registry etc.linux.memoryerror \
-	std.experimental.ndslice.internal std.stdiobase \
+	core.internal. core.stdc.config core.sys. \
+	std.algorithm.internal std.c. std.internal. std.regex.internal. \
+	std.windows.registry etc.linux.memoryerror \
 	std.typetuple \
-	tk. msvc_dmc msvc_lib \
+	msvc_dmc msvc_lib \
 	dmd.libmach dmd.libmscoff \
 	dmd.scanmach dmd.scanmscoff \
 	dmd.libmach dmd.libmscoff \

--- a/posix.mak
+++ b/posix.mak
@@ -199,7 +199,7 @@ DUB=$(STABLE_DMD_BIN_ROOT)/dub
 
 # exclude lists
 MOD_EXCLUDES_PRERELEASE=$(addprefix --ex=, \
-	gc. rt. core.internal. core.stdc.config core.sys. \
+	gc. core.internal. core.stdc.config core.sys. \
 	std.algorithm.internal std.c. std.concurrencybase std.internal. std.regex.internal. \
 	std.windows.iunknown std.windows.registry etc.linux.memoryerror \
 	std.experimental.ndslice.internal std.stdiobase \
@@ -430,7 +430,7 @@ ${GENERATED}/modlist-release.ddoc : modlist.d ${STABLE_DMD} $(DRUNTIME_DIR) $(PH
 ${GENERATED}/modlist-prerelease.ddoc : modlist.d ${STABLE_DMD} $(DRUNTIME_DIR) $(PHOBOS_DIR) $(DMD_DIR)
 	mkdir -p $(dir $@)
 	$(STABLE_RDMD) modlist.d $(DRUNTIME_DIR) $(PHOBOS_DIR) $(DMD_DIR) $(MOD_EXCLUDES_PRERELEASE) \
-		$(addprefix --dump , object std etc core) --dump dmd >$@
+		$(addprefix --dump , object std etc core dmd rt) >$@
 
 # Run "make -j rebase" for rebasing all dox in parallel!
 rebase: rebase-dlang rebase-dmd rebase-druntime rebase-phobos


### PR DESCRIPTION
See also: https://github.com/dlang/druntime/pull/2042

![image](https://user-images.githubusercontent.com/4370550/34926409-6f4c0d90-f9af-11e7-9672-41d9767dbbc4.png)


![image](https://user-images.githubusercontent.com/4370550/34926403-68ef2720-f9af-11e7-9408-6d44901c53a8.png)

For the release docs, we will have to wait until 2.079.0
Of course this is still a bit unpolished, but it won't change if we don't expose it.