### PR TITLE
Bump Ddox to 0.16.10

### DIFF
--- a/dpl-docs/dub.selections.json
+++ b/dpl-docs/dub.selections.json
@@ -4,18 +4,19 @@
 		"botan": "1.12.9",
 		"botan-math": "1.0.3",
 		"ddoc_preprocessor": {"path":"../ddoc"},
-		"ddox": "0.16.7",
-		"diet-ng": "1.4.3",
+		"ddox": "0.16.10",
+		"diet-ng": "1.4.5",
 		"dmd": {"path":"../../dmd"},
-		"eventcore": "0.8.17",
+		"eventcore": "0.8.34",
 		"hyphenate": "1.1.1",
 		"libasync": "0.8.3",
-		"libdparse": "0.7.1",
+		"libdparse": "0.7.2-alpha.4",
 		"libevent": "2.0.2+2.0.16",
-		"memutils": "0.4.9",
-		"openssl": "1.1.5+1.0.1g",
-		"taggedalgebraic": "0.10.7",
-		"vibe-core": "1.2.0",
-		"vibe-d": "0.8.1"
+		"memutils": "0.4.10",
+		"openssl": "1.1.6+1.0.1g",
+		"stdx-allocator": "2.77.1",
+		"taggedalgebraic": "0.10.11",
+		"vibe-core": "1.4.0",
+		"vibe-d": "0.8.3"
 	}
 }


### PR DESCRIPTION
To incorporate e.g. https://github.com/rejectedsoftware/ddox/pull/203

(I just pushed the tag, so this might need a restart if DAutoStart builds this too soon)