### PR TITLE
Add d-prerelease.tag to DAutoTest

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -455,7 +455,7 @@ rsync : all kindle pdf
 rsync-only :
 	rsync -avzO --chmod=u=rwX,g=rwX,o=rX --delete $(RSYNC_FILTER) $W/ $(REMOTE_DIR)/
 
-dautotest: all verbatim pdf diffable-intermediaries
+dautotest: all verbatim pdf diffable-intermediaries d-prerelease.tag
 
 ################################################################################
 # Pattern rulez


### PR DESCRIPTION
I realized in https://github.com/dlang/dlang.org/pull/1982 that we don't run
`chmgen.d` on DAutoTest.

@CyberShadow: IIRC you were planning to use `chmgen` to check for dead, internal links?