### PR TITLE
Auto-generate a TOC for the compiler help pages

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -2,23 +2,7 @@ Ddoc
 
 $(D_S dmd - $(WINDOWS Windows)$(LINUX Linux)$(OSX Mac OS X)$(FREEBSD FreeBSD) D Compiler,
 
-    $(UL
-    $(LI $(RELATIVE_LINK2 requirements, Requirements and Downloads))
-    $(LI $(RELATIVE_LINK2 files, Files))
-    $(LI $(RELATIVE_LINK2 installation, Installation))
-    $(WINDOWS $(LI $(RELATIVE_LINK2 example, Example)))
-    $(LI $(RELATIVE_LINK2 switches, Compiler Arguments and Switches))
-    $(LI $(RELATIVE_LINK2 linking, Linking))
-    $(LI $(RELATIVE_LINK2 environment, Environment Variables))
-    $(WINDOWS $(LI $(RELATIVE_LINK2 sc-ini, sc.ini Initialization File)))
-    $(UNIX $(LI $(DMD_CONF) Initialization File))
-    $(WINDOWS $(LI $(RELATIVE_LINK2 problems, Common Installation Problems)))
-    $(LI $(RELATIVE_LINK2 differences, Differences between Windows and Linux versions))
-    $(LI $(RELATIVE_LINK2 interface-files, D Interface Files))
-    $(LI $(RELATIVE_LINK2 library, Building Libraries))
-    $(LI $(RELATIVE_LINK2 compiling-dmd, Compiling dmd))
-    $(LI $(RELATIVE_LINK2 compiling-phobos, Compiling Phobos))
-    )
+    $(HEADERNAV_TOC)
 
 $(H2 $(LNAME2 requirements, Requirements and Downloads))
 

--- a/posix.mak
+++ b/posix.mak
@@ -503,8 +503,8 @@ $W/% : %
 	@mkdir -p $(dir $@)
 	cp $< $@
 
-$W/dmd-%.html : %.ddoc dcompiler.dd $(DDOC) $(DMD)
-	$(DMD) -conf= -c -o- -Df$@ $(DDOC) dcompiler.dd $<
+$W/dmd-%.html : %.ddoc dcompiler.dd $(DDOC) $(DDOC_BIN)
+	$(DDOC_BIN) -Df$@ $(DDOC) dcompiler.dd $<
 
 $W/dmd-%.verbatim : %.ddoc dcompiler.dd verbatim.ddoc $(DMD)
 	$(DMD) -c -o- -Df$@ verbatim.ddoc dcompiler.dd $<


### PR DESCRIPTION
We now can generate nice TOCs.

Before:

![image](https://user-images.githubusercontent.com/4370550/35793826-85d33f7a-0a53-11e8-88de-f3c3d6bd3943.png)


After:

![image](https://user-images.githubusercontent.com/4370550/35793772-66228708-0a53-11e8-9843-8bce1cd22bd6.png)