### PR TITLE
Bump DMD_VER to 2.078.2

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -189,7 +189,7 @@ endif
 ################################################################################
 
 # stable dub and dmd versions used to build dpl-docs
-STABLE_DMD_VER=2.077.1
+STABLE_DMD_VER=2.078.2
 STABLE_DMD_ROOT=$(GENERATED)/stable_dmd-$(STABLE_DMD_VER)
 STABLE_DMD_URL=http://downloads.dlang.org/releases/2.x/$(STABLE_DMD_VER)/dmd.$(STABLE_DMD_VER).$(OS).zip
 STABLE_DMD_BIN_ROOT=$(STABLE_DMD_ROOT)/dmd2/$(OS)/$(if $(filter $(OS),osx),bin,bin$(MODEL))


### PR DESCRIPTION
2.078.2 was released with more reliable retries and fallback mirror usage (https://github.com/dlang/dub/pull/1339) - hopefully this helps to reduce the spurious DUB failures.