### PR TITLE
Fix link in changelog for 2.079.0.

### DIFF
--- a/changelog/2.079.0.dd
+++ b/changelog/2.079.0.dd
@@ -239,7 +239,7 @@ $(CONSOLE dmd -shared awesome_d_library.d)
 
 $(LI $(LNAME2 dip1008,Experimental `@nogc` Exception throwing with `-dip1008`)
 $(P
-[DIP1008](https://github.com/dlang/DIPs/blob/master/DIPs/DIP1008.md) has been merged and it can be previewed under the experimental `-dip1008` flag:
+$(HTTPS github.com/dlang/DIPs/blob/master/DIPs/DIP1008.md, DIP 1008) has been merged and it can be previewed under the experimental `-dip1008` flag:
 )
 
 ---


### PR DESCRIPTION
Apparently, someone wasn't paying enough attention and used a markdown-style link instead of a proper ddoc macro.