### PR TITLE
Add DTour link to Resources menu

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -281,6 +281,7 @@ $(SUBMENU_MANUAL
 )
 NAVIGATION_RESOURCES=
 $(SUBMENU_MANUAL
+    $(SUBMENU_LINK https://tour.dlang.org, Tour)
     $(SUBMENU_LINK https://wiki.dlang.org/Books, Books)
     $(SUBMENU_LINK https://wiki.dlang.org/Tutorials, Tutorials)
     $(SUBMENU_LINK_DIVIDER https://wiki.dlang.org/Development_tools, Tools)


### PR DESCRIPTION
In general I'm not too happy about https://wiki.dlang.org/Tutorials
While it contains a lot of hidden gems, it doesn't contain much content
well suited for beginners and a lot of the tutorials are quite old and not
very idiomatic anymore :/