### PR TITLE
cent and ucent missing in the list BasicTypeX

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -115,6 +115,8 @@ $(MULTICOLS 5,
     $(D uint)
     $(D long)
     $(D ulong)
+    $(D cent)
+    $(D ucent)
     $(D char)
     $(D wchar)
     $(D dchar)


### PR DESCRIPTION
Even if these types are not implemented, they are reserved and they should therefore be listed. They are listed on the page but not in the grammar.