### PR TITLE
Make Donate button responsive

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1353,196 +1353,6 @@ body.chm dt.d_decl
     width: 100%;
 }
 
-body#Home > .container
-{
-    max-width: none;
-    padding: 0;
-}
-
-body#Home #content #tools,
-body#Home #content > .intro
-{
-    background: #F5F5F5;
-}
-
-body#Home #content > h1
-{
-    margin: 0;
-}
-
-body#Home #content > .intro
-{
-    padding: 1em 0 1em;
-    border-bottom: 1px solid #E6E6E6;
-}
-
-body#Home #content > .intro > div > div
-{
-    display: table;
-    width: 100%;
-}
-
-body#Home #content > .intro > div > div > *
-{
-    display: table-cell;
-}
-
-body#Home #content > .intro .pitch
-{
-    font-size: large;
-    font-weight: 300;
-    margin: auto;
-    width: 22em;
-}
-
-body#Home #content > .intro .download
-{
-    margin-top: 3em;
-    text-align: center;
-}
-
-body#Home #content > .intro .download .btn
-{
-    margin: 0 0.3em 0.3em 0.3em;
-}
-
-body#Home #content > .intro .download .btn.action
-{
-    border-color: #98312A;
-    background-color: #B03931;
-    color: white;
-}
-
-body#Home #content > .intro .download .btn.action:hover
-{
-    border-color: #943029;
-    background-color: #742620;
-    color: white;
-}
-
-.org_list_header h3
-{
-    margin: 1em 0 .5em;
-}
-
-.org_list
-{
-    max-width: 1400px;
-    margin: 0 auto;
-    padding: 20px 0;
-
-    display: flex;
-    align-items: center;
-    flex-direction: row;
-    justify-content: space-evenly;
-    flex-wrap: wrap;
-}
-
-.org_list a img
-{
-    max-width: 150px;
-    max-height: 60px;
-}
-
-.org_list_footer
-{
-    margin-bottom: 3em;
-}
-
-.org_list_footer a
-{
-    display: inline-block;
-    padding: 0;
-}
-.org_list_footer a:not(:last-child)
-{
-    padding-right: 10px;
-}
-
-body#Home #content > .intro #your-code-here
-{
-    padding-left: 1em;
-    position: relative;
-    width: 32em;
-}
-
-body#Home #content > .intro #your-code-here .tip
-{
-    position: absolute;
-    top: 0.1em;
-    right: 0.3em;
-    z-index: 1;
-}
-
-body#Home #content > .intro #your-code-here pre
-{
-    margin: 0;
-}
-
-body#Home div#news
-{
-    float: right;
-    width: 252px;
-}
-
-body#Home div#forum-summary
-{
-    color: white;
-    width: 100%;
-    margin-right: 1em;
-}
-
-body#Home div#forum-summary > iframe
-{
-    border: 0;
-    width: 100%;
-    height: 210px;
-}
-
-body#Home .more .boxes, body#Home .more .whyd
-{
-    margin-right: 252px; /* prevent overlapping with #news */
-    padding-right: 4em;
-}
-
-body#Home .boxes .item .big-icon
-{
-    padding-right: 0.5em;
-}
-
-body#Home .whyd .section
-{
-    margin-bottom: 1.5em;
-    border-left: 5px solid #B03931;
-    border-radius: 4px;
-}
-body#Home .whyd .section > div
-{
-    border: 1px solid #E6E6E6;
-    border-left: none;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
-    padding: 1.5em;
-}
-body#Home .whyd .section > div > *:first-child
-{
-    margin-top: 0;
-}
-body#Home .whyd .section > div > *:last-child
-{
-    margin-bottom: 0;
-}
-
-body#Menu #content li.expand-container a::after
-{
-    content: "";
-}
-
-body#Menu #content li.expand-container ul
-{
-    display: block;
-}
-
 .boxes
 {
     margin: 2em 0;
@@ -2053,44 +1863,10 @@ div.openInEditorButton {
     }
 }
 
-/* Narrow layout stage 2: hamburger menu, forum/twitter widgets disappear from
-the home page, intro pitch and your-code-here layed out vertically */
+
+/* Narrow layout stage 2: hamburger menu */
 @media only screen and (max-width:54em)
 {
-    body#Home #content > .intro > div > div
-    {
-        display: block;
-        width: auto;
-    }
-
-    body#Home #content > .intro > div > div > *
-    {
-        display: block;
-    }
-
-    body#Home #content > .intro .pitch
-    {
-        max-width: 22em;
-        width: auto;
-    }
-
-    body#Home #content > .intro #your-code-here
-    {
-        padding: 0;
-        margin: auto;
-        margin-top: 2em;
-    }
-
-    body#Home #news
-    {
-        display: none;
-    }
-
-    body#Home .more .boxes, body#Home .more .whyd
-    {
-        margin-right: 0;
-        padding-right: 0;
-    }
 
     #top > .helper
     {
@@ -2229,16 +2005,6 @@ the home page, intro pitch and your-code-here layed out vertically */
         content: "\f0c9"; /* bars */
         font-family: FontAwesome;
     }
-
-    .org_list a img
-    {
-        padding: 1em 2em;
-    }
-
-    .call_to_donate
-    {
-        padding: 40px 80px;
-    }
 }
 
 /* Narrow layout stage 3: no more two column boxes */
@@ -2249,26 +2015,6 @@ the home page, intro pitch and your-code-here layed out vertically */
         display: block;
         padding: 0;
         width: auto;
-    }
-
-    body#Home #content > .intro #your-code-here
-    {
-        /* change width to max-width */
-        width: auto;
-        max-width: 32em;
-    }
-
-    body#Home #content > .intro #your-code-here .tip {
-        display: none;
-    }
-
-    #your-code-here-select-example select {
-        width: 100%;
-    }
-
-    .call_to_donate
-    {
-        padding: 20px 40px;
     }
 }
 

--- a/index.dd
+++ b/index.dd
@@ -750,6 +750,271 @@ Macros:
             padding-bottom: 10px;
             font-size: 16px;
         }
+
+        body#Home #content > .intro #your-code-here
+        {
+            padding-left: 1em;
+            position: relative;
+            width: 32em;
+        }
+
+        body#Home #content > .intro #your-code-here .tip
+        {
+            position: absolute;
+            top: 0.1em;
+            right: 0.3em;
+            z-index: 1;
+        }
+
+        body#Home #content #tools,
+        body#Home #content > .intro
+        {
+            background: #F5F5F5;
+        }
+
+        body#Home #content > h1
+        {
+            margin: 0;
+        }
+
+        body#Home #content > .intro
+        {
+            padding: 1em 0 1em;
+            border-bottom: 1px solid #E6E6E6;
+        }
+
+        body#Home #content > .intro > div > div
+        {
+            display: table;
+            width: 100%;
+        }
+
+        body#Home #content > .intro > div > div > *
+        {
+            display: table-cell;
+        }
+
+        body#Home #content > .intro .pitch
+        {
+            font-size: large;
+            font-weight: 300;
+            margin: auto;
+            width: 22em;
+        }
+
+        body#Home #content > .intro .download
+        {
+            margin-top: 3em;
+            text-align: center;
+        }
+
+        body#Home #content > .intro .download .btn
+        {
+            margin: 0 0.3em 0.3em 0.3em;
+        }
+
+        body#Home #content > .intro .download .btn.action
+        {
+            border-color: #98312A;
+            background-color: #B03931;
+            color: white;
+        }
+
+        body#Home #content > .intro .download .btn.action:hover
+        {
+            border-color: #943029;
+            background-color: #742620;
+            color: white;
+        }
+
+        body#Home #content > .intro #your-code-here pre
+        {
+            margin: 0;
+        }
+
+        body#Home div#news
+        {
+            float: right;
+            width: 252px;
+        }
+
+        body#Home div#forum-summary
+        {
+            color: white;
+            width: 100%;
+            margin-right: 1em;
+        }
+
+        body#Home div#forum-summary > iframe
+        {
+            border: 0;
+            width: 100%;
+            height: 210px;
+        }
+
+        body#Home .more .boxes, body#Home .more .whyd
+        {
+            margin-right: 252px; /* prevent overlapping with #news */
+            padding-right: 4em;
+        }
+
+        body#Home .boxes .item .big-icon
+        {
+            padding-right: 0.5em;
+        }
+
+        body#Home .whyd .section
+        {
+            margin-bottom: 1.5em;
+            border-left: 5px solid #B03931;
+            border-radius: 4px;
+        }
+        body#Home .whyd .section > div
+        {
+            border: 1px solid #E6E6E6;
+            border-left: none;
+            border-top-right-radius: 4px;
+            border-bottom-right-radius: 4px;
+            padding: 1.5em;
+        }
+        body#Home .whyd .section > div > *:first-child
+        {
+            margin-top: 0;
+        }
+        body#Home .whyd .section > div > *:last-child
+        {
+            margin-bottom: 0;
+        }
+
+        body#Home > .container
+        {
+            max-width: none;
+            padding: 0;
+        }
+
+        .org_list_header h3
+        {
+            margin: 1em 0 .5em;
+        }
+
+        .org_list
+        {
+            max-width: 1400px;
+            margin: 0 auto;
+            padding: 20px 0;
+
+            display: flex;
+            align-items: center;
+            flex-direction: row;
+            justify-content: space-evenly;
+            flex-wrap: wrap;
+        }
+
+        .org_list a img
+        {
+            max-width: 150px;
+            max-height: 60px;
+        }
+
+        .org_list_footer
+        {
+            margin-bottom: 3em;
+        }
+
+        .org_list_footer a
+        {
+            display: inline-block;
+            padding: 0;
+        }
+        .org_list_footer a:not(:last-child)
+        {
+            padding-right: 10px;
+        }
+
+        body#Menu #content li.expand-container a::after
+        {
+            content: "";
+        }
+
+        body#Menu #content li.expand-container ul
+        {
+            display: block;
+        }
+
+        /* Narrow layout stage 2: forum/twitter widgets disappear from
+        the home page, intro pitch and your-code-here layed out vertically */
+        @media only screen and (max-width:54em)
+        {
+            body#Home #content > .intro > div > div
+            {
+                display: block;
+                width: auto;
+            }
+
+            body#Home #content > .intro > div > div > *
+            {
+                display: block;
+            }
+
+            body#Home #content > .intro .pitch
+            {
+                max-width: 22em;
+                width: auto;
+            }
+
+            body#Home #content > .intro #your-code-here
+            {
+                padding: 0;
+                margin: auto;
+                margin-top: 2em;
+            }
+
+            body#Home #news
+            {
+                display: none;
+            }
+
+            body#Home .more .boxes, body#Home .more .whyd
+            {
+                margin-right: 0;
+                padding-right: 0;
+            }
+
+            .org_list a img
+            {
+                padding: 1em 2em;
+            }
+
+            .call_to_donate
+            {
+                padding: 40px 80px;
+            }
+        }
+
+        /* Narrow layout stage 3: no more two column boxes */
+        @media only screen and (max-width: 40em)
+        {
+            body#Home #content > .intro #your-code-here
+            {
+                /* change width to max-width */
+                width: auto;
+                max-width: 32em;
+            }
+
+            body#Home #content > .intro #your-code-here .tip {
+                display: none;
+            }
+
+            #your-code-here-select-example select {
+                width: 100%;
+            }
+
+            .call_to_donate
+            {
+                padding: 20px 40px;
+            }
+        }
+
     )
     $(COMMENT index.html only for now, until we can figure out
               how to generate a URL to the current page for og:url)

--- a/index.dd
+++ b/index.dd
@@ -1011,7 +1011,11 @@ Macros:
 
             .call_to_donate
             {
-                padding: 20px 40px;
+                padding: 5px;
+            }
+            .call_to_donate .call_to_donate_btn
+            {
+                margin-bottom: 0.75em;
             }
         }
 


### PR DESCRIPTION
The first commit moves CSS styles affecting only the front page to `index.dd.`
This is done because:
- it keeps the main stylesheet thin and lean (easier for other sites to use it as base)
- it allows developers to know that all the changes they need to make are within the same file
- a step into only serving stylesheets needed for the current page to the user

We haven't done this before because Ddoc only allowed to do so with ugly workarounds (`padding: 0;` created a new section).
Though we have started following this pattern more and more over the last months and I used this opportunity to finally move a full chunk out of `style.css`

The second commit is the actual fix. Pretty simple.

CC @JackStouffer