### PR TITLE
Start to opt-out of Ddoc's automatic keyword highlighting

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -552,3 +552,10 @@ PROJECT_SOURCE_DIR=
 
 FA_ICON=<i class="fa fa-$1" aria-hidden="true"></i>
 _=
+
+_ = Opt-out of automatic keyword highlighting - see https://dlang.org/changelog/2.079.0.html#fix18361
+DDOC_AUTO_PSYMBOL =
+DDOC_AUTO_KEYWORD =
+DDOC_AUTO_PARAM =
+_ = DDOC_AUTO_PSYMBOL_SUPPRESS = FIXME_UNDERSCORE_PREFIX
+DDOC_AUTO_PSYMBOL_SUPPRESS = $1


### PR DESCRIPTION
Let's whether DAutoTest likes this. In theory
- no changes should show up in the diff
- existing suppression of the auto-highlighting can be gradually removed (e.g. with the SUPPRESS helper or `grep`)
- ddoc should no longer do automatic highlighting (not sure whether we can verify this here, but @JackStouffer just run into this issue again - https://github.com/dlang/phobos/pull/6356)

See also:

- https://dlang.org/changelog/2.079.0.html#fix18361
- https://github.com/dlang/dmd/pull/7834

CC @quickfur 