### PR TITLE
Fix Issue 2473, 10941 - Linux system install instructions incorrect

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -85,28 +85,16 @@ C:\&gt;unzip dmc.zip
 
     $(INSTALLATION_SCRIPT_HINT)
 
-    $(LI Unzip the archive into your home directory.
     It will create
     a $(D ~/dmd) directory with all the files in it.
+
     All the tools are command line tools, which means
     they are run from a console window.)
-
-    $(LI Copy $(D $(DMD_CONF)) to $(D /etc):
-
+    $(LI All tools can be run directly from the archive:
 $(CONSOLE
-cp $(DMDDIR)/linux/bin/$(DMD_CONF) /etc
+~/dmd/linux/bin64/dmd
 )
-    )
-
-    $(LI Put $(D $(DMDDIR)/linux/bin) on your $(B PATH),
-    or copy the linux executables
-    to $(D /usr/local/bin))
-
-    $(LI Copy the library to $(D /usr/lib):
-
-$(CONSOLE
-cp $(DMDDIR)/linux/lib/$(LIB) /usr/lib
-)
+    To install $(D dmd) globally, add this bin folder to your $(B PATH).
     )
     )
     $(FREEBSD


### PR DESCRIPTION
The dmd.html page needs serious work and apparentely it always has been like this since 2008!
I wasn't sure on the best way to fix this because the shipped `dmd.conf` looks like this:

```
[Environment32]
DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic

[Environment64]
DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic -fPIC
```

In other words, the shipped `dmd.conf` can't be simply copied to `/etc/`. This means we have the following solutions

a) just tell the user to add it to his `PATH`
b) advertise to use e.g. a symlink to `/usr/bin/dmd`
c) provide an alternative `dmd.conf` for copy/pasting to `/etc/dmd.conf`
d) provide a command to patch the shipped `dmd.conf`
e) suggest to move the entire folder to `/usr/local` and symlink `dmd` then
...


(the FreeBSD + MacOS sections of this need similar adjustments, but I left them for now until I know how to proceed here)

See also: https://github.com/dlang/dlang.org/pull/2290