### PR TITLE
Deprecate class allocators and deallocators

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -11,7 +11,7 @@ $(SPEC_S Deprecated Features,
     $(TABLE2 Deprecated Features,
         $(THEAD Feature,                                                          Spec,  Dep,    Error,  Gone)
         $(TROW $(DEPLINK Hexstring literals),                                     2.079, 2.079, &nbsp;, &nbsp;)
-        $(TROW $(DEPLINK Class allocators and deallocators),                      future, &nbsp;, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK Class allocators and deallocators),                      &nbsp;, 2.080, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Implicit comparison of different enums),                 2.075,  2.075, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Implicit string concatenation),                          2.072,  2.072, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Using the result of a comma expression),                 2.072,  2.072,  2.079, &nbsp;)


### PR DESCRIPTION
`delete` was deprecated in 2.079.  Before the `delete` keyword can be removed it will be necessary to also deprecate and remove class allocators and deallocators.  They have been planned for deprecation for years; this PR finally puts the deprecation process in motion.

See https://dlang.org/deprecate.html#Class%20allocators%20and%20deallocators

DMD PR:  https://github.com/dlang/dmd/pull/8042