### PR TITLE
Remove compatibility --html-style=pretty flag

### DIFF
--- a/dpl-docs/source/app.d
+++ b/dpl-docs/source/app.d
@@ -16,7 +16,5 @@ int main(string[] args)
 	environment["GIT_TARGET"] = git_target;
 	environment["NO_EXACT_SOURCE_CODE_LINKS"] = noExactSourceCodeLinks ? "1" : "0";
 	setLogFormat(FileLogger.Format.plain);
-	if (args.length > 1 && args[1] != "filter")
-	    args ~= "--html-style=pretty";
 	return ddoxMain(args);
 }


### PR DESCRIPTION
(Introduced in #1891 to facilite the transition to Ddox 0.16)

This was already done in https://github.com/dlang/dlang.org/pull/2054, but I have no idea why it's not showing up in the history:

https://github.com/dlang/dlang.org/commits/master/dpl-docs/source/app.d