### PR TITLE
Bump archives to 2.079

### DIFF
--- a/js/listanchors.js
+++ b/js/listanchors.js
@@ -34,7 +34,7 @@ function addAnchors()
 function addVersionSelector() {
   // Latest version offered by the archive builds
   // This needs to be manually updated after new versions have been archived
-  var currentArchivedVersion = 78;
+  var currentArchivedVersion = 79;
   // build URLs for dlang.org: DDoc + Dox
   var ddocModuleURL = document.body.id.replace(/[.]/g, "_") + ".html";
   var ddoxModuleURL = document.body.id.replace(/[.]/g, "/") + ".html";


### PR DESCRIPTION
At some point we should look into a solution that automates building the archives as part of the release process...

See also: https://github.com/dlang/docarchives.dlang.io/commit/485734452780d2ff03cdda36aee5254ad48e1cd8