### PR TITLE
Remove volatile keyword from the lexer documentation

### DIFF
--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -1023,7 +1023,6 @@ $(MULTICOLS 4,
 
     $(LINK2 version.html#version, $(D version))
     $(LINK2 declaration.html#VoidInitializer, $(D void))
-    $(LINK2 $(ROOT_DIR)ctod.html#volatile, $(D volatile)) ($(LINK2 $(ROOT_DIR)deprecate.html#volatile, deprecated))
 
     $(LINK2 type.html, $(D wchar))
     $(LINK2 statement.html#WhileStatement, $(D while))


### PR DESCRIPTION
- `volatile` is no longer part of the language.  It was removed a couple of years ago.
- It's deprecation is already documented at https://dlang.org/deprecate.html#volatile, so there's no need for it to be documented in the spec.
- The link currently goes to a non-existent anchor on the ctod page, sending the reader nowhere useful.
