### PR TITLE
Expose runtime docs on the released docs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2120,3 +2120,17 @@ dt.d_decl:hover .decl_anchor {
 .message-box-green {
     background-color: #4EBA0F;
 }
+
+/**
+Custom modifications to the navigation menu
+- Insert an Internal API divider before the dmd menu item
+*/
+.modlist-submenu-dmd::before{
+    content: "Internal API";
+    display: block;
+    height: 1em;
+    border-top: 1px solid #ccc;
+    margin-top: 1em;
+    margin-bottom: 1em;
+    padding-top: 0.5em;
+}

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -221,7 +221,7 @@ _=
 MDASH=$(T nobr, &#x200A;&mdash;&#x200A;)
 METACODE=$(SPANC metacode, $0)
 MENU = <li><a href='$1'><span>$+</span></a></li>
-MENU_W_SUBMENU = <li class='expand-container'><a class='expand-toggle' href='#'><span>$0</span></a>
+MENU_W_SUBMENU = <li class='expand-container modlist-submenu-$1'><a class='expand-toggle' href='#'><span>$(TT $1)</span></a>
 MENU_W_SUBMENU_LINK = <li class='expand-container'><a class='expand-toggle' href='$1'><span>$+</span></a>
 MENU_W_SUBMENU_END = </li>
 MESSAGE_BOX = $(DIVC message-box message-box-$1, $+)

--- a/posix.mak
+++ b/posix.mak
@@ -416,12 +416,12 @@ ${GENERATED}/${LATEST}.ddoc :
 ${GENERATED}/modlist-${LATEST}.ddoc : tools/modlist.d ${STABLE_DMD} $(DRUNTIME_LATEST_DIR) $(PHOBOS_LATEST_DIR) $(DMD_LATEST_DIR)
 	mkdir -p $(dir $@)
 	$(STABLE_RDMD) $< $(DRUNTIME_LATEST_DIR) $(PHOBOS_LATEST_DIR) $(DMD_LATEST_DIR) $(MOD_EXCLUDES_LATEST) \
-		$(addprefix --dump , object std etc core) --dump dmd >$@
+		$(addprefix --dump , object std etc core dmd rt) >$@
 
 ${GENERATED}/modlist-release.ddoc : tools/modlist.d ${STABLE_DMD} $(DRUNTIME_DIR) $(PHOBOS_DIR) $(DMD_DIR)
 	mkdir -p $(dir $@)
 	$(STABLE_RDMD) $< $(DRUNTIME_DIR) $(PHOBOS_DIR) $(DMD_DIR) $(MOD_EXCLUDES_RELEASE) \
-		$(addprefix --dump , object std etc core) --dump dmd >$@
+		$(addprefix --dump , object std etc core dmd rt) >$@
 
 ${GENERATED}/modlist-prerelease.ddoc : tools/modlist.d ${STABLE_DMD} $(DRUNTIME_DIR) $(PHOBOS_DIR) $(DMD_DIR)
 	mkdir -p $(dir $@)

--- a/tools/modlist.d
+++ b/tools/modlist.d
@@ -36,7 +36,7 @@ struct Tree
     void dumpRoot()
     {
         writeln();
-        writefln("$(MENU_W_SUBMENU $(TT %s))", name);
+        writefln("$(MENU_W_SUBMENU %s)", name);
         writefln("$(ITEMIZE");
         dumpChildren([name]);
         writeln(")");


### PR DESCRIPTION
The DRuntime docs have been exposed for quite a while after https://github.com/dlang/dlang.org/pull/2084.

However, as there has been almost no activity in improving them, I think the only way to move forward is to expose them on the main pages too.
At the moment, `rt` is only visible on the `-prerelease` menu.
Example: https://dlang.org/phobos-prerelease/rt_config.html

We did the same with the DMD docs as they also received no attention while they were only available in the `-prerelease` for a year.