### PR TITLE
add spec macros to dlang.org.ddoc

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -4,6 +4,9 @@ ACRONYM = <acronym title="$+">$1</acronym> ($+)
 ASSIGNEXPRESSION = $(GLINK2 expression, AssignExpression)
 _=
 
+$(COMMENT While not part of the spec, best practices offers advice on how to best use a feature)
+BEST_PRACTICE= $(P $(B Best Practices:) $0)
+
 BIGOH = $(SPANC bigoh, &Omicron;($(D $0)))
 BLOCKQUOTE = $(T blockquote, $(P $0))
 BLOCKQUOTE_BY = $(BLOCKQUOTE $+ $(T cite, $1))
@@ -186,6 +189,8 @@ HTMLTAG3V=<$1 $2>$(TAIL $+)
 HYPHENATE=hyphenate
 _=
 
+$(COMMENT Identifies implementation-defined behavior in the spec)
+IMPLEMENTATION_DEFINED=$(P $(B Implementation Defined): $0)
 ISEXPRESSION=$(GLINK2 expression, IsExpression)
 _=
 
@@ -503,6 +508,8 @@ TWID_LATEST_LINK=
 TWID_LATEST_TITLE=
 _=
 
+$(COMMENT Identifies undefined-defined behavior in the spec)
+UNDEFINED_BEHAVIOR=$(P $(B Undefined Behavior): $0)
 UNDERSCORE=_
 UNDERSCORE_PREFIXED=_$1$(UNDERSCORE_PREFIXED $+)
 UNDERSCORE_PREFIXED_SKIP=$(UNDERSCORE_PREFIXED $+)


### PR DESCRIPTION
Add `BEST_PRACTICE`, `IMPLEMENTATION_DEFINED` and `UNDEFINED_BEHAVIOR` to the spec macros so that the display of these will be consistent and cross-referencable.