### PR TITLE
Fix missing redirects to /articles

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -68,25 +68,32 @@ Redirect 301 /dlangupb-scholarship.html https://dlang.org/foundation/updscholars
 Redirect 301 /donate.html https://dlang.org/foundation/donate.html
 
 # Legacy article pages
-Redirect 301 /ctod.html /articles/ctod.html
-Redirect 301 /cpptod.html /articles/cpptod.html
-Redirect 301 /pretod.html /articles/pretod.html
+Redirect 301 /articles.html /articles/index.html
+Redirect 301 /builtin.html /articles/builtin.html
 Redirect 301 /code_coverage.html /articles/code_coverage.html
+Redirect 301 /const-faq.html /articles/const-faq.html
+Redirect 301 /cppcontracts.html /articles/cppcontracts.html
+Redirect 301 /cpptod.html /articles/cpptod.html
+Redirect 301 /ctarguments.html /articles/ctarguments.html
+Redirect 301 /ctod.html /articles/ctod.html
+Redirect 301 /d-array-article.html /articles/d-array-article.html
+Redirect 301 /d-floating-point.html /articles/d-floating-point.html
+Redirect 301 /dll-linux.html /articles/dll-linux.html
 Redirect 301 /exception-safe.html /articles/exception-safe.html
+Redirect 301 /faq.html /articles/faq.html
 Redirect 301 /hijack.html /articles/hijack.html
 Redirect 301 /intro-to-datetime.html /articles/intro-to-datetime.html
 Redirect 301 /lazy-evaluation.html /articles/lazy-evaluation.html
 Redirect 301 /migrate-to-shared.html /articles/migrate-to-shared.html
 Redirect 301 /mixin.html /articles/mixin.html
+Redirect 301 /pretod.html /articles/pretod.html
 Redirect 301 /regular-expression.html /articles/regular-expression.html
 Redirect 301 /safed.html /articles/safed.html
-Redirect 301 /templates-revisited.html /articles/templates-revisited.html
-Redirect 301 /ctarguments.html /articles/ctarguments.html
-Redirect 301 /variadic-function-templates.html /articles/variadic-function-templates.html
-Redirect 301 /d-array-article.html /articles/d-array-article.html
-Redirect 301 /cppcontracts.html /articles/cppcontracts.html
 Redirect 301 /template-comparison.html /articles/template-comparison.html
-Redirect 301 /dll-linux.html /articles/dll-linux.html
+Redirect 301 /templates-revisited.html /articles/templates-revisited.html
+Redirect 301 /variadic-function-templates.html /articles/variadic-function-templates.html
+Redirect 301 /warnings.html /articles/warnings.html
+Redirect 301 /rationale.html /articles/rationale.html
 
 # Error pages
 ErrorDocument 404 /404.html


### PR DESCRIPTION
I should really stop doing to important PRs late at night. Sorry for the disturbance :/
As an exception I will immediately merge this (it just modifies the .htaccess which isn't tested anyways).

I also sorted the redirects, s.t. they are easier to check for missing ones.