### PR TITLE
[trivial] Remove runnable block for the first example in spec/arrays

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -18,11 +18,9 @@ $(H2 $(LNAME2 array-kinds, Kinds))
 
 $(H3 $(LNAME2 pointers, Pointers))
 
-$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---------
 int* p;
 ---------
-)
 
         $(P A pointer to type $(I T) has a value which is a reference (address) to another
         object of type $(I T). It is commonly called a $(I pointer to T).


### PR DESCRIPTION
https://dlang.org/spec/arrays.html

Motivation:

![image](https://user-images.githubusercontent.com/4370550/36757971-3368a582-1c13-11e8-8d47-a1fc762ced8a.png)
