### PR TITLE
remove comparisons to C++

### DIFF
--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -7,9 +7,7 @@ $(HEADERNAV_TOC)
         $(P Contracts are a breakthrough technique to reduce the programming effort
         for large projects. Contracts are the concept of preconditions, postconditions,
         errors, and invariants.
-        Contracts can be done in C++ without modification to the language,
-        but the result is
-        clumsy and inconsistent.)
+        )
 
         $(P Building contract support into the language makes for:)
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -4,10 +4,6 @@ $(SPEC_S Expressions,
 
 $(HEADERNAV_TOC)
 
-    $(P C and C++ programmers will find the D expressions very familiar,
-        with a few interesting additions.
-    )
-
     $(P Expressions are used to compute values with a resulting type.
         These values can then be assigned,
         tested, or ignored. Expressions can also have side effects.
@@ -16,9 +12,7 @@ $(HEADERNAV_TOC)
 $(H2 $(LNAME2 order-of-evaluation, Order Of Evaluation))
 
 $(P Binary expressions and function arguments are evaluated in strictly
-left-to-right order. This is similar to Java but different to C and C++, where
-the evaluation order is unspecified. Thus, the following code is valid and well
-defined.)
+left-to-right order.)
 
         -------------
         import std.conv;
@@ -622,7 +616,7 @@ $(GNAME ComplementExpression):
         All the bits in the value are complemented.
     )
 
-    $(P $(B Note:) unlike in C and C++, the usual integral promotions are not performed
+    $(P $(B Note:) the usual integral promotions are not performed
         prior to the complement operation.
     )
 
@@ -763,9 +757,6 @@ $(GNAME CastExpression):
         derived class reference is done with a runtime check to make sure it
         really is a downcast. $(D null) is the result if it isn't.
     )
-
-    $(P $(B Note:) This is equivalent to the behavior of the
-        $(D dynamic_cast) operator in C++.)
 
         -------------
         class A { ... }

--- a/spec/garbage.dd
+++ b/spec/garbage.dd
@@ -14,7 +14,7 @@ $(HEADERNAV_TOC)
         is $(B not involved). More information is provided below.
         )
 
-        $(P C and C++ programmers accustomed to explicitly managing memory
+        $(P Programmers accustomed to explicitly managing memory
         allocation and
         deallocation will likely be skeptical of the benefits and efficacy of
         garbage collection. Experience both with new projects written with

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -8,7 +8,7 @@ $(HEADERNAV_TOC)
              Any C struct can be exactly represented as a D struct, except non-static
              $(RELATIVE_LINK2 nested, function-nested D structs) which access the context of
              their enclosing scope.
-             Structs and unions are meant as simple aggregations of data, or as a way
+             Structs and unions are simple aggregations of data, or as a way
              to paint a data structure over hardware or an external type. External
              types can be defined by the operating system API, or by a file format.
              Object oriented features are provided with the class data type.
@@ -17,70 +17,6 @@ $(HEADERNAV_TOC)
          $(P A struct is defined to not have an identity; that is,
              the implementation is free to make bit copies of the struct
              as convenient.)
-
-        $(TABLE2 Struct$(COMMA) Class Comparison Table,
-        $(THEAD Feature, $(D struct), $(D class), C $(D struct), C++
-        $(D struct), C++ $(D class))
-
-        $(TROW value type, $(CHECK), $(UNCHECK), $(CHECK), $(CHECK), $(CHECK))
-        $(TROW reference type, $(UNCHECK), $(CHECK), $(UNCHECK),
-        $(UNCHECK), $(UNCHECK))
-        $(TROW data members, $(CHECK), $(CHECK), $(CHECK), $(CHECK), $(CHECK))
-        $(TROW hidden members, $(CHECK),
-        $(CHECK), $(UNCHECK), $(CHECK), $(CHECK))
-        $(TROW static members, $(CHECK), $(CHECK), $(UNCHECK),
-        $(CHECK), $(CHECK))
-        $(TROW $(RELATIVE_LINK2 static_struct_init, default member initializers),
-        $(CHECK), $(CHECK), $(UNCHECK), $(UNCHECK), $(UNCHECK))
-        $(TROW bit fields, $(UNCHECK), $(UNCHECK), $(CHECK), $(CHECK),
-        $(CHECK))
-        $(TROW non-virtual member functions, $(CHECK), $(CHECK),
-        $(UNCHECK), $(CHECK), $(CHECK))
-        $(TROW virtual member functions, $(UNCHECK), $(CHECK),
-        $(UNCHECK), $(CHECK), $(CHECK))
-        $(TROW $(RELATIVE_LINK2 struct-constructor, constructors), $(CHECK),
-        $(CHECK), $(UNCHECK), $(CHECK), $(CHECK))
-        $(TROW $(RELATIVE_LINK2 struct-postblit, postblit)/copy constructors,
-        $(CHECK), $(UNCHECK), $(UNCHECK), $(CHECK), $(CHECK))
-        $(TROW $(RELATIVE_LINK2 struct-destructor, destructors), $(CHECK),
-        $(CHECK), $(UNCHECK), $(CHECK), $(CHECK))
-        $(TROW $(GLINK2 class, SharedStaticConstructor)s, $(CHECK),
-        $(CHECK), $(UNCHECK), $(UNCHECK), $(UNCHECK))
-        $(TROW $(GLINK2 class, SharedStaticDestructor)s,  $(CHECK),
-        $(CHECK), $(UNCHECK), $(UNCHECK), $(UNCHECK))
-        $(TROW RAII, $(CHECK), $(CHECK), $(UNCHECK), $(CHECK), $(CHECK))
-        $(TROW $(RELATIVE_LINK2 assign-overload, identity assign overload), $(CHECK),
-        $(UNCHECK), $(UNCHECK), $(CHECK), $(CHECK))
-        $(TROW $(RELATIVE_LINK2 struct-literal, literals), $(CHECK), $(UNCHECK),
-        $(UNCHECK), $(UNCHECK), $(UNCHECK))
-        $(TROW operator overloading, $(CHECK), $(CHECK), $(UNCHECK),
-        $(CHECK), $(CHECK))
-        $(TROW inheritance, $(UNCHECK), $(CHECK), $(UNCHECK),
-        $(CHECK), $(CHECK))
-        $(TROW invariants, $(CHECK), $(CHECK), $(UNCHECK), $(UNCHECK),
-        $(UNCHECK))
-        $(TROW unit tests, $(CHECK), $(CHECK), $(UNCHECK), $(UNCHECK),
-        $(UNCHECK))
-        $(TROW synchronizable, $(UNCHECK), $(CHECK), $(UNCHECK), $(UNCHECK),
-        $(UNCHECK))
-        $(TROW parameterizable, $(CHECK), $(CHECK), $(UNCHECK),
-        $(CHECK), $(CHECK))
-        $(TROW alignment control, $(CHECK), $(CHECK), $(UNCHECK),
-        $(UNCHECK), $(UNCHECK))
-        $(TROW member protection, $(CHECK), $(CHECK), $(UNCHECK),$(CHECK),$(CHECK))
-        $(TROW default public, $(CHECK), $(CHECK), $(CHECK),$(CHECK), $(UNCHECK))
-        $(TROW tag name space, $(UNCHECK), $(UNCHECK), $(CHECK),
-        $(CHECK), $(CHECK))
-        $(TROW anonymous, $(CHECK), $(UNCHECK), $(CHECK), $(CHECK), $(CHECK))
-        $(TROW static constructor, $(CHECK), $(CHECK), $(UNCHECK),
-        $(UNCHECK), $(UNCHECK))
-        $(TROW static destructor, $(CHECK), $(CHECK), $(UNCHECK),
-        $(UNCHECK), $(UNCHECK))
-        $(TROW const/immutable/shared, $(CHECK), $(CHECK), $(UNCHECK),
-        $(UNCHECK), $(UNCHECK))
-        $(TROW inner nesting, $(RELATIVE_LINK2 nested, $(CHECK)),
-        $(DDSUBLINK spec/class, nested, $(CHECK)), $(UNCHECK), $(UNCHECK), $(UNCHECK))
-        )
 
 $(GRAMMAR
 $(GNAME AggregateDeclaration):

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -4,9 +4,6 @@ $(SPEC_S Templates,
 
 $(HEADERNAV_TOC)
 
-$(BLOCKQUOTE_BY Richard Deyman,
-I think that I can safely say that nobody understands C++ template mechanics.)
-
     $(P Templates are D's approach to generic programming.
         Templates are defined with a $(I TemplateDeclaration):
     )
@@ -340,8 +337,6 @@ $(H3 $(LNAME2 parameters_specialization, Specialization))
 
     $(P The template picked to instantiate is the one that is most specialized
         that fits the types of the $(I TemplateArgumentList).
-        Determining which is more specialized is done in the same way as the
-        C++ partial ordering rules.
         If the result is ambiguous, it is an error.
     )
 

--- a/spec/version.dd
+++ b/spec/version.dd
@@ -6,8 +6,6 @@ $(HEADERNAV_TOC)
 
         $(P $(I Conditional compilation) is the process of selecting which
         code to compile and which code to not compile.
-        (In C and C++, conditional compilation is done with the preprocessor
-        directives $(CODE #if) / $(CODE #else) / $(CODE #endif).)
         )
 
 $(GRAMMAR


### PR DESCRIPTION
Comparisons to other languages do not belong in a language specification.