### PR TITLE
Update interfaceToC.dd

### DIFF
--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -226,7 +226,7 @@ void foo(char[] string)
 }
 ------
 
-        While the $(P The $(CODE printf) format string literal
+        $(P While the $(CODE printf) format string literal
         in the example does not end with an explicit $(CODE '\0'), $(CODE printf) will still see one.
         This is because string literals,
         when they are not part of an initializer to a larger data structure,

--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -227,7 +227,7 @@ void foo(char[] string)
 ------
 
         $(P The $(CODE printf) format string literal
-        in the example doesn't end with $(CODE '\0').
+        in the example DOES end with $(CODE '\0').
         This is because string literals,
         when they are not part of an initializer to a larger data structure,
         have a $(CODE '\0') character helpfully stored after the end of them.

--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -226,8 +226,8 @@ void foo(char[] string)
 }
 ------
 
-        $(P The $(CODE printf) format string literal
-        in the example $(I does) end with $(CODE '\0').
+        While the $(P The $(CODE printf) format string literal
+        in the example does not end with an explicit $(CODE '\0'), $(CODE printf) will still see one.
         This is because string literals,
         when they are not part of an initializer to a larger data structure,
         have a $(CODE '\0') character helpfully stored after the end of them.

--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -227,7 +227,7 @@ void foo(char[] string)
 ------
 
         $(P The $(CODE printf) format string literal
-        in the example DOES end with $(CODE '\0').
+        in the example $(I does) end with $(CODE '\0').
         This is because string literals,
         when they are not part of an initializer to a larger data structure,
         have a $(CODE '\0') character helpfully stored after the end of them.


### PR DESCRIPTION
The string literal passed to printf appears to have a null character appended. The documentation currently says that it doesn't, and that it does. Change first sentence to say that it does.