### PR TITLE
Fix building dlang.org from scratch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ os:
  - linux
 
 script:
-  - make -f posix.mak test
+  - make -f posix.mak html
+  - make -f posix.mak clean && rm -rf ../{dmd,druntime,phobos,tools,installer,dub}
+  - make -f posix.mak all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,16 @@ website pages. You may see warnings while the compiler is built. After `make`
 ended with error code 0, directory `web` contains the produced HTML
 files. Take a moment to open `web/index.html` in a browser.
 
+### Building with a slow internet connection
+
+The dlang.org build process depends on files which are downloaded during
+the build process. If you happen to have a slow internet connection, you can skip
+these downloads with `DIFFABLE=1`:
+
+```
+make -f posix.mak html DIFFABLE=1
+```
+
 ## Building the standard library documentation
 
 Now that the main site is in place, the standard library documentation would be
@@ -99,3 +109,7 @@ The output is in `web/phobos` and `web/library`.
 ### Learning more about DDoc
 
 Please see the [Ddoc fundamentals](https://wiki.dlang.org/Contributing_to_dlang.org).
+
+### Learn about more Makefile targets and options
+
+The full list of available targets and options is documented in the header of `posix.mak`.

--- a/posix.mak
+++ b/posix.mak
@@ -154,6 +154,7 @@ DRUNTIME_DIR=../druntime
 TOOLS_DIR=../tools
 INSTALLER_DIR=../installer
 DUB_DIR=../dub
+GIT_HOME=https://github.com/dlang
 
 # Auto-cloning missing directories
 $(shell [ ! -d $(DMD_DIR) ] && git clone --depth=1 ${GIT_HOME}/dmd $(DMD_DIR))
@@ -166,7 +167,6 @@ PHOBOS_LIB=$(PHOBOS_DIR)/generated/$(OS)/release/$(MODEL)/dmd/libphobos2.a
 # External directories
 DOC_OUTPUT_DIR:=$(PWD)/web
 W:=$(DOC_OUTPUT_DIR)
-GIT_HOME=https://github.com/dlang
 DPL_DOCS_PATH=dpl-docs
 DPL_DOCS=$(DPL_DOCS_PATH)/dpl-docs
 REMOTE_DIR=d-programming@digitalmars.com:data
@@ -598,7 +598,8 @@ $(DMD) : ${DMD_DIR}
 
 $(DMD_LATEST) : ${DMD_LATEST_DIR}
 	${MAKE} --directory=${DMD_LATEST_DIR}/src -f posix.mak AUTO_BOOTSTRAP=1
-	sed -i -e "s|../druntime/import |../druntime-${LATEST}/import |" -e "s|../phobos |../phobos-${LATEST} |" $@.conf
+	sed -e "s|../druntime/import |../druntime-${LATEST}/import |" -e "s|../phobos |../phobos-${LATEST} |" $@.conf > $@.conf.tmp \
+		&& mv $@.conf.tmp $@.conf
 
 dmd-prerelease : $(STD_DDOC_PRERELEASE) druntime-target $G/changelog/next-version
 	$(MAKE) AUTO_BOOTSTRAP=1 --directory=$(DMD_DIR) -f posix.mak html $(DDOC_VARS_PRERELEASE_HTML)
@@ -877,13 +878,13 @@ $G/changelog/next-version: ${DMD_DIR}/VERSION
 	@echo $(NEXT_VERSION) > $@
 
 changelog/prerelease.dd: $G/changelog/next-version $(LOOSE_CHANGELOG_FILES) | \
-							${STABLE_DMD} $(TOOLS_DIR) $(INSTALLER_DIR) $(DUB_DIR)
+							${STABLE_DMD} $(DMD_DIR) $(DRUNTIME_DIR) $(PHOBOS_DIR) $(TOOLS_DIR) $(INSTALLER_DIR) $(DUB_DIR)
 	$(STABLE_RDMD) -version=Contributors_Lib $(TOOLS_DIR)/changed.d \
 		$(CHANGELOG_VERSION_STABLE) -o $@ --version "${NEXT_VERSION}" \
 		--prev-version="${LATEST}" --date "To be released"
 
 changelog/pending.dd: $G/changelog/next-version $(LOOSE_CHANGELOG_FILES) | \
-							${STABLE_DMD} $(TOOLS_DIR) $(INSTALLER_DIR) $(DUB_DIR)
+							${STABLE_DMD} $(DMD_DIR) $(DRUNTIME_DIR) $(PHOBOS_DIR) $(TOOLS_DIR) $(INSTALLER_DIR) $(DUB_DIR)
 	$(STABLE_RDMD) -version=Contributors_Lib $(TOOLS_DIR)/changed.d \
 		$(CHANGELOG_VERSION_MASTER) -o $@ --version "${NEXT_VERSION}" \
 		--prev-version="${LATEST}" --date "To be released"


### PR DESCRIPTION
See: https://forum.dlang.org/post/azdfcrfqegubikcyntfj@forum.dlang.org

The problem was that `GIT_HOME` was undefined and thus the git clone failed.
I think we should really have a CI for this. @CyberShadow what do you think about re-enabling Travis?

I also added a hint about `DIFFABLE=1` to the docs while I was at it.