### PR TITLE
Fix trailing parenthesis + add test

### DIFF
--- a/articles/cpptod.dd
+++ b/articles/cpptod.dd
@@ -14,9 +14,6 @@ See also: <a href="ctod.html">Programming in D for C Programmers</a>
 
 $(HEADERNAV_TOC)
 
-)
-
-
 <hr>$(COMMENT  -------------------------------------------- )
 
 $(H2 $(LNAME2 constructors, Defining constructors))
@@ -903,7 +900,7 @@ SecondVariant.method();
 
 <hr>$(COMMENT  -------------------------------------------- )
 
-$(H3 $(LNAME2 references, References in D))
+$(H2 $(LNAME2 references, References in D))
 
 
         D doesn't have a (C++-style) concept of references as part of the type. Arguments can be passed by reference - hence the `ref` keyword, but "free" references don't exist in the language.

--- a/check_ddoc.d
+++ b/check_ddoc.d
@@ -1,0 +1,81 @@
+#!/usr/bin/env rdmd
+/**
+Search HTML output for errors:
+- for undefined Ddoc macros
+- raw macro leakage
+- trailing parenthesis
+*/
+import std.algorithm, std.file, std.functional, std.range, std.stdio;
+
+shared int errors = 0;
+
+void error(string name, string file, size_t lineNr, const(char)[] line)
+{
+    import core.atomic;
+    errors.atomicOp!"+="(1);
+    synchronized
+    {
+        stderr.writefln("%s:%d: [%s] %s", file, lineNr, name, line);
+    }
+}
+
+enum ErrorMessages
+{
+    undefinedMacro = "UNDEFINED MACRO",
+    rawMacroLeakage = "RAW MACRO LEAKAGE",
+    trailingParenthesis = "TRAILING PARENTHESIS",
+}
+
+void checkLine(alias errorFun)(string file, size_t lineNr, const(char)[] line)
+{
+    if (line.canFind("UNDEFINED MACRO"))
+        errorFun(ErrorMessages.undefinedMacro, file, lineNr, line);
+
+    if (line.findSplitAfter("$(")
+            .pipe!(a => !a.expand.only.any!empty && a[1].front != '\''))
+        errorFun(ErrorMessages.rawMacroLeakage, file, lineNr, line);
+
+    if (line.equal(")"))
+        errorFun(ErrorMessages.trailingParenthesis, file, lineNr, line);
+}
+
+version(unittest) {} else
+int main(string[] args)
+{
+    import std.parallelism : parallel;
+
+    auto files = args[1 .. $];
+    foreach (file; files.parallel(1))
+        foreach (nr, line; File(file, "r").byLine.enumerate)
+            checkLine!error(file, nr, line);
+
+    if (errors > 0)
+        stderr.writefln("%s error%s found. Exiting.", errors, errors > 1 ? "s" : "");
+
+    return errors != 0;
+}
+
+unittest
+{
+    string lastSeenError;
+    void errorStub(string name, string file, size_t lineNr, const(char)[] line)
+    {
+        lastSeenError = name;
+    }
+    auto check(string line)
+    {
+        lastSeenError = null;
+        checkLine!errorStub(null, 0, line);
+        return lastSeenError;
+    }
+
+    assert(check(` <!--UNDEFINED MACRO: "D_CONTRIBUTORS"--> `) == ErrorMessages.undefinedMacro);
+
+    assert(check("  $('") is null);
+    assert(check("  $(") is null);
+    assert(check("  $(FOO)") == ErrorMessages.rawMacroLeakage);
+
+    assert(check("  )") is null);
+    assert(check(") ") is null);
+    assert(check(")") == ErrorMessages.trailingParenthesis);
+}

--- a/posix.mak
+++ b/posix.mak
@@ -477,7 +477,7 @@ $W/spec/%.html : spec/%.dd $(SPEC_DDOC) $(DMD) $(DDOC_BIN)
 $W/404.html : 404.dd $(DDOC) $(DMD)
 	$(DMD) -conf= -c -o- -Df$@ $(DDOC) errorpage.ddoc $<
 
-$(DOC_OUTPUT_DIR)/contributors.html: contributors.dd $G/contributors_list.ddoc $(DDOC) $(DMD)
+$(DOC_OUTPUT_DIR)/foundation/contributors.html: foundation/contributors.dd $G/contributors_list.ddoc $(DDOC) $(DMD)
 	$(DMD) -conf= -c -o- -Df$@ $(DDOC) $(word 2, $^) $<
 
 $W/articles/%.html : articles/%.dd $(DDOC) $(DMD) $(DDOC_BIN) articles/articles.ddoc
@@ -884,15 +884,14 @@ test_dspec: dspec_tester.d $(DMD) $(PHOBOS_LIB)
 	$(DMD) -run $< --compiler=$(DMD)
 
 .PHONY:
-test: $(ASSERT_WRITELN_BIN)_test test_dspec test/next_version.sh all
+test: $(ASSERT_WRITELN_BIN)_test test_dspec test/next_version.sh all | $(STABLE_DMD)
 	@echo "Searching for trailing whitespace"
 	@grep -n '[[:blank:]]$$' $$(find . -type f -name "*.dd" | grep -v .generated) ; test $$? -eq 1
 	@echo "Searching for tabs"
 	@grep -n -P "\t" $$(find . -type f -name "*.dd" | grep -v .generated) ; test $$? -eq 1
-	@echo "Searching for undefined macros"
-	@grep -n "UNDEFINED MACRO" $$(find $W -type f -name "*.html" -not -path "$W/phobos/*") ; test $$? -eq 1
-	@echo "Searching for undefined ddoc"
-	@grep -n "[\$$]([^']" $$(find $W -type f -name "*.html" -not -path "$W/phobos/*") ; test $$? -eq 1
+	@echo "Checking DDoc's output"
+	$(STABLE_RDMD) -main -unittest check_ddoc.d
+	$(STABLE_RDMD) check_ddoc.d $$(find $W -type f -name "*.html" -not -path "$W/phobos/*")
 	@echo "Executing assert_writeln_magic tests"
 	$<
 	@echo "Executing next_version tests"


### PR DESCRIPTION
DAutoTest should fail when a trailing parenthesis is found.
Luckily, Ddoc is dump enough to just put them in an empty line with `$`.

Note that this requires all files to use unix file endings.
There was one violation which I fixed and added a test for the future.