### PR TITLE
move Special Keywords to expression.dd

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1106,8 +1106,8 @@ $(GNAME PrimaryExpression):
     $(GLINK TypeidExpression)
     $(GLINK IsExpression)
     $(D $(LPAREN)) $(GLINK Expression) $(D $(RPAREN))
+    $(GLINK SpecialKeyword)
     $(GLINK2 traits, TraitsExpression)
-    $(GLINK2 traits, SpecialKeyword)
 )
 
 $(H3 $(LNAME2 identifier, .Identifier))
@@ -2090,6 +2090,67 @@ void main()
         )
 
     )
+
+$(H2 $(LNAME2 specialkeywords, Special Keywords))
+
+$(GRAMMAR
+$(GNAME SpecialKeyword):
+    $(D $(RELATIVE_LINK2 specialkeywords, __FILE__))
+    $(D $(RELATIVE_LINK2 specialkeywords, __FILE_FULL_PATH__))
+    $(D $(RELATIVE_LINK2 specialkeywords, __MODULE__))
+    $(D $(RELATIVE_LINK2 specialkeywords, __LINE__))
+    $(D $(RELATIVE_LINK2 specialkeywords, __FUNCTION__))
+    $(D $(RELATIVE_LINK2 specialkeywords, __PRETTY_FUNCTION__))
+)
+
+
+    $(P $(CODE __FILE__) and $(CODE __LINE__) expand to the source
+    file name and line number at the point of instantiation. The path of
+    the source file is left up to the compiler. )
+
+    $(P $(CODE __FILE_FULL_PATH__) expands to the absolute source
+    file name at the point of instantiation.)
+
+    $(P $(CODE __MODULE__) expands to the module name at the point of
+    instantiation.)
+
+    $(P $(CODE __FUNCTION__) expands to the fully qualified name of the
+    function at the point of instantiation.)
+
+    $(P $(CODE __PRETTY_FUNCTION__) is similar to $(CODE __FUNCTION__),
+    but also expands the function return type, its parameter types,
+    and its attributes.)
+
+    $(P Example:)
+
+    ---
+    module test;
+    import std.stdio;
+
+    void test(string file = __FILE__, size_t line = __LINE__,
+            string mod = __MODULE__, string func = __FUNCTION__,
+            string pretty = __PRETTY_FUNCTION__,
+            string fileFullPath = __FILE_FULL_PATH__)
+    {
+        writefln("file: '%s', line: '%s', module: '%s',\nfunction: '%s', " ~
+            "pretty function: '%s',\nfile full path: '%s'",
+            file, line, mod, func, pretty, fileFullPath);
+    }
+
+    int main(string[] args)
+    {
+        test();
+        return 0;
+    }
+    ---
+
+    $(P Assuming the file was at /example/test.d, this will output:)
+
+$(CONSOLE
+file: 'test.d', line: '13', module: 'test',
+function: 'test.main', pretty function: 'int test.main(string[] args)',
+file full path: '/example/test.d'
+)
 
 $(H2 $(LNAME2 associativity, Associativity and Commutativity))
 

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -1029,12 +1029,12 @@ $(MULTICOLS 4,
     $(LINK2 statement.html#WhileStatement, $(D while))
     $(LINK2 statement.html#WithStatement, $(D with))
 
-    $(LINK2 traits.html#specialkeywords, $(D __FILE__))
-    $(LINK2 traits.html#specialkeywords, $(D __FILE_FULL_PATH__))
-    $(LINK2 traits.html#specialkeywords, $(D __MODULE__))
-    $(LINK2 traits.html#specialkeywords, $(D __LINE__))
-    $(LINK2 traits.html#specialkeywords, $(D __FUNCTION__))
-    $(LINK2 traits.html#specialkeywords, $(D __PRETTY_FUNCTION__))
+    $(LINK2 expression.html#specialkeywords, $(D __FILE__))
+    $(LINK2 expression.html#specialkeywords, $(D __FILE_FULL_PATH__))
+    $(LINK2 expression.html#specialkeywords, $(D __MODULE__))
+    $(LINK2 expression.html#specialkeywords, $(D __LINE__))
+    $(LINK2 expression.html#specialkeywords, $(D __FUNCTION__))
+    $(LINK2 expression.html#specialkeywords, $(D __PRETTY_FUNCTION__))
 
     $(LINK2 attribute.html#gshared, $(D __gshared))
     $(LINK2 traits.html, $(D __traits))

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -74,18 +74,6 @@ $(GNAME TraitsArgument):
     $(GLINK2 declaration, Type)
 )
 
-$(P Additionally special keywords are provided for debugging purposes:)
-
-$(GRAMMAR
-$(GNAME SpecialKeyword):
-    $(D $(RELATIVE_LINK2 specialkeywords, __FILE__))
-    $(D $(RELATIVE_LINK2 specialkeywords, __FILE_FULL_PATH__))
-    $(D $(RELATIVE_LINK2 specialkeywords, __MODULE__))
-    $(D $(RELATIVE_LINK2 specialkeywords, __LINE__))
-    $(D $(RELATIVE_LINK2 specialkeywords, __FUNCTION__))
-    $(D $(RELATIVE_LINK2 specialkeywords, __PRETTY_FUNCTION__))
-)
-
 $(H2 $(GNAME isArithmetic))
 
         $(P If the arguments are all either types that are arithmetic types,
@@ -1068,55 +1056,6 @@ void main()
         )
 
 
-$(H2 $(LNAME2 specialkeywords, Special Keywords))
-
-    $(P $(CODE __FILE__) and $(CODE __LINE__) expand to the source
-    file name and line number at the point of instantiation. The path of
-    the source file is left up to the compiler. )
-
-    $(P $(CODE __FILE_FULL_PATH__) expands to the absolute source
-    file name at the point of instantiation.)
-
-    $(P $(CODE __MODULE__) expands to the module name at the point of
-    instantiation.)
-
-    $(P $(CODE __FUNCTION__) expands to the fully qualified name of the
-    function at the point of instantiation.)
-
-    $(P $(CODE __PRETTY_FUNCTION__) is similar to $(CODE __FUNCTION__),
-    but also expands the function return type, its parameter types,
-    and its attributes.)
-
-    $(P Example usage:)
-
------
-module test;
-import std.stdio;
-
-void test(string file = __FILE__, size_t line = __LINE__,
-        string mod = __MODULE__, string func = __FUNCTION__,
-        string pretty = __PRETTY_FUNCTION__,
-        string fileFullPath = __FILE_FULL_PATH__)
-{
-    writefln("file: '%s', line: '%s', module: '%s',\nfunction: '%s', " ~
-        "pretty function: '%s',\nfile full path: '%s'",
-        file, line, mod, func, pretty, fileFullPath);
-}
-
-int main(string[] args)
-{
-    test();
-    return 0;
-}
------
-
-        $(P Assuming the file was at /example/test.d, this will output:)
-
-$(CONSOLE
-file: 'test.d', line: '13', module: 'test',
-function: 'test.main', pretty function: 'int test.main(string[] args)',
-file full path: '/example/test.d'
-)
 
 $(SPEC_SUBNAV_PREV_NEXT version, Conditional Compilation, errors, Error Handling)
 )


### PR DESCRIPTION
They're expressions, and belong in the expressions file, not the traits file.

This is a pure cut&paste job. No other changes other than updating links.