### PR TITLE
Add a release schedule to the changelog pages

### DIFF
--- a/changelog/changelog.ddoc
+++ b/changelog/changelog.ddoc
@@ -8,7 +8,11 @@ CHANGELOG_NAV_FIRST=$(DIVC changelog-nav, next version: $(A $1.html, $1))
 CHANGELOG_NAV_LAST=$(DIVC changelog-nav, previous version: $(A $1.html, $1))
 
 SUBNAV=$(SUBNAV_TEMPLATE
-    $(SUBNAV_HEAD Change Log, $(ROOT_DIR)changelog/index.html, List of all versions, )
+    $(SUBNAV_HEADS Change Log,
+        $(LINK2 $(ROOT_DIR)changelog/index.html, List of all versions)
+        $(BR)
+        $(LINK2 $(ROOT_DIR)changelog/release-schedule.html, Release schedule)
+    )
     $(UL $(CHANGELOG_VERSIONS))
 )
 
@@ -73,3 +77,9 @@ _=
 CHANGELOG_VERSION = $(LI <a id="$1" href="$1.html">$1</a><span class="hide-from-nav"> ($2, $3)</span>)
 CHANGELOG_VERSION_PRE = $(LI <a id="$1" href="$1.html" style="display: inline-block">$1</a> (preview) <span class="hide-from-nav"> - scheduled for $+</span>)
 CHANGELOG_VERSION_NIGHTLY = $(LI <a id="pending" href="pending.html">Nightly</a> <span class="hide-from-nav"> (preview) - upcoming changes from $(D master)</span>)
+
+SUBNAV_HEADS=
+    $(DIVC head,
+        $(H2 $1)
+        $(P $+)
+    )

--- a/changelog/release-schedule.dd
+++ b/changelog/release-schedule.dd
@@ -5,8 +5,7 @@ $(D_S $(TITLE),
 $(UL
     $(LI New release are published every $(I two) months, on the first day of every uneven month.)
     $(LI Two weeks before a new release `master` is merged into `stable` and a first beta is released.)
-    $(LI Patch releases are usually released on the first day of every even month.)
-    $(LI In the unfortunate case of serious regressions being found, more point releases or betas may be released.)
+    $(LI Point releases are published unscheduled when important issues or regressions get fixed.)
 )
 
 $(P The release schedule for 2018 is as follows:)
@@ -14,22 +13,16 @@ $(P The release schedule for 2018 is as follows:)
     $(DIVC release-schedule,
         $(TABLE
             $(MINOR_RELEASE 2018-03-01, 2.079.0)
-            $(PATCH_RELEASE 2018-04-01, 2.079.1)
             $(BETA_RELEASE 2018-04-15, 2.080.0)
             $(MINOR_RELEASE 2018-05-01, 2.080.0)
-            $(PATCH_RELEASE 2018-06-01, 2.079.1)
             $(BETA_RELEASE 2018-06-15, 2.081.0)
             $(MINOR_RELEASE 2018-07-01, 2.081.0)
-            $(PATCH_RELEASE 2018-08-01, 2.081.1)
             $(BETA_RELEASE 2018-08-15, 2.082.0)
             $(MINOR_RELEASE 2018-09-01, 2.082.0)
-            $(PATCH_RELEASE 2018-10-01, 2.082.1)
             $(BETA_RELEASE 2018-10-15, 2.083.0)
             $(MINOR_RELEASE 2018-11-01, 2.083.0)
-            $(PATCH_RELEASE 2018-12-01, 2.083.1)
             $(BETA_RELEASE 2018-12-15, 2.084.0)
             $(MINOR_RELEASE 2019-01-01, 2.084.0)
-            $(PATCH_RELEASE 2019-02-01, 2.084.1)
         )
     )
 )
@@ -37,7 +30,6 @@ $(P The release schedule for 2018 is as follows:)
 Macros:
     TITLE=D release schedule
     MINOR_RELEASE=$(ROW minor, $1, $2, minor release)
-    PATCH_RELEASE=$(ROW patch, $1, $2, patch release)
     BETA_RELEASE=$(ROW beta, $1, $2-beta.1, first beta for $2)
     ROW=<tr class="release-schedule-$1">$(TDX2 $+)</tr>
     TDX2=$(TDX $1, $+)
@@ -47,8 +39,6 @@ Macros:
         }
         .release-schedule-minor {
             font-weight: bold;
-        }
-        .release-schedule-patch {
         }
         .release-schedule-beta {
             color: #5f0303;

--- a/changelog/release-schedule.dd
+++ b/changelog/release-schedule.dd
@@ -1,0 +1,56 @@
+Ddoc
+
+$(D_S $(TITLE),
+
+$(UL
+    $(LI New release are published every $(I two) months, on the first day of every uneven month.)
+    $(LI Two weeks before a new release `master` is merged into `stable` and a first beta is released.)
+    $(LI Patch releases are usually released on the first day of every even month.)
+    $(LI In the unfortunate case of serious regressions being found, more point releases or betas may be released.)
+)
+
+$(P The release schedule for 2018 is as follows:)
+
+    $(DIVC release-schedule,
+        $(TABLE
+            $(MINOR_RELEASE 2018-03-01, 2.079.0)
+            $(PATCH_RELEASE 2018-04-01, 2.079.1)
+            $(BETA_RELEASE 2018-04-15, 2.080.0)
+            $(MINOR_RELEASE 2018-05-01, 2.080.0)
+            $(PATCH_RELEASE 2018-06-01, 2.079.1)
+            $(BETA_RELEASE 2018-06-15, 2.081.0)
+            $(MINOR_RELEASE 2018-07-01, 2.081.0)
+            $(PATCH_RELEASE 2018-08-01, 2.081.1)
+            $(BETA_RELEASE 2018-08-15, 2.082.0)
+            $(MINOR_RELEASE 2018-09-01, 2.082.0)
+            $(PATCH_RELEASE 2018-10-01, 2.082.1)
+            $(BETA_RELEASE 2018-10-15, 2.083.0)
+            $(MINOR_RELEASE 2018-11-01, 2.083.0)
+            $(PATCH_RELEASE 2018-12-01, 2.083.1)
+            $(BETA_RELEASE 2018-12-15, 2.084.0)
+            $(MINOR_RELEASE 2019-01-01, 2.084.0)
+            $(PATCH_RELEASE 2019-02-01, 2.084.1)
+        )
+    )
+)
+
+Macros:
+    TITLE=D release schedule
+    MINOR_RELEASE=$(ROW minor, $1, $2, minor release)
+    PATCH_RELEASE=$(ROW patch, $1, $2, patch release)
+    BETA_RELEASE=$(ROW beta, $1, $2-beta.1, first beta for $2)
+    ROW=<tr class="release-schedule-$1">$(TDX2 $+)</tr>
+    TDX2=$(TDX $1, $+)
+    EXTRA_HEADERS=$(T style,
+        .release-schedule table {
+            margin: 0 auto;
+        }
+        .release-schedule-minor {
+            font-weight: bold;
+        }
+        .release-schedule-patch {
+        }
+        .release-schedule-beta {
+            color: #5f0303;
+        }
+    )

--- a/posix.mak
+++ b/posix.mak
@@ -348,7 +348,7 @@ SPEC_ROOT=$(addprefix spec/, \
 	abi simd betterc)
 SPEC_DD=$(addsuffix .dd,$(SPEC_ROOT))
 
-CHANGELOG_FILES:=$(basename $(subst _pre.dd,.dd,$(wildcard changelog/*.dd)))
+CHANGELOG_FILES:=$(basename $(subst _pre.dd,.dd,$(wildcard changelog/*.dd))) changelog/release-schedule
 ifneq (1,$(RELEASE))
  CHANGELOG_FILES+=changelog/pending
 endif


### PR DESCRIPTION
For some reason the argument that D isn't stable and has no proper release model often comes up.

Also for all newcomers and not hard-core insiders its hard to know the release schedule (even many contributors on GitHub aren't aware of it).

Since @MartinNowak has revamped the release process, the releases follow a schedule, so imho we should advertise this and make it easy for people to learn about this.

If everyone is okay with the format (and it gets merged), I would do a quick follow-up that replaces that injects an automatically generated release schedule table, s.t. we don't have to update this file manually.