### PR TITLE
Always display the download icon

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -269,12 +269,8 @@ Macros:
     )
     EXTRA_HEADERS=$(T style,
         .download_paragraph > span {
-            visibility: hidden;
             margin-left: 0.4em;
             font-size: 125%;
-        }
-        .download_paragraph:hover > span {
-            visibility: visible;
         }
         .download_paragraph a > i.fa {
             color: #999;


### PR DESCRIPTION
Based on feedback from the NG:

>> https://dlang.org/install.html
> I've never seen that page. Would've helped me to see it earlier. The D download page should include a blurb with a link to that install page.
https://forum.dlang.org/post/zwizsobrbboibzqrussm@forum.dlang.org

From @quickfur:

> Wow.  I set out *deliberately* looking for that link, and couldn't find it until I looked at your screenshot. I definitely wouldn't have found it if I didn't even know it was there.
https://forum.dlang.org/post/mailman.2877.1517420581.9493.digitalmars-d@puremagic.com

The info buttons have been added in: https://github.com/dlang/dlang.org/pull/1697

And the install.sh page was added in: https://github.com/dlang/dlang.org/pull/1936