### PR TITLE
Fix Issue 14099 - Promote run.dlang.io to Resources

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -283,6 +283,7 @@ $(SUBMENU_MANUAL
     $(SUBMENU_LINK_DIVIDER https://wiki.dlang.org/Development_tools, Tools)
     $(SUBMENU_LINK https://wiki.dlang.org/Editors, Editors)
     $(SUBMENU_LINK https://wiki.dlang.org/IDEs, IDEs)
+    $(SUBMENU_LINK https://run.dlang.io, run.dlang.io)
     $(SUBMENU_LINK $(VISUALD), Visual D)
     $(SUBMENU_LINK_DIVIDER $(ROOT_DIR)acknowledgements.html, Acknowledgments)
     $(SUBMENU_LINK $(ROOT_DIR)dstyle.html, D Style)


### PR DESCRIPTION
From the issue:

> This is a proposal to make it officially a part of dlang.org: promote the website to run.dlang.org, and add a link to it on the D website (e.g. under the "Resources" submenu). 