### PR TITLE
Turn curl downloads of the DBlog into hard failures

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -577,7 +577,8 @@ $G/dlangspec.verbatim.txt : $G/dlangspec-consolidated.d $(DMD) verbatim.ddoc
 
 $G/dblog_latest.ddoc:
 	@echo "Receiving the latest DBlog article. Disable with DIFFABLE=1"
-	curl -s --retry 3 --retry-delay 5 http://blog.dlang.org > $(TMP)/blog.html
+	curl -s --fail --retry 3 --retry-delay 5 http://blog.dlang.org > $(TMP)/blog.html
+	@[ $? -eq 0 ] || (echo "Curl couldn't connect to the DBlog."; exit 1)
 	cat $(TMP)/blog.html | grep -m1 'entry-title' | \
 		sed -E 's/^.*<a href="(.+)" rel="bookmark">([^<]+)<\/a>.*<time.*datetime="[^"]+">([^<]*)<\/time><time class="updated".*Author *<\/span><a [^>]+>([^<]+)<\/a>.*/DBLOG_LATEST_TITLE=\2|DBLOG_LATEST_LINK=\1|DBLOG_LATEST_DATE=\3|DBLOG_LATEST_AUTHOR=\4/' | \
 		tr '|' '\n' > $@


### PR DESCRIPTION
This will trigger a hard failure when curl fails to download from the DBlog.
Example (with an invalid url):

```
curl -s --fail --retry 3 --retry-delay 5 http://blog22.dlang.org > /tmp/blog.html
make: *** [posix.mak:580: .generated/dblog_latest.ddoc] Error 6
```

The idea is to prevent this from happening again in production:

![image](https://user-images.githubusercontent.com/4370550/35853185-1d5c17b6-0b2d-11e8-93c8-dde3dd320611.png)