### PR TITLE
Temporarily delete an example from traits(isSame)

### DIFF
--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -1040,10 +1040,6 @@ void main()
     int b;
     static assert(!__traits(isSame, a => a + b, a => a + b));
 
-    // lambdas calling a function inside their body are considered incomparable
-    int f() { return 3;}
-    static assert(!__traits(isSame, a => a + f(), a => a + f()));
-
     class A
     {
         int a;


### PR DESCRIPTION
This is needed in order to get in [1]. The first draft of the lambda comparison did not feature function calls inside the lambda body, but now that this capability has been added, first this should get merged, then [1] then [2] which readds the deleted example in this PR and some other examples 

[1] https://github.com/dlang/dmd/pull/7935
[2] https://github.com/dlang/dlang.org/pull/2231