### PR TITLE
Use LINK2 instead of direct a href for REF macros

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -237,9 +237,9 @@ MULTICOL_CELL=<td colspan="$1">$+</td>
 MULTICOL_HEADER=<th colspan="$1">$+</th>
 MULTICOLS=$+
 MULTIROW_HEADER=<th rowspan="$1">$+</th>
-MREF=<a href="$(PHOBOS_PATH)$1$(UNDERSCORE_PREFIXED $+).html">$(D $1$(DOT_PREFIXED $+))</a>
-MREF_ALTTEXT=<a href="$(PHOBOS_PATH)$2$(UNDERSCORE_PREFIXED_SKIP $+).html">$1</a>
-MREF1=<a href="$(PHOBOS_PATH)$1.html">$(D $1)</a>
+MREF=$(LINK2 $(PHOBOS_PATH)$1$(UNDERSCORE_PREFIXED $+).html, $(D $1$(DOT_PREFIXED $+)))
+MREF_ALTTEXT=$(LINK2 $(PHOBOS_PATH)$2$(UNDERSCORE_PREFIXED_SKIP $+).html, $1)
+MREF1=$(LINK2 $(PHOBOS_PATH)$1.html, $(D $1))
 _=
 
 
@@ -364,8 +364,8 @@ $(COMMENT
     The generated href will be "phobos/std_container_array.html#.Array.back"
     (the phobos path can be different, of course).
 )
-REF=<a href="$(PHOBOS_PATH)$2$(UNDERSCORE_PREFIXED_SKIP $+).html#.$1">$(D $2$(DOT_PREFIXED_SKIP $+, $1))</a>
-REF1=<a href="$(PHOBOS_PATH)$2.html#.$1">$(D $1)</a>
+REF=$(LINK2 $(PHOBOS_PATH)$2$(UNDERSCORE_PREFIXED_SKIP $+).html#.$1, $(D $2$(DOT_PREFIXED_SKIP $+, $1)))
+REF1=$(LINK2 $(PHOBOS_PATH)$2.html#.$1", $(D $1))
 _=
 
 $(COMMENT
@@ -377,8 +377,8 @@ $(COMMENT
     generates a link like this:
     <a href="phobos/std_container_array.html#.Array.back">the 'back' method</a>
 )
-REF_ALTTEXT=<a href="$(PHOBOS_PATH)$3$(UNDERSCORE_PREFIXED_SKIP2 $+).html#.$2">$1</a>
-REF1_ALTTEXT=<a href="$(PHOBOS_PATH)$3.html#.$2">$1</a>
+REF_ALTTEXT=$(LINK2 $(PHOBOS_PATH)$3$(UNDERSCORE_PREFIXED_SKIP2 $+).html#.$2, $1)
+REF1_ALTTEXT=$(LINK2 $(PHOBOS_PATH)$3.html#.$2", $1)
 _=
 
 $(COMMENT


### PR DESCRIPTION
This allows the ref macros to be used directly in the spec.

See also: https://github.com/dlang/dlang.org/pull/1941