### PR TITLE
Use full page for search results

### DIFF
--- a/css/ddox.css
+++ b/css/ddox.css
@@ -53,25 +53,36 @@ a.inherited:after { content: url(../images/ddox/inherited.png); padding-left: 3p
 
 #symbolSearch { width: 112pt; }
 
+#symbolSearchResultsContainer {
+	width: 80%;
+	margin: 0 auto;
+	padding: 0.3em;
+	display: none;
+}
+
 #symbolSearchResults {
-	background: #F5F5F5;
-	border: 1px solid #CCC;
 	font-size: small;
 	list-style: none;
-	margin: 0;
 	margin-top: 5px;
-	padding: 0.3em;
-	position: absolute;
-	right: -1px;
-	top: 100%;
-	width: 100%;
-	z-index: 1000;
+	-moz-column-gap: 20px;
+	-webkit-column-gap: 20px;
+	column-gap: 20px;
+	-moz-column-width: 17.5em;
+	-webkit-column-width: 17.5em;
+	column-width: 17.5em;
+	list-style-type: none;
+	font-size: 1.2em;
+}
+
+#symbolSearchCloseButton {
+	float: right;
+	font-size: 1.5em;
 }
 
 #symbolSearchResults li {
 	background-repeat: no-repeat;
 	background-position: left center;
-	padding-left: 18px;
+	padding: 15px;
 }
 
 #top #symbolSearchResults li a {

--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -148,8 +148,9 @@ html(lang='en-US')
                   button(type='submit')
                     i.fa.fa-search
                     span go
-              include ddox.inc.symbol-search.results
 
+    #symbolSearchResultsContainer
+      include ddox.inc.symbol-search.results
     .container
       .subnav-helper
       .subnav

--- a/js/ddox.js
+++ b/js/ddox.js
@@ -1,3 +1,13 @@
+function getParameterByName(name, url) {
+		if (!url) url = window.location.href;
+		name = name.replace(/[\[\]]/g, "\\$&");
+		var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+				results = regex.exec(url);
+		if (!results) return '';
+		if (!results[2]) return '';
+		return decodeURIComponent(results[2].replace(/\+/g, " "));
+}
+
 function setupDdox()
 {
 	$(".tree-view").children(".package").click(toggleTree);
@@ -6,6 +16,12 @@ function setupDdox()
 
 	updateSearchBox();
 	$('#sitesearch').change(updateSearchBox);
+
+	var searchParam = getParameterByName("q");
+	if (searchParam.length > 0) {
+		$("#symbolSearch").val(searchParam)
+		performSymbolSearch(40);
+	}
 }
 
 function updateSearchBox()
@@ -30,17 +46,24 @@ function toggleTree()
 var searchCounter = 0;
 var lastSearchString = "";
 
+var closeButton = undefined;
+
 function performSymbolSearch(maxlen)
 {
 	if (maxlen === 'undefined') maxlen = 26;
 
 	var searchstring = $("#symbolSearch").val().toLowerCase();
 
+	if (searchstring.length === 0) {
+		$('.container').show();
+		return;
+	}
+
 	if (searchstring == lastSearchString) return;
 	lastSearchString = searchstring;
 
 	var scnt = ++searchCounter;
-	$('#symbolSearchResults').hide();
+	$('#symbolSearchResultsContainer').hide();
 	$('#symbolSearchResults').empty();
 
 	var terms = $.trim(searchstring).split(/\s+/);
@@ -97,6 +120,16 @@ function performSymbolSearch(maxlen)
 
 	results.sort(compare);
 
+	if (closeButton === undefined) {
+		console.log("foo");
+		closeButton = $("<div id='symbolSearchCloseButton'><i class='fa fa-times big-icon'></i></div>");
+		closeButton.on("click", function() {
+			$('#symbolSearchResultsContainer').hide();
+			$('.container').show();
+		});
+		$('#symbolSearchResultsContainer').prepend(closeButton);
+	}
+
 	for (i = 0; i < results.length && i < 100; i++) {
 			var sym = results[i];
 
@@ -127,14 +160,16 @@ function performSymbolSearch(maxlen)
 	}
 
 	$('#symbolSearchResults').show();
+	$('#symbolSearchResultsContainer').show();
+	$('.container').hide();
 }
 
 $(function(){
-  $("#search-box form").on("submit", function(e) {
-    var searchResults = $('#symbolSearchResults').children();
-    if (searchResults.length > 0) {
-      window.location = searchResults.first().find("a").attr("href");
-      e.preventDefault();
-    }
-  });
+	$("#search-box form").on("submit", function(e) {
+		var searchResults = $('#symbolSearchResults').children();
+		if (searchResults.length > 0) {
+			window.location = searchResults.first().find("a").attr("href");
+			e.preventDefault();
+		}
+	});
 });


### PR DESCRIPTION
A start and experiment with using the full site for showing the search results.

Preview:

![image](https://user-images.githubusercontent.com/4370550/38160019-10b4d45a-34b6-11e8-8794-521cfe4680d0.png)

This is the initial "proof of concept". When I find more time, I will try to tweak it and make it more "visually appealling". Ideas or examples of other good searches are of course always welcome.


See also:
- https://github.com/dlang/dlang.org/pull/2314 (for using the same search with Ddoc)
- http://www.scala-lang.org/api/current/scala/collection/immutable/Vector.html?search=fun (for a nice search)

BTW in case someone wants to test this locally, the most pleasant way is with:

```
make -f posix.mak apidocs-serve
```

(as then the JS/CSS is always "up-to-date" / needs to manual copy-overs)