### PR TITLE
Use the dlang.org's XML stream at feedburner to convert the latest articles to ddoc macros

### DIFF
--- a/dblog_feed_example.xml
+++ b/dblog_feed_example.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" media="screen" href="/~d/styles/rss2full.xsl"?><?xml-stylesheet type="text/css" media="screen" href="http://feeds.feedburner.com/~d/styles/itemcontent.css"?><rss xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:wfw="http://wellformedweb.org/CommentAPI/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:slash="http://purl.org/rss/1.0/modules/slash/" xmlns:feedburner="http://rssnamespace.org/feedburner/ext/1.0" version="2.0">
+
+<channel>
+	<title>The D Blog</title>
+	
+	<link>https://dlang.org/blog</link>
+	<description>The official blog for the D Programming Language.</description>
+	<lastBuildDate>Mon, 19 Mar 2018 13:27:32 +0000</lastBuildDate>
+	<language>en-US</language>
+	<sy:updatePeriod>hourly</sy:updatePeriod>
+	<sy:updateFrequency>1</sy:updateFrequency>
+	<generator>https://wordpress.org/?v=4.9.4</generator>
+<site xmlns="com-wordpress:feed-additions:1">112438176</site>	<atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="self" type="application/rss+xml" href="http://feeds.feedburner.com/OfficialDBlog" /><feedburner:info uri="officialdblog" /><atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="hub" href="http://pubsubhubbub.appspot.com/" /><feedburner:browserFriendly></feedburner:browserFriendly><item>
+		<title>DConf 2018 Programme &amp; Open Registration</title>
+		<link>https://dlang.org/blog/2018/03/19/dconf-2018-programme-open-registration/</link>
+		<comments>https://dlang.org/blog/2018/03/19/dconf-2018-programme-open-registration/#respond</comments>
+		<pubDate>Mon, 19 Mar 2018 13:27:32 +0000</pubDate>
+		<dc:creator><![CDATA[Michael Parker]]></dc:creator>
+				<category><![CDATA[D Foundation]]></category>
+		<category><![CDATA[DConf]]></category>
+
+		<guid isPermaLink="false">http://dlang.org/blog/?p=1493</guid>
+		<description><![CDATA[Registration for DConf 2018 Munich, May 2-5, is open! 21 hours of engaging presentations and panels, an all-day Hackathon, and intelligent conversation with members of the D programming language community! We have keynotes from language stewards Walter Bright and Andrei Alexandrescu, along with our invited guest from academia Martin Odersky, professor at EPFL and creator of the Scala language. Whether you know nothing of DLang or you're a seasoned pro, we invite you to spend 4 days with us to partake in the fun, the education, and the German beer. Check the programme and register today!]]></description>
+		<wfw:commentRss>https://dlang.org/blog/2018/03/19/dconf-2018-programme-open-registration/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+	<post-id xmlns="com-wordpress:feed-additions:1">1493</post-id>	</item>
+		<item>
+		<title>User Stories: Funkwerk</title>
+		<link>https://dlang.org/blog/2018/03/14/user-stories-funkwerk/</link>
+		<comments>https://dlang.org/blog/2018/03/14/user-stories-funkwerk/#comments</comments>
+		<pubDate>Wed, 14 Mar 2018 14:06:32 +0000</pubDate>
+		<dc:creator><![CDATA[Michael Parker]]></dc:creator>
+				<category><![CDATA[Code]]></category>
+		<category><![CDATA[Community]]></category>
+		<category><![CDATA[Companies]]></category>
+		<category><![CDATA[Guest Posts]]></category>
+		<category><![CDATA[User Stories]]></category>
+
+		<guid isPermaLink="false">http://dlang.org/blog/?p=1479</guid>
+		<description><![CDATA[In this post, we cap off the Funkwerk series with the launch of a new feature we creatively call “User Stories”. Now and again, we’ll publish a post in which D users talk of their experiences with D, not about specific projects, but about the language itself. They’ll tell of things like their favorite features, why they use it, how it has changed the way they write code, or anything they’d like to say that expresses how they feel about programming in D.]]></description>
+		<wfw:commentRss>https://dlang.org/blog/2018/03/14/user-stories-funkwerk/feed/</wfw:commentRss>
+		<slash:comments>3</slash:comments>
+	<post-id xmlns="com-wordpress:feed-additions:1">1479</post-id>	</item>
+		<item>
+		<title>The D Language Foundation at Open Collective</title>
+		<link>https://dlang.org/blog/2018/03/12/the-d-foundation-at-open-collective/</link>
+		<comments>https://dlang.org/blog/2018/03/12/the-d-foundation-at-open-collective/#respond</comments>
+		<pubDate>Mon, 12 Mar 2018 14:20:54 +0000</pubDate>
+		<dc:creator><![CDATA[Michael Parker]]></dc:creator>
+				<category><![CDATA[Community]]></category>
+		<category><![CDATA[D Foundation]]></category>
+
+		<guid isPermaLink="false">http://dlang.org/blog/?p=1441</guid>
+		<description><![CDATA[In its work guiding the development of D and promoting its adoption, the D Language Foundation is driven primarily by donations big and small. The money comes in from different sources, the most visible being those listed on the website’s donation page, and is put to use in different ways. Today, the D Language Foundation is opening a new chapter in the donation story.]]></description>
+		<wfw:commentRss>https://dlang.org/blog/2018/03/12/the-d-foundation-at-open-collective/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+	<post-id xmlns="com-wordpress:feed-additions:1">1441</post-id>	</item>
+		<item>
+		<title>The New New DIP Process</title>
+		<link>https://dlang.org/blog/2018/03/09/the-new-new-dip-process/</link>
+		<comments>https://dlang.org/blog/2018/03/09/the-new-new-dip-process/#comments</comments>
+		<pubDate>Fri, 09 Mar 2018 12:49:07 +0000</pubDate>
+		<dc:creator><![CDATA[Michael Parker]]></dc:creator>
+				<category><![CDATA[Community]]></category>
+		<category><![CDATA[Core Team]]></category>
+
+		<guid isPermaLink="false">http://dlang.org/blog/?p=1437</guid>
+		<description><![CDATA[When I took on the role of DIP Manager last year, my number one goal was to clear out the queue. I made a few revisions to the process and got busy. Over the next few months, things went along fairly well, not so much from anything I did as from the quality of the submissions. But at some point, things broke down and the process stalled.]]></description>
+		<wfw:commentRss>https://dlang.org/blog/2018/03/09/the-new-new-dip-process/feed/</wfw:commentRss>
+		<slash:comments>3</slash:comments>
+	<post-id xmlns="com-wordpress:feed-additions:1">1437</post-id>	</item>
+		<item>
+		<title>LDC 1.8.0 Released</title>
+		<link>https://dlang.org/blog/2018/03/06/ldc-1-8-0-released/</link>
+		<comments>https://dlang.org/blog/2018/03/06/ldc-1-8-0-released/#respond</comments>
+		<pubDate>Tue, 06 Mar 2018 13:56:15 +0000</pubDate>
+		<dc:creator><![CDATA[LDC Developers]]></dc:creator>
+				<category><![CDATA[Compilers & Tools]]></category>
+		<category><![CDATA[Guest Posts]]></category>
+		<category><![CDATA[LDC Releases]]></category>
+		<category><![CDATA[News]]></category>
+
+		<guid isPermaLink="false">http://dlang.org/blog/?p=1428</guid>
+		<description><![CDATA[The LDC developers are proud to announce the release of version 1.8.0, following a short year and a half from the 1.0 release. This version integrates version 2.078.3 of the D front-end, which is itself written in D, making LDC one of the most prominent mixed D/C++ codebases.]]></description>
+		<wfw:commentRss>https://dlang.org/blog/2018/03/06/ldc-1-8-0-released/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+	<post-id xmlns="com-wordpress:feed-additions:1">1428</post-id>	</item>
+		<item>
+		<title>DMD 2.079.0 Released</title>
+		<link>https://dlang.org/blog/2018/03/03/dmd-2-079-0-released/</link>
+		<comments>https://dlang.org/blog/2018/03/03/dmd-2-079-0-released/#respond</comments>
+		<pubDate>Sat, 03 Mar 2018 12:00:30 +0000</pubDate>
+		<dc:creator><![CDATA[Michael Parker]]></dc:creator>
+				<category><![CDATA[Code]]></category>
+		<category><![CDATA[Compilers & Tools]]></category>
+		<category><![CDATA[Core Team]]></category>
+		<category><![CDATA[DMD Releases]]></category>
+		<category><![CDATA[News]]></category>
+
+		<guid isPermaLink="false">http://dlang.org/blog/?p=1408</guid>
+		<description><![CDATA[It’s not always easy to choose which enhancements or changes from a release to highlight on the blog. What’s important to some will elicit a shrug from others. This time, there's so much to choose from that my head is spinning. But two in particular stand out as having the potential to result in a significant impact on the D programming experience, especially for those who are new to the language.]]></description>
+		<wfw:commentRss>https://dlang.org/blog/2018/03/03/dmd-2-079-0-released/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+	<post-id xmlns="com-wordpress:feed-additions:1">1408</post-id>	</item>
+		<item>
+		<title>The State of D 2018 Survey</title>
+		<link>https://dlang.org/blog/2018/02/28/the-state-of-d-2018-survey/</link>
+		<comments>https://dlang.org/blog/2018/02/28/the-state-of-d-2018-survey/#respond</comments>
+		<pubDate>Wed, 28 Feb 2018 13:30:49 +0000</pubDate>
+		<dc:creator><![CDATA[Michael Parker]]></dc:creator>
+				<category><![CDATA[Community]]></category>
+		<category><![CDATA[Core Team]]></category>
+		<category><![CDATA[News]]></category>
+		<category><![CDATA[State of D]]></category>
+
+		<guid isPermaLink="false">http://dlang.org/blog/?p=1400</guid>
+		<description><![CDATA[This is your chance to turn your praise, complaints, and nitpicks into action. By participating in the State of D survey, you'll be providing guidance to the D Language Foundation to help identify both short and long-term goals for the future development of D and its ecosystem.]]></description>
+		<wfw:commentRss>https://dlang.org/blog/2018/02/28/the-state-of-d-2018-survey/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+	<post-id xmlns="com-wordpress:feed-additions:1">1400</post-id>	</item>
+		<item>
+		<title>DConf 2018 Munich: The Venue</title>
+		<link>https://dlang.org/blog/2018/02/23/dconf-2018-munich-the-venue/</link>
+		<comments>https://dlang.org/blog/2018/02/23/dconf-2018-munich-the-venue/#respond</comments>
+		<pubDate>Fri, 23 Feb 2018 13:38:00 +0000</pubDate>
+		<dc:creator><![CDATA[Michael Parker]]></dc:creator>
+				<category><![CDATA[D Foundation]]></category>
+		<category><![CDATA[DConf]]></category>
+
+		<guid isPermaLink="false">http://dlang.org/blog/?p=1386</guid>
+		<description><![CDATA[This is our first time in Munich, and if you can pad out your visit by two or three days, there’s a lot to see while you’re there. The venue is the NH Munich Messe hotel, located in the Zamdorf area of the city.]]></description>
+		<wfw:commentRss>https://dlang.org/blog/2018/02/23/dconf-2018-munich-the-venue/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+	<post-id xmlns="com-wordpress:feed-additions:1">1386</post-id>	</item>
+		<item>
+		<title>Project Highlight: The D Community Hub</title>
+		<link>https://dlang.org/blog/2018/02/17/project-highlight-the-d-community-hub/</link>
+		<comments>https://dlang.org/blog/2018/02/17/project-highlight-the-d-community-hub/#respond</comments>
+		<pubDate>Sat, 17 Feb 2018 12:46:19 +0000</pubDate>
+		<dc:creator><![CDATA[Michael Parker]]></dc:creator>
+				<category><![CDATA[Community]]></category>
+		<category><![CDATA[Compilers & Tools]]></category>
+		<category><![CDATA[Project Highlights]]></category>
+
+		<guid isPermaLink="false">http://dlang.org/blog/?p=1381</guid>
+		<description><![CDATA[Sometimes projects are abandoned. Sometimes they aren&#8217;t updated as frequently as users would like. This can become an issue for those who depend upon these projects, but it&#8217;s alleviated by the fact that most D projects are open source and their repositories are publicly available. All it takes to keep a project alive and up-to-date are more volunteers willing to pitch in. That&#8217;s the motivation behind the <a href="https://tour.dlang.org/">dlang-community organization</a> at GitHub.]]></description>
+		<wfw:commentRss>https://dlang.org/blog/2018/02/17/project-highlight-the-d-community-hub/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+	<post-id xmlns="com-wordpress:feed-additions:1">1381</post-id>	</item>
+		<item>
+		<title>Vanquish Forever These Bugs That Blasted Your Kingdom</title>
+		<link>https://dlang.org/blog/2018/02/07/vanquish-forever-these-bugs-that-blasted-your-kingdom/</link>
+		<comments>https://dlang.org/blog/2018/02/07/vanquish-forever-these-bugs-that-blasted-your-kingdom/#comments</comments>
+		<pubDate>Wed, 07 Feb 2018 13:07:26 +0000</pubDate>
+		<dc:creator><![CDATA[Walter Bright]]></dc:creator>
+				<category><![CDATA[BetterC]]></category>
+		<category><![CDATA[Code]]></category>
+		<category><![CDATA[Core Team]]></category>
+
+		<guid isPermaLink="false">http://dlang.org/blog/?p=1350</guid>
+		<description><![CDATA[Do you ever get tired of bugs that are easy to make, hard to check for, often don’t show up in testing, and blast your kingdom once they are widely deployed? They cost you time and money again and again. If you were only a better programmer, these things wouldn’t happen, right?]]></description>
+		<wfw:commentRss>https://dlang.org/blog/2018/02/07/vanquish-forever-these-bugs-that-blasted-your-kingdom/feed/</wfw:commentRss>
+		<slash:comments>4</slash:comments>
+	<post-id xmlns="com-wordpress:feed-additions:1">1350</post-id>	</item>
+	</channel>
+</rss>

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -144,14 +144,7 @@ DDOCKEYVAL2=$(DIVC keyval $1, $(SPANC key key$1, $2:) $(DIVC val val$1, $(TAIL $
 DDSUBLINK=$(LINK2 $(ROOT_DIR)$1.html#$2, $3)
 _=
 
-DBLOG_LATEST_AUTHOR=A D enthusiast
-DBLOG_LATEST_DATE=December 17, $(YEAR)
-DBLOG_LATEST_LINK=https://dlang.org/blog
-DBLOG_LATEST_TITLE=An article from the DBlog about `DIFFABLE=1`
-DBLOG_LATEST_AUTHOR2=A D-eveloper
-DBLOG_LATEST_DATE2=December 5, $(YEAR)
-DBLOG_LATEST_LINK2=https://dlang.org/blog
-DBLOG_LATEST_TITLE2=Yet another article that will be replaced with real content
+
 DMDSRC=$(HTTPS github.com/dlang/dmd/blob/master/src/dmd/$0, $0)
 DOT_PREFIXED=.$1$(DOT_PREFIXED $+)
 DOT_PREFIXED_SKIP=$(DOT_PREFIXED $+)

--- a/index.dd
+++ b/index.dd
@@ -365,14 +365,14 @@ $(DIVC boxes,
         $(TOUR newspaper-o, News,
             $(P Stay updated with the latest posts in the
                 $(LINK2 http://blog.dlang.org,
-                    <cite>Official D Blog</cite>) from $(DBLOG_LATEST_DATE):
-                $(LINK2 $(DBLOG_LATEST_LINK), $(DBLOG_LATEST_TITLE)) by
-                $(DBLOG_LATEST_AUTHOR).
+                    <cite>Official D Blog</cite>) from $(DBLOG_LATEST_DATE_1):
+                $(LINK2 $(DBLOG_LATEST_LINK_1), $(DBLOG_LATEST_TITLE_1)) by
+                $(DBLOG_LATEST_AUTHOR_1).
             )
             $(P
-                From $(DBLOG_LATEST_DATE2):
-                $(LINK2 $(DBLOG_LATEST_LINK2), $(DBLOG_LATEST_TITLE2)) by
-                $(DBLOG_LATEST_AUTHOR2).
+                From $(DBLOG_LATEST_DATE_2):
+                $(LINK2 $(DBLOG_LATEST_LINK_2), $(DBLOG_LATEST_TITLE_2)) by
+                $(DBLOG_LATEST_AUTHOR_2).
             )
         )
         $(TOUR graduation-cap, Learn,

--- a/tools/ddoc_xml_extractor.d
+++ b/tools/ddoc_xml_extractor.d
@@ -1,0 +1,101 @@
+#!/usr/bin/env rdmd
+/*
+ * Extracts the newest articles from dlang.org's XML site and
+ * converts them to Ddoc macros.
+ *
+ * Copyright (C) 2018 by D Language Foundation
+ *
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+*/
+// Written in the D programming language.
+
+import std.format : format;
+import std.datetime;
+
+// crude representation of an article at the DBlog
+struct Article
+{
+    string title;
+    string link;
+    SysTime date;
+    string author;
+}
+
+auto toDdoc(const ref Article article, string suffix)
+{
+    import std.xml : encode;
+    string text;
+with(article)
+{
+    auto prettyMonth = ["January", "February", "March", "April", "May", "June", "July",
+    "August", "September", "October", "November", "December"][date.month-1];
+    auto prettyDate = "%s %d, %d".format(prettyMonth, date.day, date.year);
+    text =
+`DBLOG_LATEST_TITLE%5$s=%1$s
+DBLOG_LATEST_LINK%5$s=%2$s
+DBLOG_LATEST_DATE%5$s=%3$s
+DBLOG_LATEST_AUTHOR%5$s=%4$s`.format(title.encode, link, prettyDate, author.encode, suffix);
+}
+    return text;
+}
+
+int main(string[] args)
+{
+    import std.algorithm, std.exception, std.file, std.getopt, std.range, std.stdio, std.xml;
+
+    string inputFile, outputFile;
+    auto help = getopt(args,
+        config.required,
+        "i|input", &inputFile,
+        config.required,
+        "o|output", &outputFile,
+    );
+    if (help.helpWanted || !inputFile.exists)
+    {
+        defaultGetoptPrinter("./dblog_xml_extractor", help.options);
+        return 1;
+    }
+
+    auto text = inputFile.readText;
+
+    Article[] articles;
+
+    // check and parse XML
+    text.check;
+    auto doc = new DocumentParser(text);
+    doc.onStartTag["item"] = (ElementParser xml)
+    {
+        Article article;
+        scope(exit)
+        {
+            xml.parse;
+            articles ~= article;
+        }
+
+        xml.onEndTag["title"] = (const Element e) { article.title = e.text; };
+        xml.onEndTag["link"] = (const Element e) { article.link = e.text; };
+
+        // <pubDate>Wed, 07 Feb 2018 13:07:26 +0000</pubDate>
+        // -> Wed, 07 Feb 2018
+        xml.onEndTag["pubDate"] = (const Element e) { article.date = e.text.parseRFC822DateTime; };
+
+        // ugly std.xml way to extract CData
+        string lastCData;
+        xml.onEndTag["dc:creator"] = (const Element e) {
+            article.author = lastCData;
+        };
+        xml.onCData = (string s){
+            lastCData = s;
+        };
+    };
+    doc.parse;
+
+    // output the latest two article in Ddoc
+    with(File(outputFile, "w"))
+    foreach (i, el; articles.take(2).enumerate(1))
+        writeln(el.toDdoc("_%s".format(i)));
+
+    return 0;
+}


### PR DESCRIPTION
This won't work on DAutoTest, but the generated Ddoc file will be e.g.

```
DBLOG_LATEST_TITLE_1=DConf 2018 Programme &amp; Open Registration
DBLOG_LATEST_LINK_1=https://dlang.org/blog/2018/03/19/dconf-2018-programme-open-registration/
DBLOG_LATEST_DATE_1=March 19, 2018
DBLOG_LATEST_AUTHOR_1=Michael Parker
DBLOG_LATEST_TITLE_2=User Stories: Funkwerk
DBLOG_LATEST_LINK_2=https://dlang.org/blog/2018/03/14/user-stories-funkwerk/
DBLOG_LATEST_DATE_2=March 14, 2018
DBLOG_LATEST_AUTHOR_2=Michael Parker
```