### PR TITLE
Title font shrinks if too long

### DIFF
--- a/css/html-skeleton.css
+++ b/css/html-skeleton.css
@@ -85,6 +85,16 @@ parameters will be rendered in this style everywhere.*/
 {
 }
 
+/* SPAN: D module title */
+.d_title
+{
+}
+
+/* SPAN: link to Phobos resource */
+.phobos_src
+{
+}
+
 /* DIV: Formats the "Date" section */
 .Date
 {

--- a/css/style.css
+++ b/css/style.css
@@ -1177,6 +1177,24 @@ td .d_code2, td .cppcode2, td .cppcode
     font-weight: bold;
 }
 
+.d_title
+{
+    font-weight: bold;
+    text-overflow: clip;
+    overflow: hidden;
+    display: block;
+    word-wrap: break-word;
+    font-family: Consolas, "Bitstream Vera Sans Mono", "Andale Mono", Monaco, "DejaVu Sans Mono", "Lucida Console", monospace;
+}
+
+.phobos_src
+{
+    text-overflow: clip;
+    overflow: hidden;
+    display: block;
+    word-wrap: break-word;
+}
+
 /* syntax highlighting
 
 d_* classes come from Ddoc.

--- a/html.ddoc
+++ b/html.ddoc
@@ -95,6 +95,7 @@ D_STRING  = $(SPANC d_string, $0)
 D_KEYWORD = $(SPANC d_keyword, $0)
 D_PSYMBOL = $(SPANC d_psymbol, $0)
 D_PARAM   = $(SPANC d_param, $0)
+D_TITLE   = $(SPANC d_title, $0)
 _=
 
 _=Main entry point

--- a/std.ddoc
+++ b/std.ddoc
@@ -8,7 +8,7 @@ LAYOUT_SUFFIX =
 $(SCRIPTLOAD ../js/listanchors.js)
 $(SCRIPTLOAD ../js/show_contributors.js)
 $(SCRIPT jQuery(document).ready(listanchors);)
-LAYOUT_TITLE=$(H1 $(D $(TITLE)))
+LAYOUT_TITLE=$(H1 $(D_TITLE $(TITLE)))
 _=
 
 LREF = <a href="#$1">$(D $1)</a>


### PR DESCRIPTION
Some modules from phobos, more precisely the allocators, had very long names.
All titles now have the separate class "d_title" and if the length exceeds a threshold, the font size shrinks.

