### PR TITLE
Remove -fsS from the recommended flags to use for the install.sh script

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -88,7 +88,7 @@ $(DIVC download_channels,
          $(SBTN $(ARCH freebsd-32, tar.xz), i386) $(SBTN $(ARCH freebsd-64, tar.xz), x86_64)
     )
 
-    $(INSTALL_SCRIPT curl -fsS https://dlang.org/install.sh | bash -s dmd)
+    $(INSTALL_SCRIPT curl https://dlang.org/install.sh | bash -s dmd)
   )
 
   $(BETA
@@ -122,7 +122,7 @@ $(DIVC download_channels,
         $(SBTN $(B_ARCH freebsd-32, tar.xz), i386) $(SBTN $(B_ARCH freebsd-64, tar.xz), x86_64)
     )
 
-    $(INSTALL_SCRIPT curl -fsS https://dlang.org/install.sh | bash -s dmd-beta)
+    $(INSTALL_SCRIPT curl https://dlang.org/install.sh | bash -s dmd-beta)
     )
   )
 
@@ -155,7 +155,7 @@ $(DIVC download_channels,
         $(SBTN $(N_ARCH freebsd-32, tar.xz), i386) $(SBTN $(N_ARCH freebsd-64, tar.xz), x86_64)
     )
 
-    $(INSTALL_SCRIPT curl -fsS https://dlang.org/install.sh | bash -s dmd-nightly)
+    $(INSTALL_SCRIPT curl https://dlang.org/install.sh | bash -s dmd-nightly)
   )
 )
 

--- a/install.dd
+++ b/install.dd
@@ -54,6 +54,7 @@ $(UL
         $(LI $(RELATIVE_LINK2 list, Listing available compilers))
         $(LI $(RELATIVE_LINK2 update, Update))
     )
+    $(LI $(RELATIVE_LINK2 ci, Continuous integration))
 )
 
 $(H2 $(LNAME2 get, Downloading the installer))
@@ -202,6 +203,39 @@ Update the installer itself.
 $(CONSOLE
 ~/dlang/install.sh update
 )
+
+
+$(H3 $(LNAME2 ci, Continuous integration))
+
+If you use this script in your favorite CI runner, we recommend the following curl flags:
+
+$(CONSOLE
+curl --silent --fail --show-error --retry 5 --retry-max-time 60 https://dlang.org/install.sh | bash -s
+)
+
+If you are still experiencing issues with spurious download failures, you might want to use more mirrors:
+
+---
+download_install_sh() {
+  local mirrors location
+  location="${1:-install.sh}"
+  mirrors=(
+    "https://dlang.org/install.sh"
+    "https://downloads.dlang.org/other/install.sh"
+    "https://nightlies.dlang.org/install.sh"
+  )
+  if [ -f "$location" ] ; then
+      return
+  fi
+  for mirror in "${mirrors[@]}" ; do
+    if curl -fsS --retry 5 --retry-max-time 60 --connect-timeout 5 --speed-time 30 --speed-limit 1024 "$mirror" -o "$location" ; then
+        break 2
+    fi
+  done
+}
+download_install_sh
+bash install.sh dmd
+---
 
 )
 Macros:


### PR DESCRIPTION
Motivation:

- these flags are only useful for scripts, not human usage
- I have seen actual human beings blindly typings these flags because we recommend them
- For server usage more flags would be needed anyways e.g. at least `--retry 3 --retry-delay 5`
- These flags aren't well-known and thus we somewhat require people to look them up

Imho we should only recommend flags that are useful in all cases.

As the usage of install.sh in CI scripts is more complicated, I added a dedicated section to its documentation.

So, what the heck does `-fsS` do?
-----------------------------

Exactly! One of the reasons why we shouldn't display it by default.
Anyhow, this saves you a trip to the man page:

```
-S, --show-error
	  When  used  with -s, --silent, it makes curl show an error mes‐
	  sage if it fails.

-s, --silent
	  Silent or quiet mode. Don't show progress meter or  error  mes‐
	  sages.   Makes Curl mute. It will still output the data you ask
	  for, potentially even to the terminal/stdout unless  you  redi‐
	  rect it.

	  Use  -S,  --show-error  in  addition  to this option to disable
	  progress meter but still show error messages.


-f, --fail
	  (HTTP) Fail silently (no output at all) on server errors.  This
	  is mostly done to better enable scripts etc to better deal with
	  failed attempts. In normal cases when an HTTP server  fails  to
	  deliver  a  document,  it  returns  an HTML document stating so
	  (which often also describes why and more). This flag will  pre‐
	  vent curl from outputting that and return error 22.

	  This method is not fail-safe and there are occasions where non-
	  successful response codes will slip  through,  especially  when
	  authentication is involved (response codes 401 and 407).
```