### PR TITLE
Remove outdated clean warning

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -441,7 +441,6 @@ rebase-phobos: ; cd $(PHOBOS_DIR) && $(call REBASE,phobos)
 
 clean:
 	rm -rf $W ${GENERATED} dpl-docs/.dub dpl-docs/dpl-docs
-	@echo You should issue manually: rm -rf ${DMD_LATEST_DIR} ${DRUNTIME_LATEST_DIR} ${PHOBOS_LATEST_DIR} ${STABLE_DMD_ROOT}
 
 RSYNC_FILTER=-f 'P /Usage' -f 'P /.dpl_rewrite*' -f 'P /install.sh*'
 


### PR DESCRIPTION
The repositories are now checked out to `.generated` too.