### PR TITLE
Fix-up opt-ing out of Ddoc

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -554,8 +554,8 @@ FA_ICON=<i class="fa fa-$1" aria-hidden="true"></i>
 _=
 
 _ = Opt-out of automatic keyword highlighting - see https://dlang.org/changelog/2.079.0.html#fix18361
-DDOC_AUTO_PSYMBOL =
-DDOC_AUTO_KEYWORD =
-DDOC_AUTO_PARAM =
+DDOC_AUTO_PSYMBOL = $0
+DDOC_AUTO_KEYWORD = $0
+DDOC_AUTO_PARAM = $0
 _ = DDOC_AUTO_PSYMBOL_SUPPRESS = FIXME_UNDERSCORE_PREFIX
-DDOC_AUTO_PSYMBOL_SUPPRESS = $1
+DDOC_AUTO_PSYMBOL_SUPPRESS = $0


### PR DESCRIPTION
So it looks like this should have been the correct definition for the opt-out (not what the changelog said).
See also:

- https://github.com/dlang/dmd/blob/master/res/default_ddoc_theme.ddoc#L739
- https://github.com/dlang/dlang.org/pull/2307