### PR TITLE
fix import paths for dmd-${LATEST}

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -622,6 +622,7 @@ $(DMD) : ${DMD_DIR}
 
 $(DMD_LATEST) : ${DMD_LATEST_DIR}
 	${MAKE} --directory=${DMD_LATEST_DIR}/src -f posix.mak AUTO_BOOTSTRAP=1
+	sed -i -e "s|../druntime/import |../druntime-${LATEST}/import |" -e "s|../phobos |../phobos-${LATEST} |" $@.conf
 
 dmd-prerelease : $(STD_DDOC_PRERELEASE) druntime-target $G/changelog/next-version
 	$(MAKE) AUTO_BOOTSTRAP=1 --directory=$(DMD_DIR) -f posix.mak html $(DDOC_VARS_PRERELEASE_HTML)


### PR DESCRIPTION
Cherry-picked from https://github.com/dlang/dlang.org/pull/2257

- needs to use ../druntime-${LATEST}/import and ../phobos-${LATEST}
- unclear how this used to work beforehand, likely did pick up ../druntime/import
  and ../phobos from a concurrent (or previous) prerelease build

Needed for DAutoTest to pass on `stable`.