### PR TITLE
Move verbose files listing to the middle

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -4,10 +4,10 @@ $(D_S dmd - $(WINDOWS Windows)$(LINUX Linux)$(OSX Mac OS X)$(FREEBSD FreeBSD) D 
 
     $(UL
     $(LI $(RELATIVE_LINK2 requirements, Requirements and Downloads))
-    $(LI $(RELATIVE_LINK2 files, Files))
     $(LI $(RELATIVE_LINK2 installation, Installation))
     $(WINDOWS $(LI $(RELATIVE_LINK2 example, Example)))
     $(LI $(RELATIVE_LINK2 switches, Compiler Arguments and Switches))
+    $(LI $(RELATIVE_LINK2 files, Files))
     $(LI $(RELATIVE_LINK2 linking, Linking))
     $(LI $(RELATIVE_LINK2 environment, Environment Variables))
     $(WINDOWS $(LI $(RELATIVE_LINK2 sc-ini, sc.ini Initialization File)))
@@ -49,213 +49,6 @@ $(H2 $(LNAME2 requirements, Requirements and Downloads))
 
     $(LI Gnu C compiler (gcc))
     )
-    )
-
-$(H2 $(LNAME2 files, Files))
-
-    $(DL
-
-    $(DT $(D $(DMDDIR)$(SEP)src$(SEP)phobos$(SEP))
-    $(DD D runtime library source)
-    )
-
-    $(DT $(D $(DMDDIR)$(SEP)src$(SEP)dmd$(SEP))
-    $(DD D compiler front end source under dual (GPL and Artistic) license)
-    )
-
-    $(DT $(D $(DMDDIR)$(SEP)html$(SEP)d$(SEP))
-    $(DD Documentation)
-    )
-
-    $(DT $(D $(DMDDIR)$(SEP)samples$(SEP)d$(SEP))
-    $(DD Sample D programs)
-    )
-    $(WINDOWS
-
-    $(DT $(D $(DMDDIR)\windows\bin\ddemangle.exe)
-    $(DD D symbol demangler)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\dman.exe)
-    $(DD D manual lookup tool)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\dmd.exe)
-    $(DD D compiler executable)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\$(DUB))
-    $(DD D's package manager)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\$(DUSTMITE))
-    $(DD D source code minimizer)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\$(LINK2 http://www.digitalmars.com/ctg/optlink.html, link.exe))
-    $(DD OPTLINK)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\$(LINK2 http://www.digitalmars.com/ctg/make.html, make.exe))
-    $(DD Digitalmars Make)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\replace.exe)
-    $(DD Find/replace text in files)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\$(RDMD))
-    $(DD D build tool for script-like D code execution)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\$(SC_INI))
-    $(DD Global compiler settings)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\$(LINK2 http://www.digitalmars.com/ctg/shell.html, shell.exe))
-    $(DD Simple command line shell)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\$(LINK2 http://www.digitalmars.com/d/2.0/windbg.html, windbg.exe))
-    $(DD Microsoft debugger)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\lib\$(LIB))
-    $(DD D runtime library)
-    )
-    )
-    $(LINUX
-    $(DT $(D $(DMDDIR)/linux/bin/ddemangle)
-    $(DD D symbol demangler)
-    )
-
-    $(DT $(D $(DMDDIR)/linux/bin/dman)
-    $(DD D manual lookup tool)
-    )
-
-    $(DT $(D $(DMDDIR)/linux/bin/dmd)
-    $(DD D compiler executable)
-    )
-
-    $(DT $(D $(DMDDIR)/linux/bin/$(DMD_CONF))
-    $(DD Global compiler settings (copy to $(D /etc/dmd.conf)))
-    )
-
-    $(DT $(D $(DMDDIR)/linux/bin/$(DUB))
-    $(DD D's package manager)
-    )
-
-    $(DT $(D $(DMDDIR)/linux/bin/$(DUMPOBJ))
-    $(DD ELF file dumper)
-    )
-
-    $(DT $(D $(DMDDIR)/linux/bin/$(DUSTMITE))
-    $(DD D source code minimizer)
-    )
-
-    $(DT $(D $(DMDDIR)/linux/bin/$(OBJ2ASM))
-    $(DD ELF file disassembler)
-    )
-
-    $(DT $(D $(DMDDIR)/linux/bin/$(RDMD))
-    $(DD D build tool for script-like D code execution)
-    )
-
-    $(DT $(D $(DMDDIR)/linux/lib/$(LIB))
-    $(DD D runtime library (copy to $(D /usr/lib/$(LIB))))
-    )
-    )
-    $(FREEBSD
-    $(DT $(D $(DMDDIR)/freesd/bin/ddemangle)
-    $(DD D symbol demangler)
-    )
-
-    $(DT $(D $(DMDDIR)/freebsd/bin/dman)
-    $(DD D manual lookup tool)
-    )
-
-    $(DT $(D $(DMDDIR)/freebsd/bin/dmd)
-    $(DD D compiler executable)
-    )
-
-    $(DT $(D $(DMDDIR)/freebsd/bin/$(DMD_CONF))
-    $(DD Global compiler settings (copy to $(D /etc/dmd.conf)))
-    )
-
-    $(DT $(D $(DMDDIR)/freebsd/bin/$(DUB))
-    $(DD D's package manager)
-    )
-
-    $(DT $(D $(DMDDIR)/freebsd/bin/$(DUMPOBJ))
-    $(DD ELF file dumper)
-    )
-
-    $(DT $(D $(DMDDIR)/freebsd/bin/$(DUSTMITE))
-    $(DD D source code minimizer)
-    )
-
-    $(DT $(D $(DMDDIR)/freebsd/bin/$(OBJ2ASM))
-    $(DD ELF file disassembler)
-    )
-
-    $(DT $(D $(DMDDIR)/freebsd/bin/$(RDMD))
-    $(DD D build tool for script-like D code execution)
-    )
-
-    $(DT $(D $(DMDDIR)/freebsd/bin/$(SHELL))
-    $(DD Simple command line shell)
-    )
-
-    $(DT $(D $(DMDDIR)/freebsd/lib/$(LIB))
-    $(DD D runtime library (copy to $(D /usr/lib/$(LIB))))
-    )
-    )
-    $(OSX
-    $(DT $(D $(DMDDIR)/osx/bin/ddemangle)
-    $(DD D symbol demangler)
-    )
-
-    $(DT $(D $(DMDDIR)/osx/bin/dman)
-    $(DD D manual lookup tool)
-    )
-
-    $(DT $(D $(DMDDIR)/osx/bin/dmd)
-    $(DD D compiler executable)
-    )
-
-    $(DT $(D $(DMDDIR)/osx/bin/$(DMD_CONF))
-    $(DD Global compiler settings (copy to $(D /etc/dmd.conf)))
-    )
-
-    $(DT $(D $(DMDDIR)/osx/bin/$(DUB))
-    $(DD D's package manager)
-    )
-
-    $(DT $(D $(DMDDIR)/osx/bin/$(DUMPOBJ))
-    $(DD Mach-O file dumper)
-    )
-
-    $(DT $(D $(DMDDIR)/osx/bin/$(DUSTMITE))
-    $(DD D source code minimizer)
-    )
-
-    $(DT $(D $(DMDDIR)/osx/bin/$(OBJ2ASM))
-    $(DD Mach-O file disassembler)
-    )
-
-    $(DT $(D $(DMDDIR)/osx/bin/$(RDMD))
-    $(DD D build tool for script-like D code execution)
-    )
-
-    $(DT $(D $(DMDDIR)/osx/bin/$(SHELL))
-    $(DD Simple command line shell)
-    )
-
-    $(DT $(D $(DMDDIR)/osx/lib/$(LIB))
-    $(DD D runtime library (copy to $(D /usr/local/lib/$(LIB))))
-    )
-    )
-
     )
 
 $(H2 $(LNAME2 installation, Installation))
@@ -929,6 +722,215 @@ dmd -cov -unittest myprog.d
     $(WINDOWS
     $(P Empty switches, i.e. "", are ignored.)
     )
+
+$(H2 $(LNAME2 files, Files))
+
+    $(DL
+
+    $(DT $(D $(DMDDIR)$(SEP)src$(SEP)phobos$(SEP))
+    $(DD D runtime library source)
+    )
+
+    $(DT $(D $(DMDDIR)$(SEP)src$(SEP)dmd$(SEP))
+    $(DD D compiler front end source under dual (GPL and Artistic) license)
+    )
+
+    $(DT $(D $(DMDDIR)$(SEP)html$(SEP)d$(SEP))
+    $(DD Documentation)
+    )
+
+    $(DT $(D $(DMDDIR)$(SEP)samples$(SEP)d$(SEP))
+    $(DD Sample D programs)
+    )
+    $(WINDOWS
+
+    $(DT $(D $(DMDDIR)\windows\bin\ddemangle.exe)
+    $(DD D symbol demangler)
+    )
+
+    $(DT $(D $(DMDDIR)\windows\bin\dman.exe)
+    $(DD D manual lookup tool)
+    )
+
+    $(DT $(D $(DMDDIR)\windows\bin\dmd.exe)
+    $(DD D compiler executable)
+    )
+
+    $(DT $(D $(DMDDIR)\windows\bin\$(DUB))
+    $(DD D's package manager)
+    )
+
+    $(DT $(D $(DMDDIR)\windows\bin\$(DUSTMITE))
+    $(DD D source code minimizer)
+    )
+
+    $(DT $(D $(DMDDIR)\windows\bin\$(LINK2 http://www.digitalmars.com/ctg/optlink.html, link.exe))
+    $(DD OPTLINK)
+    )
+
+    $(DT $(D $(DMDDIR)\windows\bin\$(LINK2 http://www.digitalmars.com/ctg/make.html, make.exe))
+    $(DD Digitalmars Make)
+    )
+
+    $(DT $(D $(DMDDIR)\windows\bin\replace.exe)
+    $(DD Find/replace text in files)
+    )
+
+    $(DT $(D $(DMDDIR)\windows\bin\$(RDMD))
+    $(DD D build tool for script-like D code execution)
+    )
+
+    $(DT $(D $(DMDDIR)\windows\bin\$(SC_INI))
+    $(DD Global compiler settings)
+    )
+
+    $(DT $(D $(DMDDIR)\windows\bin\$(LINK2 http://www.digitalmars.com/ctg/shell.html, shell.exe))
+    $(DD Simple command line shell)
+    )
+
+    $(DT $(D $(DMDDIR)\windows\bin\$(LINK2 http://www.digitalmars.com/d/2.0/windbg.html, windbg.exe))
+    $(DD Microsoft debugger)
+    )
+
+    $(DT $(D $(DMDDIR)\windows\lib\$(LIB))
+    $(DD D runtime library)
+    )
+    )
+    $(LINUX
+    $(DT $(D $(DMDDIR)/linux/bin/ddemangle)
+    $(DD D symbol demangler)
+    )
+
+    $(DT $(D $(DMDDIR)/linux/bin/dman)
+    $(DD D manual lookup tool)
+    )
+
+    $(DT $(D $(DMDDIR)/linux/bin/dmd)
+    $(DD D compiler executable)
+    )
+
+    $(DT $(D $(DMDDIR)/linux/bin/$(DMD_CONF))
+    $(DD Global compiler settings (copy to $(D /etc/dmd.conf)))
+    )
+
+    $(DT $(D $(DMDDIR)/linux/bin/$(DUB))
+    $(DD D's package manager)
+    )
+
+    $(DT $(D $(DMDDIR)/linux/bin/$(DUMPOBJ))
+    $(DD ELF file dumper)
+    )
+
+    $(DT $(D $(DMDDIR)/linux/bin/$(DUSTMITE))
+    $(DD D source code minimizer)
+    )
+
+    $(DT $(D $(DMDDIR)/linux/bin/$(OBJ2ASM))
+    $(DD ELF file disassembler)
+    )
+
+    $(DT $(D $(DMDDIR)/linux/bin/$(RDMD))
+    $(DD D build tool for script-like D code execution)
+    )
+
+    $(DT $(D $(DMDDIR)/linux/lib/$(LIB))
+    $(DD D runtime library (copy to $(D /usr/lib/$(LIB))))
+    )
+    )
+    $(FREEBSD
+    $(DT $(D $(DMDDIR)/freesd/bin/ddemangle)
+    $(DD D symbol demangler)
+    )
+
+    $(DT $(D $(DMDDIR)/freebsd/bin/dman)
+    $(DD D manual lookup tool)
+    )
+
+    $(DT $(D $(DMDDIR)/freebsd/bin/dmd)
+    $(DD D compiler executable)
+    )
+
+    $(DT $(D $(DMDDIR)/freebsd/bin/$(DMD_CONF))
+    $(DD Global compiler settings (copy to $(D /etc/dmd.conf)))
+    )
+
+    $(DT $(D $(DMDDIR)/freebsd/bin/$(DUB))
+    $(DD D's package manager)
+    )
+
+    $(DT $(D $(DMDDIR)/freebsd/bin/$(DUMPOBJ))
+    $(DD ELF file dumper)
+    )
+
+    $(DT $(D $(DMDDIR)/freebsd/bin/$(DUSTMITE))
+    $(DD D source code minimizer)
+    )
+
+    $(DT $(D $(DMDDIR)/freebsd/bin/$(OBJ2ASM))
+    $(DD ELF file disassembler)
+    )
+
+    $(DT $(D $(DMDDIR)/freebsd/bin/$(RDMD))
+    $(DD D build tool for script-like D code execution)
+    )
+
+    $(DT $(D $(DMDDIR)/freebsd/bin/$(SHELL))
+    $(DD Simple command line shell)
+    )
+
+    $(DT $(D $(DMDDIR)/freebsd/lib/$(LIB))
+    $(DD D runtime library (copy to $(D /usr/lib/$(LIB))))
+    )
+    )
+    $(OSX
+    $(DT $(D $(DMDDIR)/osx/bin/ddemangle)
+    $(DD D symbol demangler)
+    )
+
+    $(DT $(D $(DMDDIR)/osx/bin/dman)
+    $(DD D manual lookup tool)
+    )
+
+    $(DT $(D $(DMDDIR)/osx/bin/dmd)
+    $(DD D compiler executable)
+    )
+
+    $(DT $(D $(DMDDIR)/osx/bin/$(DMD_CONF))
+    $(DD Global compiler settings (copy to $(D /etc/dmd.conf)))
+    )
+
+    $(DT $(D $(DMDDIR)/osx/bin/$(DUB))
+    $(DD D's package manager)
+    )
+
+    $(DT $(D $(DMDDIR)/osx/bin/$(DUMPOBJ))
+    $(DD Mach-O file dumper)
+    )
+
+    $(DT $(D $(DMDDIR)/osx/bin/$(DUSTMITE))
+    $(DD D source code minimizer)
+    )
+
+    $(DT $(D $(DMDDIR)/osx/bin/$(OBJ2ASM))
+    $(DD Mach-O file disassembler)
+    )
+
+    $(DT $(D $(DMDDIR)/osx/bin/$(RDMD))
+    $(DD D build tool for script-like D code execution)
+    )
+
+    $(DT $(D $(DMDDIR)/osx/bin/$(SHELL))
+    $(DD Simple command line shell)
+    )
+
+    $(DT $(D $(DMDDIR)/osx/lib/$(LIB))
+    $(DD D runtime library (copy to $(D /usr/local/lib/$(LIB))))
+    )
+    )
+
+    )
+
+
 
 $(H2 $(LNAME2 linking, Linking))
 


### PR DESCRIPTION
Most people opening dmd-*.html are looking for a description of the CLI flags or maybe an installation guide. While a complete listing of the files is nice, it's not super-useful to the user.
Hence, I moved it down a few section (below the CLI argument listing).