### PR TITLE
Correct unittest point: with -> without

### DIFF
--- a/spec/betterc.dd
+++ b/spec/betterc.dd
@@ -50,7 +50,7 @@ $(OL
     $(LI `synchronized` and $(MREF core, sync))
     $(LI Static module constructors or deconstructors)
     $(LI Struct deconstructors)
-    $(LI `unittest` (testing can be as usual with the `-betterC` flag))
+    $(LI `unittest` (testing can be done without the `-betterC` flag))
 )
 
 The predefined $(LINK2 version.html, version) `D_BetterC` can be used for conditional compilation.


### PR DESCRIPTION
I suspect that's what was intended?