### PR TITLE
DBlog now uses HTTPS by default

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -583,7 +583,7 @@ $G/dlangspec.verbatim.txt : $G/dlangspec-consolidated.d $(DMD) verbatim.ddoc
 
 $G/dblog_latest.html:
 	@echo "Receiving the latest DBlog article. Disable with DIFFABLE=1"
-	curl -s --fail --retry 3 --retry-delay 5 http://blog.dlang.org -o $@
+	curl -s --fail --retry 3 --retry-delay 5 -L https://blog.dlang.org -o $@
 
 $G/dblog_latest.ddoc: $G/dblog_latest.html
 	cat $< | grep -m1 'entry-title' | \


### PR DESCRIPTION
Apparentely Jan changed the config today and now it redirects to HTTPS by default:

```
> curl http://blog.dlang.org
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://blog.dlang.org/">here</a>.</p>
</body></html>
```

Our curl command here didn't use `-L`, hence this file was written and the following commands silently failed. I will work on making them fail louder, but for now we should pull this.
As an exception, I will merge this myself as it's a trivial change and we need to fix the front page ASAP.

edit: rebased to get the highest priority in the queue.