### PR TITLE
[discuss] Use full width for the documentation pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -83,6 +83,12 @@ body > .container
     position: relative;
 }
 
+/*full width for the documentation pages*/
+body.std > .container
+{
+    max-width: 100%;
+}
+
 body.doc input,
 body.doc textarea,
 body.std input,


### PR DESCRIPTION
So I don't expect that everyone likes this idea, but I just accidentally saw this and imho it looks more structured. This is entirely subjective, so just "up" or "down" vote to show your personal opinion.

Having the menu aligned to the right isn't too uncommon:

- readthedocs (e.g. http://docs.readthedocs.io/en/latest/getting_started.html)
- Python (e.g. https://docs.python.org/3/library/shutil.html)
- scod (http://martinnowak.github.io/bloom/bloom.html)
- Git Book (https://doc.rust-lang.org/book/second-edition/)
- devdocs.io (http://devdocs.io/d/
...

This is just a quick CSS trick to roughly show how it would look. If there's interest, it would probably be done, s.t. there's no padding between the navigation menu and the browsers' right side and s.t. there's a fixed width (e.g. like currently) for the main content.

Current 76em width:

![image](https://user-images.githubusercontent.com/4370550/38159404-3314ecdc-34a8-11e8-8db1-cea2005812b0.png)

Full-width:

![image](https://user-images.githubusercontent.com/4370550/38159393-14f78d2c-34a8-11e8-9535-b1caf3966926.png)