### PR TITLE
[trivial] Fix using *sequence* in expression.dd

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -953,18 +953,18 @@ $(GNAME IndexExpression):
 
 $(P $(I PostfixExpression) is evaluated. If $(I PostfixExpression) is an
 expression of type static array or dynamic array, the symbol $(DOLLAR) is set to
-be the the number of elements in the array. If $(I PostfixExpression) is an $(I
-ExpressionTuple), the symbol $(DOLLAR) is set to be the the number of elements
-in the tuple. A new declaration scope is created for the evaluation of the
+be the number of elements in the array. If $(I PostfixExpression) is a $(I
+ValueSeq), the symbol $(DOLLAR) is set to be the number of elements
+in the sequence. A new declaration scope is created for the evaluation of the
 $(GLINK ArgumentList) and $(DOLLAR) appears in that scope only.)
 
-    $(P If $(I PostfixExpression) is an $(I ExpressionTuple),
+    $(P If $(I PostfixExpression) is a $(I ValueSeq),
         then the $(GLINK ArgumentList) must consist of only one argument,
         and that must be statically evaluatable to an integral constant.
         That integral constant $(I n) then selects the $(I n)th
-        expression in the $(I ExpressionTuple), which is the result
+        expression in the $(I ValueSeq), which is the result
         of the $(I IndexExpression).
-        It is an error if $(I n) is out of bounds of the $(I ExpressionTuple).
+        It is an error if $(I n) is out of bounds of the $(I ValueSeq).
     )
 
 $(H2 $(LNAME2 slice_expressions, Slice Expressions))
@@ -1065,8 +1065,8 @@ type:)
         $(TROW $(D arr[e-a .. e-b]), $(D a - b) $(I if) $(D a >= b))
         )
 
-    $(P If $(I PostfixExpression) is an $(I ExpressionTuple), then
-        the result of the slice is a new $(I ExpressionTuple) formed
+    $(P If $(I PostfixExpression) is a $(I ValueSeq), then
+        the result of the slice is a new $(I ValueSeq) formed
         from the upper and lower bounds, which must statically evaluate
         to integral constants.
         It is an error if those
@@ -1299,8 +1299,8 @@ $(GNAME ArrayLiteral):
         -------------
 
     $(P If any of the arguments in the $(GLINK ArgumentList) are
-        an $(I ExpressionTuple), then the elements of the $(I ExpressionTuple)
-        are inserted as arguments in place of the tuple.
+        a $(I ValueSeq), then the elements of the $(I ValueSeq)
+        are inserted as arguments in place of the sequence.
     )
 
     $(P Array literals are allocated on the memory managed heap.
@@ -1379,8 +1379,8 @@ $(GNAME ValueExpression):
         ---
 
     $(P If any of the keys or values in the $(I KeyValuePairs) are
-        an $(I ExpressionTuple), then the elements of the $(I ExpressionTuple)
-        are inserted as arguments in place of the tuple.
+        a $(I ValueSeq), then the elements of the $(I ValueSeq)
+        are inserted as arguments in place of the sequence.
     )
 
 $(H3 $(LNAME2 function_literals, Function Literals))
@@ -1999,15 +1999,15 @@ void foo()
         $(TROW $(D union), $(I Type))
         $(TROW $(D class), $(I Type))
         $(TROW $(D interface), $(I Type))
-        $(TROW $(D super), $(I TypeTuple) of base classes and interfaces)
+        $(TROW $(D super), $(I TypeSeq) of base classes and interfaces)
         $(TROW $(D enum), the base type of the enum)
-        $(TROW $(D function), $(ARGS $(I TypeTuple) of the function parameter types.
+        $(TROW $(D function), $(ARGS $(I TypeSeq) of the function parameter types.
              For C- and D-style variadic functions,
              only the non-variadic parameters are included.
              For typesafe variadic functions, the $(D ...) is ignored.))
         $(TROW $(CODE delegate), the function type of the delegate)
         $(TROW $(CODE return), $(ARGS the return type of the function, delegate, or function pointer))
-        $(TROW $(CODE __parameters), $(ARGS the parameter tuple of a function, delegate, or function pointer.
+        $(TROW $(CODE __parameters), $(ARGS the parameter sequence of a function, delegate, or function pointer.
          This includes the parameter types, names, and default values.))
         $(TROW $(D const), $(I Type))
         $(TROW


### PR DESCRIPTION
Following on from #2204:
* Compile-time Tuple -> Sequence
* ExpressionTuple -> ValueSeq (this matches https://dlang.org/spec/template.html#variadic-templates point 2)