### PR TITLE
Fix DIP1003 url

### DIFF
--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -76,7 +76,7 @@ do
 }
 ------
 
-    $(P Since $(LINK2 https://github.com/dlang/DIPs/blob/master/DIPs/DIP1003.md, DIP1003 has been applied)
+    $(P Since $(LINK2 https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1003.md, DIP1003 has been applied)
     the actual function body starts with $(D do).
     In the past, $(D body) was used, and could still be encountered in old code bases.
     In the long term, $(D body) may be deprecated, but for now it's allowed


### PR DESCRIPTION
This fixes the url for DIP1003 which now lives under an accepted sub folder.