### PR TITLE
Change documentation style requirement to /++ +/.

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -404,7 +404,7 @@ enum myFancyConstant;
     $(LI Every public function should have a Ddoc description and documented
     `Params:` and `Returns:` sections (if applicable):)
 ---
-/**
+/++
 Checks whether a number is positive.
 `0` isn't considered as positive number.
 
@@ -414,7 +414,7 @@ Params:
 Returns: `true` if the number is positive, `0` otherwise.
 
 See_Also: $(LREF isNegative)
-*/
++/
 bool isPositive(int number)
 {
     return number > 0;
@@ -422,7 +422,7 @@ bool isPositive(int number)
 ---
     $(LI Text in sections (e.g. `Params:`, `Returns:`, `See_Also`) should be indented by one level if it spans more than the line of the section.)
     $(LI Documentation comments should not use more than two stars `/**` in the header line.)
-    $(LI Block comments (`/**`) should be used - not nesting block comments (`/++`))
+    $(LI Nested block comments (`/++`) should be used - not C-style block comments (`/**`))
     $(LI Global functions shouldn't indent their documentation block nor use stars as indentation.)
     $(LI Text example blocks should use three dashes (`---`) only.)
 )


### PR DESCRIPTION
If we're going to require either `/++ +/` or `/** */`, `/++ +/` makes more
sense, because it allows for comments to be put into the documentation
if need be, whereas `/** */` does not, because it doesn't allow comments to
nest. And while comments would usually be in code examples inside a
documented unit test, sometimes we still need to put code examples
directly in the documentation.

I'm all for disallowing stars or pluses on the beginning of documentation lines (they're really annoying IMHO), but if we're going to require `/++ +/` or `/** */`, I very much would prefer `/++ +/`, and as the commit message points out, `/++ +/` is objectively better. In most cases, it doesn't matter, and it's personal preference, but in some cases, it really does matter, and in those cases, `/++ +/` works well, whereas `/** */` does not. I don't see any advantage to requiring `/** */`.