### PR TITLE
Provide direct link to Bugzilla on a 404 page

### DIFF
--- a/404.dd
+++ b/404.dd
@@ -5,7 +5,7 @@ $(D_S 404 Not Found,
 $(P
 Page not found!
 
-If you think there should be something here, please use the "Report a bug" link above to let us know.
+If you think there should be something here, please $(LINK2 $(BUGZILLA_NEW_BUG_URL)$(AMP)bug_severity=normal, report a bug).
 ))
 
 Macros:

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -15,6 +15,7 @@ BLUE=$(SPANC blue, $0)
 BODY_PREFIX=
 BOOKTABLE = $(TC table, book, $(T caption, $1)$+)
 BUGZILLA = $(SPANC bugzilla, $(AHTTPS issues.dlang.org/show_bug.cgi?id=$0, Bugzilla $0))
+BUGZILLA_NEW_BUG_URL=https://issues.dlang.org/enter_bug.cgi?bug_file_loc=http%3A%2F%2Fdlang.org/$(SELF_PATH)$(AMP)component=$(PROJECT)$(AMP)op_sys=All$(AMP)priority=P3$(AMP)product=D$(AMP)rep_platform=All$(AMP)short_desc=%5B$(TITLE)%5D$(AMP)version=D2
 _=
 
 CCODE=$(TC pre, ccode notranslate, $0)
@@ -311,7 +312,7 @@ _=
 PAGE_TOOLS=
 $(DIVID tools, $(DIV,
 	$(DIVC tip smallprint,
-		$(HTMLTAG3 a, href="https://issues.dlang.org/enter_bug.cgi?bug_file_loc=http%3A%2F%2Fdlang.org/$(SELF_PATH)$(AMP)bug_severity=enhancement$(AMP)component=$(PROJECT)$(AMP)op_sys=All$(AMP)priority=P3$(AMP)product=D$(AMP)rep_platform=All$(AMP)short_desc=%5B$(TITLE)%5D$(AMP)version=D2", Report a bug)
+		$(HTMLTAG3 a, href="$(BUGZILLA_NEW_BUG_URL)$(AMP)bug_severity=enhancement", Report a bug)
 		$(DIV,
 			If you spot a problem with this page, click here to create a Bugzilla issue.
 		)


### PR DESCRIPTION
I know it's a tiny improvement, but everything that makes it a bit easier for someone to report a bug, makes it a bit easier that he/she does so.
(I am aware that the "Report a bug" button already exists, but "above" is inconvenient for people.
After all, the last regression has been reported on the NG and not Bugzilla.

This also changes the default priority of 404 errors to "normal" instead of enhancement.