### PR TITLE
Fix REF1 to behave analogous to the other REF macros

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -365,7 +365,7 @@ $(COMMENT
     (the phobos path can be different, of course).
 )
 REF=<a href="$(PHOBOS_PATH)$2$(UNDERSCORE_PREFIXED_SKIP $+).html#.$1">$(D $2$(DOT_PREFIXED_SKIP $+, $1))</a>
-REF1=<a href="$(PHOBOS_PATH)$2.html#.$1">$(D $2)</a>
+REF1=<a href="$(PHOBOS_PATH)$2.html#.$1">$(D $1)</a>
 _=
 
 $(COMMENT


### PR DESCRIPTION
REF1 is currently only used once in entire DRuntime and Phobos, so maybe
a special OBJECTREF macro would have been better?
Anyhow, have a look at the only use of `REF1` to understand the
motivation for this PR:

https://dlang.org/phobos/std_file.html#.thisExePath

Also there are three other PRs being blocked on this:

- https://github.com/dlang/dmd/pull/7342
- https://github.com/dlang/druntime/pull/2082
- https://github.com/dlang/phobos/pull/6140