### PR TITLE
Add a pointer to dstep

### DIFF
--- a/htod.dd
+++ b/htod.dd
@@ -2,9 +2,8 @@ Ddoc
 
 $(D_S htod,
 
-$(MESSAGE_BOX orange, $(B Warning) - $(D htod) is no longer considered a core tool and maintained
-    by the same people. More modern tools like $(LINK2 https://github.com/jacob-carlborg/dstep, dstep)
-    might work better for your use case.)
+$(MESSAGE_BOX orange, $(B Warning) - `htod` is not developed actively. Alternatives include 
+    $(HTTPS github.com/jacob-carlborg/dstep, dstep).)
 
 $(P     While D is binary compatible with C code, it cannot
         compile C code nor C header files. In order for

--- a/htod.dd
+++ b/htod.dd
@@ -2,6 +2,10 @@ Ddoc
 
 $(D_S htod,
 
+$(MESSAGE_BOX orange, $(B Warning) - $(D htod) is no longer considered a core tool and maintained
+    by the same people. More modern tools like $(LINK2 https://github.com/jacob-carlborg/dstep, dstep)
+    might work better for your use case.)
+
 $(P     While D is binary compatible with C code, it cannot
         compile C code nor C header files. In order for
         D to link with C code, the C declarations residing

--- a/htod.dd
+++ b/htod.dd
@@ -2,8 +2,10 @@ Ddoc
 
 $(D_S htod,
 
-$(MESSAGE_BOX orange, $(B Warning) - `htod` is not developed actively. Alternatives include 
-    $(HTTPS github.com/jacob-carlborg/dstep, dstep).)
+$(MESSAGE_BOX orange, $(B Warning) - `htod` is not developed actively.
+    Please see $(LINK2 https://wiki.dlang.org/Bindings#Binding_generators,
+    Binding generators on the D Wiki) for a list of alternatives.)
+
 
 $(P     While D is binary compatible with C code, it cannot
         compile C code nor C header files. In order for


### PR DESCRIPTION
Imho htod shouldn't be documented on dlang.org, because

- it's not part of the release archives
- it's closed source
- it's Windows-only
- there are more modern tools like dstep

As removing the documentation might be a bit drastic, I went with adding a warning.