### PR TITLE
Ddoc: Auto-detected URLs should be wrapped in DDOC_LINK_AUTODETECT instead of LINK directly.

### DIFF
--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -561,7 +561,7 @@ URLs are sequences of characters starting with 'http://' or 'https://',
 continue with one or more characters from the set of letters, digits and
 `-_?=%&/+#~.`, and contain at least one period.
 URL recognition happens before all macro text substitution.
-The URL is wrapped with a `$(DOLLAR)(LINK)` macro.
+The URL is wrapped with a `$(DOLLAR)(DDOC_LINK_AUTODETECT)` macro.
 The $(LINK2 #emphasis, underscore prefix processing) is not done for URL text.
 )
 


### PR DESCRIPTION
This is a followup to #1858 