### PR TITLE
Change C++ code background to white

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1163,7 +1163,7 @@ body.dcompiler dt a.anchor:hover:before
 
 .ccode, .cppcode, .cppcode2 /* C/C++ code */
 {
-    background-color: #f6ecf0;
+    background-color: #fcfcfc;
 }
 
 td .d_code2, td .cppcode2, td .cppcode


### PR DESCRIPTION
@andralex requested this. The pink background made it look like we're trying to portray C++ in a bad light. IMO, we ought to syntax highlight it too.