### PR TITLE
Clean up line about leading stars in style guide.

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -423,7 +423,7 @@ bool isPositive(int number)
     $(LI Text in sections (e.g. `Params:`, `Returns:`, `See_Also`) should be indented by one level if it spans more than the line of the section.)
     $(LI Documentation comments should not use more than two stars `/**` or two pluses `/++` in the header line.)
     $(LI Either Block comments (`/**`) or nesting block comments (`/++`) should be used except when the ddoc comment is a ditto comment such as `/// Ditto`)
-    $(LI Documentation comments should not have leading stars or zeroes on each line.)
+    $(LI Documentation comments should not have leading stars on each line.)
     $(LI Text example blocks should use three dashes (`---`) only.)
 )
 


### PR DESCRIPTION
I'm not sure why it says something about no leading zeroes. It's true that there' shouldn't be any, but AFAIK, no one has been doing it, so it comes off as weird. It's stars that some folks like to do. IIRC, it's a javadoc thing.