### PR TITLE
Adjust guidelines for attributes on templated functions.

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -355,8 +355,13 @@ $(LISTSECTION phobos_return_types, Return type,
 $(LISTSECTION phobos_attributes, Attributes,
     $(LI $(I Non-templated) functions should be annotated with
          matching attributes (`@nogc`, `@safe`, `pure`, `nothrow`).)
-    $(LI $(I Templated) functions should $(B not) be annotated with attributes
-         as the compiler can infer them.)
+    $(LI If the template arguments for a $(I templated) function affect whether
+         an attribute is appropriate, then the function should $(B not) be
+         annotated with that attribute so that the compiler can infer it.
+         However, if the attribute is not affected by the template arguments
+         (and thus would always be inferred), then the function should be
+         explicitly annotated with that attribute just like a non-templated
+         function would be.)
     $(LI Attributes should be listed in alphabetical ordering, e.g. `const @nogc nothrow pure @safe`
         (the ordering should ignore the leading `@`).
     )


### PR DESCRIPTION
If whether a particular attribute is applicable to a templated function
or not does not depend on the template arguments (e.g. it's a function
for operating on arrays of characters that's templated on character type
and @safe would always be inferred), then having the attributes be
explicit is better for the documentation. It also ensures that the
attribute is enforced so that it's caught if the code changes
accidentally conflict with the attribute. One of the major downsides to
attribute inference is that it's unclear which attributes apply, and
it's easier to accidentally make changes which change the attributes.

Attribute inference is critical when the applicability of an attribute
depends on the template arguments, but if the attribute is _always_
inferred regardless of the template arguments, then avoiding putting the
attributes on the function just give us the downsides of attribute
inference without the gains. So, ultimately, it makes the most sense to
be as explicit about attributes as we can be.