### PR TITLE
Use correct HTML for BEST_PRACTICE

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -4,9 +4,6 @@ ACRONYM = <acronym title="$+">$1</acronym> ($+)
 ASSIGNEXPRESSION = $(GLINK2 expression, AssignExpression)
 _=
 
-$(COMMENT While not part of the spec, best practices offers advice on how to best use a feature)
-BEST_PRACTICE= $(P $(B Best Practices:) $0)
-
 BIGOH = $(SPANC bigoh, &Omicron;($(D $0)))
 BLOCKQUOTE = $(T blockquote, $(P $0))
 BLOCKQUOTE_BY = $(BLOCKQUOTE $+ $(T cite, $1))
@@ -207,8 +204,7 @@ HTMLTAG3V=<$1 $2>$(TAIL $+)
 HYPHENATE=hyphenate
 _=
 
-$(COMMENT Identifies implementation-defined behavior in the spec)
-IMPLEMENTATION_DEFINED=$(P $(B Implementation Defined): $0)
+
 ISEXPRESSION=$(GLINK2 expression, IsExpression)
 _=
 
@@ -544,8 +540,6 @@ TROW=$(TR $(TDX $1, $+))
 TROW_EXPLANATORY=<td colspan="10">$0</td>
 _=
 
-$(COMMENT Identifies undefined-defined behavior in the spec)
-UNDEFINED_BEHAVIOR=$(P $(B Undefined Behavior): $0)
 UNDERSCORE=_
 UNDERSCORE_PREFIXED=_$1$(UNDERSCORE_PREFIXED $+)
 UNDERSCORE_PREFIXED_SKIP=$(UNDERSCORE_PREFIXED $+)

--- a/ebook.ddoc
+++ b/ebook.ddoc
@@ -68,3 +68,10 @@ HEADERNAV_TOC=
 HEADERNAV_ITEM=
 HEADERNAV_SUBITEMS=
 _=
+
+
+_= specification boxes
+BEST_PRACTICE= $(P $(B Best Practices:) $0)
+IMPLEMENTATION_DEFINED=$(P $(B Implementation Defined): $0)
+UNDEFINED_BEHAVIOR=$(P $(B Undefined Behavior): $0)
+_=

--- a/spec/latex.ddoc
+++ b/spec/latex.ddoc
@@ -8,6 +8,7 @@ AMP=\&
 _=
 
 B=\textbf{$0}
+BEST_PRACTICE= $(P $(B Best Practices:) $0)
 BIG=\large{$0}
 BLACK={\color{black}$0}
 BLUE={\color{blue}$0}
@@ -117,6 +118,7 @@ HTMLTAG3=
 _=
 
 I=\textit{$0}
+IMPLEMENTATION_DEFINED=$(P $(B Implementation Defined): $0)
 _=
 
 LAYOUT=
@@ -361,6 +363,8 @@ $0
 \end{itemize}
 _=
 
+
+UNDEFINED_BEHAVIOR=$(P $(B Undefined Behavior): $0)
 UNDERSCORE=\_
 _=
 

--- a/spec/spec.ddoc
+++ b/spec/spec.ddoc
@@ -3,6 +3,18 @@ ROOT = ..
 SEARCHDEFAULT_SPEC = selected
 DDOC_BLANKLINE = $(DIVC blankline)
 
+
+_ = special specification boxes
+$(COMMENT While not part of the spec, best practices offers advice on how to best use a feature)
+BEST_PRACTICE= $(DIVC spec-boxes best-practice, $(B Best Practices:) $0)
+
+$(COMMENT Identifies implementation-defined behavior in the spec)
+IMPLEMENTATION_DEFINED=$(DIVC spec-boxes implementation-defined, $(B Implementation Defined): $0)
+
+$(COMMENT Identifies undefined-defined behavior in the spec)
+UNDEFINED_BEHAVIOR=$(DIVC spec-boxes undefined-behavior, $(B Undefined Behavior): $0)
+_ =
+
 BODY_PREFIX =
 $(T style,
     body { counter-reset: h1 $(CHAPTER); counter-increment: h1 -1; }
@@ -26,11 +38,11 @@ $(T style,
         counter-increment: h4;
         content: counter(h1) "." counter(h2) "." counter(h3) "." counter(h4) " ";
     }
-    p::before {
+    p::before, .spec-boxes::before {
         counter-increment: p;
         content: counter(p) ". ";
     }
-    h1::before, h2::before, h3::before, h4::before, p::before
+    h1::before, h2::before, h3::before, h4::before, p::before, .spec-boxes::before
     {
         color: #999;
         font-size: 80%;


### PR DESCRIPTION
See e.g. https://dlang.org/spec/arrays.html for the problem.
In short, `BEST_PRACTICE` is defined as:

```
BEST_PRACTICE= $(P best-practice, $(B Best Practices:) $0)
```

BUT `OL,UL` are individual HTML blocks:

```html
<p>
foo
 <ol> ... </ol> // <-- "invalid" HTML, starts a new block
bar
</p>
```

The [spec](https://www.w3.org/TR/html5/grouping-content.html#the-p-element) says this pretty explicitly:

> List elements (in particular, ol and ul elements) __cannot__ be children of p elements.

This fixes this and moves the macros to `spec.ddoc` where they should have been put.