### PR TITLE
Cherry-pick 1891 + 1926 from master to stable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ Make sure you have these prerequisites working:
 * The C++ compiler for your platform (invokable as `gcc`)
 * Optional: `latex` for building the pdf documentation
 * Optional: `kindlegen` for building the Kindle documentation
-* If you're running OSX, make sure you have some version of `libevent` installed (needed for Ddox)
 
 ## Getting the code
 

--- a/dpl-docs/dub.json
+++ b/dpl-docs/dub.json
@@ -1,7 +1,8 @@
 {
 	"name": "dpl-docs",
 	"dependencies": {
-		"ddox": "~>0.15.0"
+		"ddox": "~>0.16.7"
 	},
-	"versions": ["VibeCustomMain", "VibeNoSSL"]
+	"versions": ["VibeNoSSL"],
+	"subConfigurations": { "eventcore": "libasync"}
 }

--- a/dpl-docs/dub.selections.json
+++ b/dpl-docs/dub.selections.json
@@ -1,14 +1,19 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"ddox": "0.15.18",
-		"experimental_allocator": "2.70.0-b1",
+		"botan": "1.12.9",
+		"botan-math": "1.0.3",
+		"ddox": "0.16.7",
+		"diet-ng": "1.4.3",
+		"eventcore": "0.8.17",
 		"hyphenate": "1.1.1",
 		"libasync": "0.8.3",
-		"libdparse": "0.7.0",
-		"libev": "5.0.0+4.04",
+		"libdparse": "0.7.1",
 		"libevent": "2.0.2+2.0.16",
 		"memutils": "0.4.9",
-		"vibe-d": "0.7.31"
+		"openssl": "1.1.5+1.0.1g",
+		"taggedalgebraic": "0.10.7",
+		"vibe-core": "1.2.0",
+		"vibe-d": "0.8.1"
 	}
 }

--- a/dpl-docs/source/app.d
+++ b/dpl-docs/source/app.d
@@ -16,5 +16,7 @@ int main(string[] args)
 	environment["GIT_TARGET"] = git_target;
 	environment["NO_EXACT_SOURCE_CODE_LINKS"] = noExactSourceCodeLinks ? "1" : "0";
 	setLogFormat(FileLogger.Format.plain);
+	if (args.length > 1 && args[1] != "filter")
+	    args ~= "--html-style=pretty";
 	return ddoxMain(args);
 }

--- a/dpl-docs/views/ddox.inc.module-tree.dt
+++ b/dpl-docs/views/ddox.inc.module-tree.dt
@@ -1,11 +1,5 @@
 - import ddox.entities;
 
-- Module getPackageModule(Package pack)
-	- import std.algorithm : find;
-	- if (auto pp = cast(Package)pack.parent)
-		- return pp.lookup!Module(pack.name);
-	- return null;
-
 - void moduleNavTree(Package pack, Module pack_mod)
 	- string pack_class = "expand-container";
 	- foreach(i, p; pack.packages)

--- a/dpl-docs/views/ddox.layout.dt
+++ b/dpl-docs/views/ddox.layout.dt
@@ -5,6 +5,7 @@ block title
 	block ddox.title
 
 block navigation
+	include ddox.inc.utils
 	include ddox.inc.module-tree
 
 block body

--- a/dpl-docs/views/ddox.overview.dt
+++ b/dpl-docs/views/ddox.overview.dt
@@ -7,6 +7,7 @@ block ddox.title
 	- title = "API documentation";
 
 block ddox.members
+	- import std.conv : to;
 
 	- void moduleInfoRec(Package pack)
 		- foreach( p; pack.packages )
@@ -16,7 +17,7 @@ block ddox.members
 				tr
 					td
 						a(href="#{info.linkTo(m)}")
-							code!= m.qualifiedName.replace(".", "<wbr/>.")
+							code!= m.qualifiedName.to!string.replace(".", "<wbr/>.")
 					td
 						- if( m.docGroup )
 							|!= info.formatDoc(m.docGroup, 0, sec => sec == "$Short")
@@ -27,7 +28,7 @@ block ddox.members
 		- foreach( m; pack.modules )
 			- if (m.qualifiedName.startsWith(prefix))
 				a(href="#{info.linkTo(m)}")
-					code!= m.qualifiedName.replace(".", "<wbr/>.")
+					code!= m.qualifiedName.to!string.replace(".", "<wbr/>.")
 
 	table
 		col.caption

--- a/dpl-docs/views/inc.disqus.dt
+++ b/dpl-docs/views/inc.disqus.dt
@@ -1,8 +1,9 @@
+- import std.conv : text;
 div#disqus_thread
 script(language="javascript").
     var disqus_shortname = 'vibe-d'; // required: replace example with your forum shortname
     var disqus_developer = 1;
-    var disqus_identifier = #{"\\\"phobos-" ~ info.node.qualifiedName ~ "\\\""};
+    var disqus_identifier = #{text(`"phobos-`, info.node.qualifiedName.text, `"`)};
 
 
     /* * * DON'T EDIT BELOW THIS LINE * * */

--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -7,6 +7,7 @@ html(lang='en-US')
     | All Rights Reserved.
     | https://dlang.org/foundation.html
   - import std.process : environment;
+  - import std.array : replace;
   - string version_id = environment["GIT_TARGET"];
   - bool noExactSourceCodeLinks = environment["NO_EXACT_SOURCE_CODE_LINKS"] == "1";
   - bool haveVersion = version_id.startsWith("v");
@@ -51,7 +52,7 @@ html(lang='en-US')
                   span Documentation
                 ul
                   li
-                    a(href="#{root_dir}spec/spec.html")Language Reference
+                    a(href="#{root_dir}spec/spec.html") Language Reference
                   li
                     a(href="#{root_dir}phobos/index.html") Library Reference
                   li
@@ -159,6 +160,7 @@ html(lang='en-US')
       #content.hyphenate
         #tools
           div
+            - import ddox.entities : Declaration;
             - auto modname = info.node.moduleName;
             - string project = "dlang.org";
             - string path_prefix, line_suffix, filename;

--- a/posix.mak
+++ b/posix.mak
@@ -186,7 +186,7 @@ endif
 ################################################################################
 
 # stable dub and dmd versions used to build dpl-docs
-STABLE_DMD_VER=2.072.2
+STABLE_DMD_VER=2.077.1
 STABLE_DMD_ROOT=$(GENERATED)/stable_dmd-$(STABLE_DMD_VER)
 STABLE_DMD_URL=http://downloads.dlang.org/releases/2.x/$(STABLE_DMD_VER)/dmd.$(STABLE_DMD_VER).$(OS).zip
 STABLE_DMD_BIN_ROOT=$(STABLE_DMD_ROOT)/dmd2/$(OS)/$(if $(filter $(OS),osx),bin,bin$(MODEL))


### PR DESCRIPTION
- https://github.com/dlang/dlang.org/pull/1891
- https://github.com/dlang/dlang.org/pull/1926

2.077.1 comes with DUB mirrors which should avoid the problems due to
code.dlang.org being down which we are seeing on doc builds against `stable`.

See also: https://github.com/dlang/phobos/pull/6035#issuecomment-357824158