### PR TITLE
Improve `.tupleof` spec for class, struct

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -167,15 +167,19 @@ void test(Foo foo)
 
 $(H2 $(LNAME2 class_properties, Class Properties))
 
-        $(P The $(D .tupleof) property returns an $(I ExpressionTuple)
-        of all the fields
-        in the class, excluding the hidden fields and the fields in the
-        base class.
+        $(P The $(D .tupleof) property is an
+        $(DDSUBLINK spec/template, variadic-templates, expression sequence)
+        of all the fields in the class, excluding the hidden fields and
+        the fields in the base class.
         )
 ---
 class Foo { int x; long y; }
+
 void test(Foo foo)
 {
+    import std.stdio;
+    static assert(typeof(foo.tupleof).stringof == `(int, long)`);
+
     foo.tupleof[0] = 1; // set foo.x to 1
     foo.tupleof[1] = 2; // set foo.y to 2
     foreach (x; foo.tupleof)

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -267,13 +267,23 @@ $(TABLE2 Struct Properties,
 $(THEAD Name, Description)
 $(TROW $(D .sizeof), Size in bytes of struct)
 $(TROW $(D .alignof), Size boundary struct needs to be aligned on)
-$(TROW $(D .tupleof), Gets type tuple of fields))
+)
+
+$(H2 $(LNAME2 struct_instance_properties, Struct Instance Properties))
+
+$(TABLE2 Struct Instance Properties,
+$(THEAD Name, Description)
+$(TROW $(D .tupleof), An $(DDSUBLINK spec/template, variadic-templates, expression sequence)
+    of all struct fields - see
+    $(DDSUBLINK spec/class, class_properties, Class Properties) for a class-based example.)
+)
 
 $(H2 $(LNAME2 struct_field_properties, Struct Field Properties))
 
 $(TABLE2 Struct Field Properties,
 $(THEAD Name, Description)
-$(TROW $(D .offsetof), Offset in bytes of field from beginning of struct))
+$(TROW $(D .offsetof), Offset in bytes of field from beginning of struct)
+)
 
 $(H2 $(LEGACY_LNAME2 ConstStruct, const-struct, Const, Immutable and Shared Structs))
 


### PR DESCRIPTION
* Don't use *tuple* when we mean expression sequence.
* Struct `.tupleof` is not a *type* sequence & it operates on a struct *instance* only.
* Add links.
