### PR TITLE
Only compile the failing spec tester example

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -255,7 +255,7 @@ s[1..3] = s[0..2]; // error, overlapping copy
         $(REF copy, std,algorithm,mutation):
         )
 
-$(SPEC_RUNNABLE_EXAMPLE_RUN
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---------
 import std.algorithm;
 int[] s = [1, 2, 3, 4];

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -304,7 +304,7 @@ $(H2 $(LEGACY_LNAME2 StructLiteral, struct-literal, Struct Literals))
         $(P Struct literals consist of the name of the struct followed
         by a parenthesized argument list:)
 
-        $(SPEC_RUNNABLE_EXAMPLE_RUN
+        $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ---
         struct S { int x; float y; }
 


### PR DESCRIPTION
This currently fails on some PRs with:

```
Test the D Language specification
../dmd/generated/linux/release/64/dmd -run tools/dspec_tester.d --compiler=../dmd/generated/linux/release/64/dmd
---
void main() {
import std.stdio;
import std.algorithm;
int[] s = [1, 2, 3, 4];

copy(s[1..3], s[0..2]);
assert(s == [2, 3, 3, 4]);

}
---
gcc: error: __stdin.o: No such file or directory
Error: linker exited with status 1
```

(e.g. https://github.com/dlang/phobos/pull/6443, https://github.com/dlang/phobos/pull/6453 or https://github.com/dlang/dmd/pull/8168)

Hence, I think for now the best strategy is to just compile the respective test.