### PR TITLE
Document the preferred Phobos documentation style

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -395,6 +395,38 @@ class MyClass
 -------------------------------
 )
 
+$(LISTSECTION phobos_documentation, Documentation,
+    $(LI Every public symbol be exposed on the documentation:)
+---
+/// A public symbol
+enum myFancyConstant;
+---
+    $(LI Every public function should have a Ddoc description and documented
+    `Params:` and `Returns:` sections (if applicable):)
+---
+/**
+Checks whether a number is positive.
+`0` isn't considered as positive number.
+
+Params:
+    number = number to be checked
+
+Returns: `true` if the number is positive, `0` otherwise.
+
+See_Also: $(LREF isNegative)
+*/
+bool isPositive(int number)
+{
+    return number > 0;
+}
+---
+    $(LI Text in sections (e.g. `Params:`, `Returns:`, `See_Also`) should be indented by one level if spans more than the line of the section.)
+    $(LI Documentation comments should not use more than two stars `/**` in the header line.)
+    $(LI Block comments (`/**`) should be used - not nesting block comments (`/++`))
+    $(LI Global functions shouldn't indent their documentation block nor use stars as indentation.)
+    $(LI Text example blocks should use three dashes (`---`) only.)
+)
+
 $(BR)
 $(P
     We are not necessarily recommending that all code follow these rules.


### PR DESCRIPTION
Follow-up to https://github.com/dlang/druntime/pull/2054.
I'm fully aware that Phobos is a wild mixture of a many, many styles.
This PR won't do any reformatting of Phobos, but tries to define best practices for writing new documentation header as it seems to come up often lately.

--- edit:

Obviously this entire topic is purely subjective and emotional, but the idea here is to find a common ground that can be recommended to newcomers.