### PR TITLE
Improve *Foreach over Tuples* spec

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -458,7 +458,7 @@ $(GNAME ForeachAggregate):
 $(P
         $(I ForeachAggregate) is evaluated. It must evaluate to an expression
         of type static array, dynamic array, associative array,
-        struct, class, delegate, or tuple.
+        struct, class, delegate, or sequence.
         The $(PS0) is executed, once for each element of the
         aggregate.
         At the start of each iteration, the variables declared by
@@ -835,25 +835,25 @@ void main()
         that is confusing to read. Therefore, using $(D foreach_reverse) with a
         delegate is now deprecated, and will be rejected in the future.)
 
-$(H3 $(LNAME2 foreach_over_tuples, Foreach over Tuples))
+$(H3 $(LNAME2 foreach_over_tuples, Foreach over Sequences))
 
 $(P
-        If the aggregate expression is a tuple, there
+        If the aggregate expression is a sequence, there
         can be one or two variables declared. If one, then the variable
-        is said to be the $(I value) set to the elements of the tuple,
+        is said to be the $(I value) set to the elements of the sequence,
         one by one. If the type of the
-        variable is given, it must match the type of the tuple contents.
+        variable is given, it must match the type of the sequence contents.
         If it is not given, the type of the variable is set to the type
-        of the tuple element, which may change from iteration to iteration.
+        of the sequence element, which may change from iteration to iteration.
         If there are
         two variables declared, the first is said to be the $(I index)
         and the second is said to be the $(I value). The $(I index)
         must be of $(D int) or $(D uint) type, it cannot be $(I ref),
-        and it is set to be the index of the tuple element.
+        and it is set to be the index of the sequence element.
 )
 
 $(P
-        If the tuple is a list of types, then the foreach statement
+        If the sequence is a $(I TypeSeq), then the foreach statement
         is executed once for each type, and the value is aliased to that
         type.
 )

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -839,47 +839,48 @@ $(H3 $(LNAME2 foreach_over_tuples, Foreach over Sequences))
 
 $(P
         If the aggregate expression is a sequence, there
-        can be one or two variables declared. If one, then the variable
-        is said to be the $(I value) set to the elements of the sequence,
-        one by one. If the type of the
-        variable is given, it must match the type of the sequence contents.
-        If it is not given, the type of the variable is set to the type
-        of the sequence element, which may change from iteration to iteration.
-        If there are
-        two variables declared, the first is said to be the $(I index)
-        and the second is said to be the $(I value). The $(I index)
-        must be of $(D int) or $(D uint) type, it cannot be $(I ref),
-        and it is set to be the index of the sequence element.
-)
-
-$(P
+        can be one or two iteration symbols declared. If one, then the symbol
+        is an $(I element alias) of each element in the sequence in turn.
+)$(P
         If the sequence is a $(I TypeSeq), then the foreach statement
-        is executed once for each type, and the value is aliased to that
+        is executed once for each type, and the element alias is set to each
         type.
+)$(P
+        When the sequence is a $(I ValueSeq), the element alias is a variable
+        and is set to each value in the sequence. If the type of the
+        variable is given, it must match the type of the sequence contents.
+        If no type is given, the type of the variable is set to the type
+        of the sequence element, which may change from iteration to iteration.
+)$(P
+        If there are
+        two symbols declared, the first is the $(I index variable)
+        and the second is the $(I element alias). The index
+        must be of $(D int) or $(D uint) type, it cannot be `ref`,
+        and it is set to the index of each sequence element.
 )
-
+        $(P Example:)
 -----
-import std.stdio;
 import std.meta : AliasSeq;
 
 void main()
 {
-    alias TL = AliasSeq!(int, long, double);
+    alias Seq = AliasSeq!(int, "literal", main);
 
-    foreach (T; TL)
+    foreach (sym; Seq)
     {
-        writeln(typeid(T));
+        pragma(msg, sym.stringof);
     }
 }
 -----
-
-        $(P Prints:)
+        $(P Output:)
 
 $(CONSOLE
 int
-long
-double
+"literal"
+main()
 )
+
+        $(P See also: $(DDSUBLINK spec/version, staticforeach, Static Foreach).)
 
 $(H3 $(LNAME2 foreach_ref_parameters, Foreach Ref Parameters))
 

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -485,8 +485,8 @@ $(P
         If there are
         two variables declared, the first is said to be the $(I index)
         and the second is said to be the $(I value). The $(I index)
-        must be of $(D int), $(D uint) or $(D size_t) type,
-        it cannot be $(I ref),
+        must be of `int`, `uint`, `long` or `ulong` type,
+        it cannot be `ref`,
         and it is set to be the index of the array element.
 )
 --------------
@@ -585,7 +585,7 @@ $(H3 $(LNAME2 foreach_over_associative_arrays, Foreach over Associative Arrays))
         two variables declared, the first is said to be the $(I index)
         and the second is said to be the $(I value). The $(I index)
         must be of the same type as the indexing type of the associative
-        array. It cannot be $(I ref),
+        array. It cannot be `ref`,
         and it is set to be the index of the array element.
         The order in which the elements of the array are iterated over is unspecified
         for $(D foreach). $(D foreach_reverse) for associative arrays
@@ -855,7 +855,8 @@ $(P
         If there are
         two symbols declared, the first is the $(I index variable)
         and the second is the $(I element alias). The index
-        must be of $(D int) or $(D uint) type, it cannot be `ref`,
+        must be of `int`, `uint`, `long` or `ulong` type,
+        it cannot be `ref`,
         and it is set to the index of each sequence element.
 )
         $(P Example:)


### PR DESCRIPTION
* Compile-time Tuple -> Sequence (see #2204)
* ExpressionTuple -> ValueSeq (this matches https://dlang.org/spec/template.html#variadic-templates point 2)
* Improve wording of *Foreach over Tuples* & example
* Add link to `static foreach`