### PR TITLE
Remove redundant REF_OBJECT_SHORT in favor of REF1

### DIFF
--- a/changelog/2.070.0.dd
+++ b/changelog/2.070.0.dd
@@ -59,7 +59,7 @@ $(LI $(LNAME2 typeinfo-initializer, `TypeInfo.init` has been renamed to
     `TypeInfo.initializer`.)
 
     $(P The method `TypeInfo.init` has been renamed to
-        $(REF_OBJECT_SHORT TypeInfo.initializer) to resolve
+        $(REF1 TypeInfo.initializer, object) to resolve
         a name clash with the type property $(GLINK2 property, init).
     )
 

--- a/changelog/2.072.0.dd
+++ b/changelog/2.072.0.dd
@@ -350,7 +350,7 @@ $(BUGSTITLE Library Changes,
             to resolve a name clash with the type property $(GLINK2 property, init).
         )
 
-        $(P Use $(REF_OBJECT_SHORT TypeInfo.initializer) instead.)
+        $(P Use $(REF1 TypeInfo.initializer, object) instead.)
     )
 
     $(LI $(LNAME2 drt-oncycle, New druntime switch `--DRT-oncycle` allows

--- a/changelog/2.074.0.dd
+++ b/changelog/2.074.0.dd
@@ -34,13 +34,13 @@ $(BUGSTITLE Runtime changes,
 
 $(LI $(LNAME2 disable-TypeInfo.init,`TypeInfo.init` has been `@disable`d.)
 $(P
-$(REF_OBJECT_SHORT TypeInfo.init) has been `@disable`d. Use
-$(REF_OBJECT_SHORT TypeInfo.initializer) instead.
+$(REF1 TypeInfo.init, object) has been `@disable`d. Use
+$(REF1 TypeInfo.initializer, object) instead.
 )
 
 $(P
 `TypeInfo.init` is a legacy alias of the method that is now called
-$(REF_OBJECT_SHORT TypeInfo.initializer). The name change is necessary because
+$(REF1 TypeInfo.initializer, object). The name change is necessary because
 the name "init" clashes with the type property of the same name
 ($(GLINK2 property, init)).
 )

--- a/changelog/2.075.0.dd
+++ b/changelog/2.075.0.dd
@@ -171,7 +171,7 @@ stack overflow.
 $(LI $(LNAME2 remove-TypeInfo.init,`TypeInfo.init` now refers to type property.)
 $(P
 `TypeInfo.init` used to refer to the method that is now called
-$(REF_OBJECT_SHORT TypeInfo.initializer). The name change was necessary because
+$(REF1 TypeInfo.initializer, object). The name change was necessary because
 the name "init" would clash with the type property of the same name
 ($(GLINK2 property, init)). `TypeInfo.init` now refers to the type property.
 )

--- a/changelog/changelog.ddoc
+++ b/changelog/changelog.ddoc
@@ -63,8 +63,6 @@ DMDBUGSFIXED2=$(LINK2 https://issues.dlang.org/buglist.cgi?chfieldto=$2$(AMP)que
 DRUNTIMEBUGSFIXED2=$(LINK2 https://issues.dlang.org/buglist.cgi?chfieldto=$2$(AMP)query_format=advanced$(AMP)chfield=resolution$(AMP)chfieldfrom=$1$(AMP)chfieldvalue=FIXED$(AMP)bug_severity=regression$(AMP)bug_severity=blocker$(AMP)bug_severity=critical$(AMP)bug_severity=major$(AMP)bug_severity=normal$(AMP)bug_severity=minor$(AMP)bug_severity=trivial$(AMP)bug_status=RESOLVED$(AMP)version=D2$(AMP)version=D1%20%26%20D2$(AMP)component=druntime$(AMP)resolution=FIXED$(AMP)product=D, Druntime Bugs Fixed)
 PHOBOSBUGSFIXED2=$(LINK2 https://issues.dlang.org/buglist.cgi?chfieldto=$2$(AMP)query_format=advanced$(AMP)chfield=resolution$(AMP)chfieldfrom=$1$(AMP)chfieldvalue=FIXED$(AMP)bug_severity=regression$(AMP)bug_severity=blocker$(AMP)bug_severity=critical$(AMP)bug_severity=major$(AMP)bug_severity=normal$(AMP)bug_severity=minor$(AMP)bug_severity=trivial$(AMP)bug_status=RESOLVED$(AMP)version=D2$(AMP)version=D1%20%26%20D2$(AMP)component=Phobos$(AMP)resolution=FIXED$(AMP)product=D, Phobos Bugs Fixed)
 
-REF_OBJECT_SHORT=$(LINK2 $(PHOBOS_PATH)object.html#.$1, $(D $1))
-
 PULL_REQUEST = $(LINK2 https://github.com/dlang/$1/pull/$2, $1#$2)
 DMDPR = $(PULL_REQUEST dmd,$1)
 DRUNTIMEPR = $(PULL_REQUEST druntime,$1)


### PR DESCRIPTION
No need to duplicate things. It just created more confusion.