### PR TITLE
Remove ddoc workarounds

### DIFF
--- a/ddoc/source/preprocessor.d
+++ b/ddoc/source/preprocessor.d
@@ -62,7 +62,6 @@ All unknown options are passed to the compiler.
     text = genHeader(text);
     text = genChangelogVersion(inputFile, text);
     text = genSwitches(text);
-    text = fixDdocBugs(inputFile, text);
 
     // Phobos index.d should have been named index.dd
     if (inputFile.endsWith(".d") && !inputFile.endsWith("index.d"))
@@ -443,19 +442,4 @@ private void highlightSpecialWords(ref string flag, ref string helpText)
             .joiner(" ")
             .to!string;
     }
-}
-
-// Fix ddoc bugs
-string fixDdocBugs(string inputFile, string text)
-{
-
-    // https://github.com/dlang/dlang.org/pull/2069#issuecomment-363154934
-    // can be removed once the Phobos PR is in stable and master
-    // https://github.com/dlang/phobos/pull/6126
-    if (inputFile.endsWith("exception.d"))
-    {
-        text = text.replace(`typeof(new E("", __FILE__, __LINE__)`, `typeof(new E("", string.init, size_t.init)`);
-        text = text.replace(`typeof(new E(__FILE__, __LINE__)`, `typeof(new E(string.init, size_t.init)`);
-    }
-    return text;
 }


### PR DESCRIPTION
This can now be merged as https://github.com/dlang/phobos/pull/6126 is in 2.079.0.