### PR TITLE
Add an 'Open in IDE' button for the frontpage + spec examples

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1582,6 +1582,10 @@ input.runButton, input.resetButton, input.argsButton, input.inputButton, input.e
     z-index: 2;
     cursor: pointer;
 }
+input.openInEditorButton {
+    float: right;
+    width: auto;
+}
 input.runButton:hover, input.resetButton:hover, input.argsButton:hover, input.inputButton:hover, input.editButton:hover,input.runButton[disabled]
 {
     background:-webkit-gradient( linear, left top, left bottom, color-stop(0.05, #dfdfdf), color-stop(1, #ededed) );

--- a/js/run.js
+++ b/js/run.js
@@ -233,7 +233,8 @@ $(document).ready(function()
             + (args.length > 0 ? '<input type="button" class="argsButton" value="Args">' : '')
             + (stdin.length > 0 ? '<input type="button" class="inputButton" value="Input">' : '')
             + '<input type="button" class="runButton" value="Run">'
-            + '<input type="button" class="resetButton" value="Reset"></div>'
+            + '<input type="button" class="resetButton" value="Reset">'
+            + '<input type="button" class="openInEditorButton" value="Open in IDE"></div>'
         );
     });
 


### PR DESCRIPTION
From https://github.com/dlang/dlang.org/pull/2147#issuecomment-367089547

> One further idea would be to add a third button beside "Edit" "Input" "Run" called e.g. "Open Online IDE" that opens run.dlang.io with the chosen code snippet.

Note that we already have this feature for the Phobos documentation, that's why it was so easy to do here:


![image](https://user-images.githubusercontent.com/4370550/36560803-29102326-1812-11e8-8099-2bd3964ca9b9.png)


Preview:

![image](https://user-images.githubusercontent.com/4370550/36562901-b3364d86-1818-11e8-8d5c-3a9c942e09e3.png)

![image](https://user-images.githubusercontent.com/4370550/36562895-ac9df67c-1818-11e8-973b-20703a92eac3.png)
