### PR TITLE
Use /bin/bash as SHELL for dlang.org to have more consistent behavior across platforms and distros

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -128,6 +128,7 @@
 #  See also: https://dlang.org/blog/2017/03/08/editable-and-runnable-doc-examples-on-dlang-org
 PWD=$(shell pwd)
 MAKEFILE=$(firstword $(MAKEFILE_LIST))
+SHELL:=/bin/bash
 
 # Latest released version
 ifeq (,${LATEST})


### PR DESCRIPTION
To avoids things like https://github.com/dlang/dlang.org/pull/2180