### PR TITLE
Add deprecation note for opIn and opIn_r to operatoroverloading.html

### DIFF
--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -285,6 +285,8 @@ T opBinary(string op)(T rhs)
 }
 ---
 
+        $(P Note that `opIn` and `opIn_r` have been deprecated in favor of
+        `opBinary!"in"` and `opBinaryRight!"in"` respectively.)
 
 $(H2 $(LNAME2 eqcmp, Overloading the Comparison Operators))
 


### PR DESCRIPTION
Fix issue 18337

I recently was unable to find any documentation on `opIn` and `opIn_r`.  I opened an issue and was told these were deprecated.  Adding a note about this deprecation in the spec should be helpful for others in the future who will have the same question.