### PR TITLE
use UNDEFINED_BEHAVIOR macro

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -720,7 +720,7 @@ int x = foo[3]; // error, out of bounds
         with a compile time switch.
         )
 
-        $(P An out of bounds memory access will cause undefined behavior,
+        $(UNDEFINED_BEHAVIOR An out of bounds memory access will cause undefined behavior,
             therefore array bounds check is normally enabled in `@safe` functions.
             The runtime behavior is part of the language semantics.
         )

--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -277,10 +277,12 @@ auto sz = S.sizeof;  // 12
         $(P Do not align references or pointers that were allocated
         using $(GLINK2 expression, NewExpression) on boundaries that are not
         a multiple of $(D size_t). The garbage collector assumes that pointers
-        and references to gc allocated objects will be on $(D size_t)
-        byte boundaries. If they are not, undefined behavior will
-        result.
+        and references to GC allocated objects will be on $(D size_t)
+        byte boundaries.
         )
+
+        $(UNDEFINED_BEHAVIOR If any pointers and references to GC
+        allocated objects are not aligned on `size_t` byte boundaries.)
 
         $(P The $(I AlignAttribute) is reset to the default when
         entering a function scope or a non-anonymous struct, union, class, and restored

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -389,6 +389,20 @@ $(GNAME Constructor):
         $(P The following restrictions apply to class construction:)
 
     $(OL
+        $(LI It is illegal for constructors to mutually call each other.
+
+        ------
+        this() { this(1); }
+        this(int i) { this(); } // illegal, cyclic constructor calls
+        ------
+
+        $(IMPLEMENTATION_DEFINED The compiler is not required to detect
+        cyclic constructor calls.)
+
+        $(UNDEFINED_BEHAVIOR If the program executes with cyclic constructor
+        calls.)
+        )
+
         $(LI If a constructor's code contains a delegate constructor call, all
         possible execution paths through the constructor must make exactly one
         delegate constructor call:

--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -40,8 +40,7 @@ assert(expression);
         $(P As a contract, an $(D assert) represents a guarantee that the code
         $(I must) uphold. Any failure of this expression represents a logic
         error in the code that must be fixed in the source code.  A program for
-        which the assert contract is false is, by definition, invalid, and
-        therefore has undefined behaviour.)
+        which the assert contract is false is, by definition, invalid.)
 
         $(P As a debugging aid, the compiler may insert a runtime check to
         verify that the expression is indeed true.  If it is false, an
@@ -52,6 +51,9 @@ assert(expression);
 
         $(P The compiler is free to assume the assert expression is true and
         optimize subsequent code accordingly.)
+
+        $(UNDEFINED_BEHAVIOR The subsequent execution of the program after an
+        assert contract is false.)
 
 $(H2 $(LNAME2 pre_post_contracts, Pre and Post Contracts))
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -757,15 +757,11 @@ $(GNAME DeleteExpression):
 
     $(P Otherwise, the garbage collector is called to immediately free the
         memory allocated for the class instance or struct instance.
-        If the garbage collector was not used to allocate the memory for
-        the instance, undefined behavior will result.
     )
 
     $(P If the $(I UnaryExpression) is a pointer or a dynamic array,
         the garbage collector is called to immediately release the
         memory.
-        If the garbage collector was not used to allocate the memory for
-        the instance, undefined behavior will result.
     )
 
     $(P The pointer, dynamic array, or reference is set to $(D null)
@@ -779,6 +775,12 @@ $(GNAME DeleteExpression):
         instance. Neither the garbage collector nor any class deallocator
         is called.
     )
+
+    $(UNDEFINED_BEHAVIOR
+    $(OL
+    $(LI Using `delete` to free memory not allocated by the garbage collector.)
+    $(LI Referring to data that has been the operand of `delete`.)
+    ))
 
 $(H3 $(LNAME2 cast_expressions, Cast Expressions))
 

--- a/spec/garbage.dd
+++ b/spec/garbage.dd
@@ -193,7 +193,7 @@ $(H2 $(LNAME2 pointers_and_gc, Pointers and the Garbage Collector))
         to enable the maximum flexibility in garbage collector design.
         )
 
-        $(P Undefined behavior:)
+        $(UNDEFINED_BEHAVIOR
 
         $(UL
 
@@ -303,6 +303,7 @@ struct Foo
         came from, with likely disastrous results.
         )
 
+        )
         )
 
         $(P Things that are reliable and can be done:)

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -348,13 +348,15 @@ $(GNAME TokenString):
 
         $(P
         A string literal is either a double quoted string, a wysiwyg quoted
-        string, a delimited string, a token string,     or a hex string.
+        string, a delimited string, a token string, or a hex string.
         )
 
         $(P In all string literal forms, an $(GLINK EndOfLine) is regarded as a single
         $(D \n) character.)
 
-        $(P String literals are read only. Writes to string literals
+        $(P String literals are read only.)
+
+        $(UNDEFINED_BEHAVIOR Writes to string literals
         cannot always be detected, but cause undefined behavior.)
 
 $(H3 $(LNAME2 wysiwyg, Wysiwyg Strings))


### PR DESCRIPTION
Searched the spec for descriptions of undefined behavior, and delineated them with the UNDEFINED_BEHAVIOR macro.