### PR TITLE
Check all files for undefined ddoc

### DIFF
--- a/faq.dd
+++ b/faq.dd
@@ -225,7 +225,7 @@ $(ITEM q4, Why is printf in D?)
         is not part of D, it is part of C's standard
         runtime library which is accessible from D.
         D's standard runtime library has
-        $(LINK2 https://dlang.org/phobos/std_stdio.html#writefln, std.stdio.writefln),
+        $(REF writefln, std,stdio)
         which is as powerful as $(LINK2 http://www.digitalmars.com/rtl/stdio.html#printf, printf)
         but is much easier to use.
         )
@@ -393,7 +393,7 @@ $(ITEM printf, How do I get printf() to work with strings?)
 $(CCODE
 char s[8];
 strcpy(s, "foo");
-printf("string = '$(B %s)'\n", s);
+printf("string = '%s'\n", s);
 )
 
         Attempting this in D, as in:
@@ -401,7 +401,7 @@ printf("string = '$(B %s)'\n", s);
 ---------------------------------
 char[] s;
 s = "foo";
-printf("string = '$(B %s)'\n", s);
+printf("string = '%s'\n", s);
 ---------------------------------
 
         usually results in garbage being printed, or an access violation.
@@ -414,7 +414,7 @@ printf("string = '$(B %s)'\n", s);
 ---------------------------------
 char[] s;
 s = "foo";
-printf("string = '$(B %.*s)'\n", s);
+printf("string = '%.*s'\n", s);
 ---------------------------------
 
         $(P which will behave as expected.
@@ -423,7 +423,7 @@ printf("string = '$(B %.*s)'\n", s);
         will only print up to the first 0.
         )
 
-        $(P Of course, the easier solution is just use $(B std.stdio.writefln)
+        $(P Of course, the easier solution is just use $(REF writefln, std, stdio)
         which works correctly with D strings.
         )
 

--- a/html.ddoc
+++ b/html.ddoc
@@ -18,6 +18,7 @@ DIVC = $(TC div, $1, $+)
 DIVCID = $(DIV class="$1" id="$2", $3)
 DIVID = $(DIV id="$1", $+)
 DL = $(T dl, $0)
+DOLLAR=&dollar;
 DOUBLEQUOTE = $(LDQUO)$0$(RDQUO)
 DT = $(T dt, $0)
 EMC = $(TC em, $1, $+)

--- a/install.dd
+++ b/install.dd
@@ -148,7 +148,7 @@ and `PS1` environment variables.
 It's also possible to combine this into one command:
 
 $(CONSOLE
-source $(~/dlang/install.sh dmd -a)
+source $(DOLLAR)(~/dlang/install.sh dmd -a)
 )
 
 The activated compiler can be removed from the current session by restoring

--- a/posix.mak
+++ b/posix.mak
@@ -870,6 +870,7 @@ test_dspec: dspec_tester.d $(DMD) $(PHOBOS_LIB)
 	@echo "Test the D Language specification"
 	$(DMD) -run $< --compiler=$(DMD)
 
+.PHONY:
 test: $(ASSERT_WRITELN_BIN)_test test_dspec test/next_version.sh all
 	@echo "Searching for trailing whitespace"
 	@grep -n '[[:blank:]]$$' $$(find . -type f -name "*.dd" | grep -v .generated) ; test $$? -eq 1
@@ -878,7 +879,7 @@ test: $(ASSERT_WRITELN_BIN)_test test_dspec test/next_version.sh all
 	@echo "Searching for undefined macros"
 	@grep -n "UNDEFINED MACRO" $$(find $W -type f -name "*.html" -not -path "$W/phobos/*") ; test $$? -eq 1
 	@echo "Searching for undefined ddoc"
-	@grep -rn '[$$](' $$(find $W/phobos-prerelease -type f -name "*.html") ; test $$? -eq 1
+	@grep -n "[\$$]([^']" $$(find $W -type f -name "*.html" -not -path "$W/phobos/*") ; test $$? -eq 1
 	@echo "Executing assert_writeln_magic tests"
 	$<
 	@echo "Executing next_version tests"

--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -502,13 +502,13 @@ $(P
 
 $(P
     Text inside these sections will be escaped according to the rules described above,
-    then wrapped in a `$(RAW_DOLLAR)(DDOC_BACKQUOTED)` macro. By default, this macro expands
+    then wrapped in a `$(DOLLAR)(DDOC_BACKQUOTED)` macro. By default, this macro expands
     to be displayed as an inline text span, formatted as code.
 )
 
 $(P
     A literal backtick character can be output either as a non-paired $(BACKTICK) on a single
-    line or by using the `$(RAW_DOLLAR)(BACKTICK)` macro.
+    line or by using the `$(DOLLAR)(BACKTICK)` macro.
 )
 
 ---
@@ -979,4 +979,3 @@ $(SPEC_SUBNAV_PREV_NEXT iasm, D x86 Inline Assembler, interfaceToC, Interfacing 
 Macros:
     CHAPTER=31
     TITLE=Documentation Generator
-    RAW_DOLLAR=$

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -74,7 +74,7 @@ $(GNAME AltDeclaratorSuffixes):
 
 $(GNAME AltDeclaratorSuffix):
     $(D [ ])
-    $(D [) $($(GLINK2 expression, AssignExpression)) $(D ])
+    $(D [) $(GLINK2 expression, AssignExpression) $(D ])
     $(D [) $(GLINK Type) $(D ])
 
 $(GNAME AltFuncDeclaratorSuffix):
@@ -135,8 +135,8 @@ $(GNAME BasicType2):
 $(GNAME BasicType2X):
     $(D *)
     $(D [ ])
-    $(D [) $($(GLINK2 expression, AssignExpression)) $(D ])
-    $(D [) $($(GLINK2 expression, AssignExpression)) .. $($(GLINK2 expression, AssignExpression)) $(D ])
+    $(D [) $(GLINK2 expression, AssignExpression) $(D ])
+    $(D [) $(GLINK2 expression, AssignExpression) .. $(GLINK2 expression, AssignExpression) $(D ])
     $(D [) $(GLINK Type) $(D ])
     $(D delegate) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT)
     $(D function) $(GLINK2 function, Parameters) $(GLINK2 function, FunctionAttributes)$(OPT)
@@ -146,7 +146,7 @@ $(GNAME IdentifierList):
     $(I Identifier) $(D .) $(I IdentifierList)
     $(GLINK2 template, TemplateInstance)
     $(GLINK2 template, TemplateInstance) $(D .) $(I IdentifierList)
-    $(I Identifier) $(D [) $($(GLINK2 expression, AssignExpression)) $(D].) $(I IdentifierList)
+    $(I Identifier) $(D [) $(GLINK2 expression, AssignExpression) $(D].) $(I IdentifierList)
 )
 
 $(GRAMMAR
@@ -189,7 +189,7 @@ $(GNAME NonVoidInitializer):
     $(GLINK StructInitializer)
 
 $(GNAME ExpInitializer):
-    $($(GLINK2 expression, AssignExpression))
+    $(GLINK2 expression, AssignExpression)
 
 $(GNAME ArrayInitializer):
     $(D [) $(GLINK ArrayMemberInitializations)$(OPT) $(D ])
@@ -201,7 +201,7 @@ $(GNAME ArrayMemberInitializations):
 
 $(GNAME ArrayMemberInitialization):
     $(GLINK NonVoidInitializer)
-    $($(GLINK2 expression, AssignExpression)) $(D :) $(GLINK NonVoidInitializer)
+    $(GLINK2 expression, AssignExpression) $(D :) $(GLINK NonVoidInitializer)
 
 $(GNAME StructInitializer):
     $(D {) $(GLINK StructMemberInitializers)$(OPT) $(D })


### PR DESCRIPTION
Extends the undefined ddoc check for all files and fixes the violations.