### PR TITLE
Add a html-verbatim target analogous to html

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -406,7 +406,9 @@ docs : docs-latest docs-prerelease
 
 html : $(ALL_FILES)
 
-verbatim : $(addprefix $W/, $(addsuffix .verbatim,$(PAGES_ROOT))) phobos-prerelease-verbatim
+html-verbatim: $(addprefix $W/, $(addsuffix .verbatim,$(PAGES_ROOT)))
+
+verbatim : html-verbatim phobos-prerelease-verbatim
 
 kindle : $W/dlangspec.mobi
 


### PR DESCRIPTION
This allows just running `verbatim` for all HTML pages. Not really a neccessity, but sometimes handy and a trivial change.