### PR TITLE
Disable building the man preview on OSX

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -986,7 +986,7 @@ $W/$(MAN_PAGE): $(DMD_DIR)/generated/$(MAN_PAGE) | ${STABLE_DMD}
 	mkdir -p $(dir $@)
 	cp $< $@
 	# CircleCi + nightlies.dlang.org might not have `man` installed
-	if command -v man > /dev/null ; then \
+	if [ $(OS) != "osx" ] -a [ command -v man > /dev/null ] ; then \
 		${MAKE} -s -C $(DMD_DIR)/docs DMD=$(abspath $(STABLE_DMD)) DIFFABLE=$(DIFFABLE) preview > $(dir $@)dmd.txt; \
 	fi
 


### PR DESCRIPTION
Apparentely the `man` tool behaves a bit differently on OSX.
As this is only used for previewing the man page changes at dmd (for now),
I think the best course of action is to simply disable this on OSX.

I don't use OSX, someone who does and wants to fix the underlying preview command (https://github.com/dlang/dmd/blob/master/docs/Makefile#L26), is of course always invited to do so.