### PR TITLE
Don't deploy _hq images of the orgs-using-d

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -282,7 +282,10 @@ CSS_MINIFY=
 
 IMAGES=favicon.ico images/d002.ico $(filter-out $(wildcard images/*_hq.*) images/dlogo_2015.svg, \
 			$(wildcard images/*.jpg images/*.png images/*.svg images/*.gif)) \
-		$(wildcard images/ddox/* images/orgs-using-d/*)
+		$(wildcard images/ddox/*) \
+		$(filter-out $(wildcard images/orgs-using-d/*_hq.*), $(wildcard images/orgs-using-d/*))
+$(info $(IMAGES))
+
 JAVASCRIPT=$(addsuffix .js, $(addprefix js/, \
 	codemirror-compressed dlang ddox listanchors platform-downloads run \
 	run_examples show_contributors jquery-1.7.2.min))


### PR DESCRIPTION
Follow-up to https://github.com/dlang/dlang.org/pull/2310

>> BTW, does that mean that we're deploying unused organization HQ logos?
> Yes good catch.
> They were intended to be used for the orgs page (e.g. Retina displays), but this never got to my priority list. I will remove them in a quick follow-up.
