### PR TITLE
[WIP] Ddoc: in-site (Ddox-like) search (chmgen version)

### DIFF
--- a/css/ddox.css
+++ b/css/ddox.css
@@ -53,52 +53,6 @@ a.inherited:after { content: url(../images/ddox/inherited.png); padding-left: 3p
 
 #symbolSearch { width: 112pt; }
 
-#symbolSearchResults {
-	background: #F5F5F5;
-	border: 1px solid #CCC;
-	font-size: small;
-	list-style: none;
-	margin: 0;
-	margin-top: 5px;
-	padding: 0.3em;
-	position: absolute;
-	right: -1px;
-	top: 100%;
-	width: 100%;
-	z-index: 1000;
-}
-
-#symbolSearchResults li {
-	background-repeat: no-repeat;
-	background-position: left center;
-	padding-left: 18px;
-}
-
-#top #symbolSearchResults li a {
-	color: #B03931;
-	height: auto;
-	padding: 0;
-}
-#symbolSearchResults li a:hover
-{
-	background: transparent;
-	color: #742620;
-	text-decoration: underline;
-}
-
-#symbolSearchResults .deprecated a { color: gray; }
-#symbolSearchResults .module { background-image: url(../images/ddox/module.png); }
-#symbolSearchResults .functiondeclaration { background-image: url(../images/ddox/function.png); }
-#symbolSearchResults .classdeclaration { background-image: url(../images/ddox/class.png); }
-#symbolSearchResults .interfacedeclaration { background-image: url(../images/ddox/interface.png); }
-#symbolSearchResults .structdeclaration { background-image: url(../images/ddox/struct.png); }
-#symbolSearchResults .variabledeclaration { background-image: url(../images/ddox/variable.png); }
-#symbolSearchResults .property { background-image: url(../images/ddox/property.png); }
-#symbolSearchResults .enumdeclaration { background-image: url(../images/ddox/enum.png); }
-#symbolSearchResults .enummemberdeclaration { background-image: url(../images/ddox/enummember.png); }
-#symbolSearchResults .aliasdeclaration { background-image: url(../images/ddox/alias.png); }
-#symbolSearchResults .templatedeclaration { background-image: url(../images/ddox/template.png); }
-
 /* Don't show simple handcrafted cheat sheets. DDOX does a good job generating
  * them. */
 table.simple-cheatsheet { display: none; }

--- a/css/style.css
+++ b/css/style.css
@@ -2134,3 +2134,53 @@ Custom modifications to the navigation menu
     margin-bottom: 1em;
     padding-top: 0.5em;
 }
+
+
+
+#symbolSearchResults {
+	background: #F5F5F5;
+	border: 1px solid #CCC;
+	font-size: small;
+	list-style: none;
+	margin: 0;
+	margin-top: 5px;
+	padding: 0.3em;
+	position: absolute;
+	right: -1px;
+	top: 100%;
+	width: 100%;
+	z-index: 1000;
+}
+
+#symbolSearchResults li {
+	background-repeat: no-repeat;
+	background-position: left center;
+	padding-left: 18px;
+}
+
+#top #symbolSearchResults li a {
+	color: #B03931;
+	height: auto;
+	padding: 0;
+}
+#symbolSearchResults li a:hover
+{
+	background: transparent;
+	color: #742620;
+	text-decoration: underline;
+}
+
+#symbolSearchResults .deprecated a { color: gray; }
+#symbolSearchResults .module { background-image: url(../images/ddox/module.png); }
+#symbolSearchResults .functiondeclaration { background-image: url(../images/ddox/function.png); }
+#symbolSearchResults .classdeclaration { background-image: url(../images/ddox/class.png); }
+#symbolSearchResults .interfacedeclaration { background-image: url(../images/ddox/interface.png); }
+#symbolSearchResults .structdeclaration { background-image: url(../images/ddox/struct.png); }
+#symbolSearchResults .variabledeclaration { background-image: url(../images/ddox/variable.png); }
+#symbolSearchResults .property { background-image: url(../images/ddox/property.png); }
+#symbolSearchResults .enumdeclaration { background-image: url(../images/ddox/enum.png); }
+#symbolSearchResults .enummemberdeclaration { background-image: url(../images/ddox/enummember.png); }
+#symbolSearchResults .aliasdeclaration { background-image: url(../images/ddox/alias.png); }
+#symbolSearchResults .templatedeclaration { background-image: url(../images/ddox/template.png); }
+
+

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -37,7 +37,9 @@ COMMON_SCRIPTS =
 _=
 COMMON_SCRIPTS_DLANG =
     $(SCRIPTLOAD $(STATIC js/codemirror-compressed.js))
+    $(SCRIPTLOAD $(STATIC library/symbols.js))
     $(SCRIPTLOAD $(STATIC js/run.js))
+    $(SCRIPTLOAD $(STATIC js/ddox.js))
 _=
 
 COMPATIBILITY_BOX_DEPRECATED = $(MESSAGE_BOX red, $(B Deprecated) - $0)
@@ -411,6 +413,7 @@ SEARCH_BOX=
                 </select>
             ))$(SPANID search-submit, <button type="submit"><i class="fa fa-search"></i><span>go</span></button>)
         </form>
+        <ul id="symbolSearchResults" class="symbolList" style="display: none"></ul>
     )
 SEARCH_OPTIONS_EXTRA=
 _=

--- a/js/ddox.js
+++ b/js/ddox.js
@@ -34,7 +34,10 @@ function performSymbolSearch(maxlen)
 {
 	if (maxlen === 'undefined') maxlen = 26;
 
-	var searchstring = $("#symbolSearch").val().toLowerCase();
+	var el = $("#symbolSearch");
+	if (el.length  === 0) el = $("#q");
+
+	var searchstring = el.val().toLowerCase();
 
 	if (searchstring == lastSearchString) return;
 	lastSearchString = searchstring;
@@ -118,7 +121,17 @@ function performSymbolSearch(maxlen)
 			if (np > 0) shortname = ".." + shortname;
 			else shortname = shortname.substr(1);
 
-			el.append('<a href="'+symbolSearchRootDir+sym.path+'" title="'+name+'" tabindex="1001">'+shortname+'</a>');
+      if (typeof(symbolSearchRootDir) === "undefined") {
+        // translate ddox path into ddoc path
+        var hashName = sym.name.replace(/(.*)[.](.*)$/g, "$2")
+        var path = sym.path.slice(0, -5);
+        path = path.replace(/(.*)\/(.*)$/g, "$1.html");
+        path = path.replace(/\//g, "_").replace("._", "");
+        path = path + "#" + hashName;
+			  el.append('<a href="'+path+'" title="'+name+'" tabindex="1001">'+shortname+'</a>');
+      } else {
+			  el.append('<a href="'+symbolSearchRootDir+sym.path+'" title="'+name+'" tabindex="1001">'+shortname+'</a>');
+			}
 			$('#symbolSearchResults').append(el);
 		}
 

--- a/js/dlang.js
+++ b/js/dlang.js
@@ -74,5 +74,83 @@
                 elem.show();
             }
         });
+
+      var search = $("#q")
+      search.attr("placeholder", "API Search");
+      search.attr("autocomplete", "off");
+      var onChange = function(){
+        performChmgenSearch(80);
+      };
+      search.on("change", onChange);
+      search.on("keypress", onChange);
+      search.on("input", onChange);
+    });
+    jQuery.get("../js/d-tags-prerelease.json", function(d){
+      chmgenSymbols = d;
     });
 })(jQuery);
+
+var chmgenSymbols = undefined;
+
+function performChmgenSearch(maxlen)
+{
+  // not loaded yet
+  if (!chmgenSymbols) return;
+	if (maxlen === 'undefined') maxlen = 26;
+
+	var el = $("#symbolSearch");
+	if (el.length  === 0) el = $("#q");
+
+	var searchstring = el.val().toLowerCase();
+
+	if (searchstring == lastSearchString) return;
+	lastSearchString = searchstring;
+
+	var scnt = ++searchCounter;
+	$('#symbolSearchResults').hide();
+	$('#symbolSearchResults').empty();
+
+	var terms = $.trim(searchstring).split(/\s+/);
+	if (terms.length == 0 || (terms.length == 1 && terms[0].length < 2)) return;
+
+	var results = [];
+	for (var key in chmgenSymbols) {
+		var sym = chmgenSymbols[key];
+		var all_match = true;
+		for (var j in terms)
+			if (key.toLowerCase().indexOf(terms[j]) < 0) {
+				all_match = false;
+				break;
+			}
+		if (!all_match) continue;
+
+    sym.forEach(function(e){
+      results.push({
+        name: key,
+        href: e,
+      });
+		});
+	}
+
+  console.log(results);
+
+	for (i = 0; i < results.length && i < 100; i++) {
+			var sym = results[i];
+
+			var el = $(document.createElement("li"));
+			//el.addClass(sym.kind);
+			//for (j in sym.attributes)
+				//el.addClass(sym.attributes[j]);
+
+			var name = sym.name;
+			var shortname = sym.name;
+			el.append('<a href="'+sym.href+'" title="'+name+'" tabindex="1001">'+shortname+'</a>');
+			$('#symbolSearchResults').append(el);
+		}
+
+	if (results.length > 100) {
+		$('#symbolSearchResults').append("<li>&hellip;"+(results.length-100)+" additional results</li>");
+	}
+
+	$('#symbolSearchResults').show();
+}

--- a/posix.mak
+++ b/posix.mak
@@ -661,15 +661,17 @@ $W/phobos-prerelease/object.verbatim : $(DMD) $G/changelog/next-version
 
 .PHONY: phobos-prerelease
 phobos-prerelease : druntime-target $(STD_DDOC_PRERELEASE) $(DDOC_BIN) $(DMD) \
-					$G/changelog/next-version
+					$G/changelog/next-version $W/js/d-tags-release.json
 	$(MAKE) --directory=$(PHOBOS_DIR) -f posix.mak html $(DDOC_VARS_PRERELEASE_HTML) \
 		DMD="$(abspath $(DDOC_BIN)) --compiler=$(abspath $(DMD))"
 
-phobos-release : druntime-target $(STD_DDOC_RELEASE) $(DDOC_BIN) $(DMD)
+phobos-release : druntime-target $(STD_DDOC_RELEASE) $(DDOC_BIN) $(DMD) \
+				$W/js/d-tags-release.json
 	$(MAKE) --directory=$(PHOBOS_DIR) -f posix.mak html $(DDOC_VARS_RELEASE_HTML) \
 		DMD="$(abspath $(DDOC_BIN)) --compiler=$(abspath $(DMD))"
 
-phobos-latest : druntime-latest-target $(STD_DDOC_LATEST) $(DDOC_BIN) $(DMD_LATEST)
+phobos-latest : druntime-latest-target $(STD_DDOC_LATEST) $(DDOC_BIN) $(DMD_LATEST) \
+				$W/js/d-tags-release.json
 	$(MAKE) --directory=$(PHOBOS_LATEST_DIR) -f posix.mak html $(DDOC_VARS_LATEST_HTML) \
 		DMD="$(abspath $(DDOC_BIN)) --compiler=$(abspath $(DMD_LATEST))"
 
@@ -820,6 +822,13 @@ d-release.tag d-tags-release.json : tools/chmgen.d $(STABLE_DMD) $(ALL_FILES) ph
 
 d-prerelease.tag d-tags-prerelease.json : tools/chmgen.d $(STABLE_DMD) $(ALL_FILES) phobos-prerelease druntime-prerelease chm-nav-prerelease.json
 	$(STABLE_RDMD) $< --root=$W --target prerelease
+
+$W/js/d-tags-prerelease.json: d-tags-prerelease.json
+ifeq (1,$(RELEASE))
+$W/js/d-tags-release.json: d-tags-release.json
+else
+$W/js/d-tags-latest.json: d-tags-latest.json
+endif
 
 ################################################################################
 # Style tests


### PR DESCRIPTION
This is an initial experiment with using the symbols from chmgen for an in-site search.

Cons:
- JSON file is rather large (1.7M, 171K gzipped) - though the JSON file can be loaded lazily, s.t. this shouldn't have an impact
- no information about the symbol (class vs. struct, enum?, member?, field?)

See also: https://github.com/dlang/dlang.org/pull/2314

Todo:
- [ ] filter for duplicates?
- [ ] sort the results in a meaningful way
- [ ] generate a shortname for long names
- [ ] expand the name, e.g. `std_regex#.splitter` should be displayed as such not a just `splitter`

Example:

Chmgen:

![image](https://user-images.githubusercontent.com/4370550/38221338-47a842c8-36df-11e8-8efd-d992fb23f321.png)

Ddox's symbols:

![image](https://user-images.githubusercontent.com/4370550/38221364-635bb2e8-36df-11e8-9bef-92e8b5d7334c.png)