### PR TITLE
Update dub.selections.json files

### DIFF
--- a/ddoc/dub.selections.json
+++ b/ddoc/dub.selections.json
@@ -1,6 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
+		"dmd": {"path":"../../dmd"},
 		"libdparse": "0.7.2-alpha.4"
 	}
 }

--- a/dpl-docs/dub.selections.json
+++ b/dpl-docs/dub.selections.json
@@ -3,8 +3,10 @@
 	"versions": {
 		"botan": "1.12.9",
 		"botan-math": "1.0.3",
+		"ddoc_preprocessor": {"path":"../ddoc"},
 		"ddox": "0.16.7",
 		"diet-ng": "1.4.3",
+		"dmd": {"path":"../../dmd"},
 		"eventcore": "0.8.17",
 		"hyphenate": "1.1.1",
 		"libasync": "0.8.3",


### PR DESCRIPTION
Fixes auto-deploy and avoids a dirty working tree after `dub upgrade --missing-only`.