### PR TITLE
Adjust section for ddoc comments in style guide.

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -421,9 +421,9 @@ bool isPositive(int number)
 }
 ---
     $(LI Text in sections (e.g. `Params:`, `Returns:`, `See_Also`) should be indented by one level if it spans more than the line of the section.)
-    $(LI Documentation comments should not use more than two stars `/**` in the header line.)
-    $(LI Block comments (`/**`) should be used - not nesting block comments (`/++`))
-    $(LI Global functions shouldn't indent their documentation block nor use stars as indentation.)
+    $(LI Documentation comments should not use more than two stars `/**` or two pluses `/++` in the header line.)
+    $(LI Either Block comments (`/**`) or nesting block comments (`/++`) should be used except when the ddoc comment is a ditto comment such as `/// Ditto`)
+    $(LI Documentation comments should not have leading stars or zeroes on each line.)
     $(LI Text example blocks should use three dashes (`---`) only.)
 )
 


### PR DESCRIPTION
Some changes per the discussion in https://github.com/dlang/dlang.org/pull/2129

Phobos uses both `/++ +/` and `/** */` heavily, and there are cases where `/++ +/` works better than `/** */`, because the documentation includes `/* */` comment. Andrei agreed that both are acceptable. I did add a note about ditto comments, since those should be just fine as single line comments.

Also, I removed the bit about not having indentation in comments, since I'm pretty sure that most existing ddoc comments in Phobos do have indentation, and I don't see any reason not to have it. Personally, I think that it's ugly to have the comment smashed up to the side of the screen. instead of being indented.