### PR TITLE
Long names now have trailing dots

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -477,6 +477,8 @@ body.std .subnav .d_inlinecode
 {
     display: block;
     font-weight: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 body.std .subnav li li > a > span,


### PR DESCRIPTION
Did some minor changes to style.css in order for longer names, such as 'ascending_page_allocator' to not exceed the length of the sidebar.

In order to see the changes, go to dlang.org/phobos, expand 'std' on the sidebar and check longer names such as 'ascending_page_allocator' or 'kerrigan_ritchie' to see that it now fits the length of the sidebar.