### PR TITLE
Remove PHOBOS macro in favor in REF

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -338,7 +338,6 @@ _=
 PC=$(TC p, $1, $+)
 _=
 
-PHOBOS=$(SPANC phobos, $(AHTTPS dlang.org/phobos/std_$1.html#$2, $(TAIL $+)))
 PHOBOSSRC=$(SPANC phobos_src, $(AHTTPS github.com/dlang/phobos/blob/master/$0, $0))
 _=
 

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -919,8 +919,8 @@ $(H4 $(LEGACY_LNAME2 strings_unicode, strings-unicode, Strings and Unicode))
         primitives it's assumed to be enforced by the user.
         )
         $(P The standard library lends a hand for comparing strings with mixed encodings
-        (by transparently decoding, see $(PHOBOS algorithm, cmp, std.algorithm.cmp)),
-        $(PHOBOS uni, icmp, case-insensitive comparison) and $(PHOBOS uni, normalize, normalization).
+        (by transparently decoding, see $(REF cmp, std,algorithm)),
+        $(REF_ALTTEXT case-insensitive comparison icmp, std,uni) and $(REF_ALTTEXT normalization, normalize, std,uni).
         )
         $(P Last but not least, a desired string sorting order differs
         by culture and language and is usually nothing like code point

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -909,18 +909,18 @@ d = 'd';     // d is assigned the character 'd'
 
 $(H4 $(LEGACY_LNAME2 strings_unicode, strings-unicode, Strings and Unicode))
         $(P Note that built-in comparison operators operate on a
-        $(HTTPS goo.gl/zRY1K, code unit) basis.
+        $(LINK2 http://www.unicode.org/glossary/#code_unit, code unit) basis.
         The end result for valid strings is the same as that of
-        $(HTTPS goo.gl/WR424, code point)
-        for $(HTTPS goo.gl/WR424, code point)
+        $(LINK2 http://www.unicode.org/glossary/#code_point, code point)
+        for $(LINK2 http://www.unicode.org/glossary/#code_point, code point)
         comparison as long as both strings are in the same
-        $(HTTPS goo.gl/3DKfI, normalization form).
+        $(LINK2 http://www.unicode.org/glossary/#normalization_form, normalization form).
         Since normalization is a costly operation not suitable for language
         primitives it's assumed to be enforced by the user.
         )
         $(P The standard library lends a hand for comparing strings with mixed encodings
         (by transparently decoding, see $(REF cmp, std,algorithm)),
-        $(REF_ALTTEXT case-insensitive comparison icmp, std,uni) and $(REF_ALTTEXT normalization, normalize, std,uni).
+        $(REF_ALTTEXT case-insensitive comparison, icmp, std,uni) and $(REF_ALTTEXT normalization, normalize, std,uni).
         )
         $(P Last but not least, a desired string sorting order differs
         by culture and language and is usually nothing like code point

--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -726,7 +726,7 @@ $(H2 $(LNAME2 packing-and-alignment, Packing and Alignment))
     )
 
     $(P D supports bitfields in the standard library: see
-    $(PHOBOS bitmanip, bitfields, std.bitmanip.bitfields).
+    $(REF bitfields, std, bitmanip).
     )
 
 $(H2 $(LNAME2 lifetime-management, Lifetime Management))

--- a/spec/latex.ddoc
+++ b/spec/latex.ddoc
@@ -242,7 +242,6 @@ _=
 
 P= $0 \par
 PERCENT=\%
-PHOBOS=$(LINK2 phobos/std_$1.html\#$2, $3)
 _=
 
 RAWHTML=\begin{lstlisting}[language=html,breaklines=true,breakatwhitespace=true]$0\end{lstlisting}

--- a/spec/property.dd
+++ b/spec/property.dd
@@ -176,7 +176,7 @@ $(H2 $(LNAME2 stringof, .stringof Property))
     $(BEST_PRACTICE Do not use `.stringof` for code generation.
     Instead use the
     $(DDSUBLINK spec/traits, identifier, identifier) trait,
-    or one of the Phobos helper functions such as $(PHOBOS traits, fullyQualifiedName, std.traits.fullyQualifiedName).)
+    or one of the Phobos helper functions such as $(REF fullyQualifiedName, std,traits).)
 
 $(H2 $(LNAME2 sizeof, .sizeof Property))
 


### PR DESCRIPTION
Seems like the `PHOBOS` macro was a hack to get references to the standard library.
We should really use the universal `REF` here.

Note - this depends on https://github.com/dlang/dlang.org/pull/2194

edit: this PR has been merged -> this should be good to go.