### PR TITLE
[trivial] apidocs: fix serve command

### DIFF
--- a/dpl-docs/source/ddox_main.d
+++ b/dpl-docs/source/ddox_main.d
@@ -50,7 +50,7 @@ int ddoxMain(string[] args)
 static import ddox.main;
 
 alias cmdGenerateHtml = ddox.main.cmdGenerateHtml;
-alias cmdServeHtml = ddox.main.cmdServeTest;
+alias cmdServeHtml = ddox.main.cmdServeHtml;
 alias cmdServeTest = ddox.main.cmdServeTest;
 alias parseDocFile = ddox.main.parseDocFile;
 alias setupGeneratorInput = ddox.main.setupGeneratorInput;


### PR DESCRIPTION
This got accidentally broken in https://github.com/dlang/dlang.org/commit/474fb077d1f32e5c6c3ca0ad716234a279e01e42