### PR TITLE
Fix Issue 16206 - traits getOverloads fails when one of the overload is a templatized function

### DIFF
--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -658,8 +658,10 @@ $(H2 $(GNAME getOverloads))
 
         $(P The first argument is an aggregate (e.g. struct/class/module).
         The second argument is a string that matches the name of
-        one of the functions in that aggregate.
+        one of the members in that aggregate.
+        The third argument is a bool, and is optional.
         The result is a tuple of all the overloads of that function.
+        If the third member evaluates to true, the result will include all members that matches the supplied name.
         )
 
 ---
@@ -671,6 +673,8 @@ class D
     ~this() { }
     void foo() { }
     int foo(int) { return 2; }
+    void bar(T)() { return T.init; }
+    class bar(int n) {}
 }
 
 void main()
@@ -686,6 +690,9 @@ void main()
 
     auto i = __traits(getOverloads, d, "foo")[1](1);
     writeln(i);
+
+    foreach (t; __traits(getOverloads, D, "bar", true))
+        writeln(t.stringof);
 }
 ---
 
@@ -697,6 +704,8 @@ int()
 void()
 int()
 2
+bar(T)()
+bar(int n)
 )
 
 $(H2 $(GNAME getParameterStorageClasses))

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -660,7 +660,7 @@ $(H2 $(GNAME getOverloads))
         The second argument is a `string` that matches the name of
         the member(s) to return.
         The third argument is a `bool`, and is optional.  If `true`, the
-        result will include template overloads.
+        result will also include template overloads.
         The result is a tuple of all the overloads of the supplied name.
         )
 

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -657,11 +657,11 @@ void main()
 $(H2 $(GNAME getOverloads))
 
         $(P The first argument is an aggregate (e.g. struct/class/module).
-        The second argument is a string that matches the name of
-        one of the members in that aggregate.
-        The third argument is a bool, and is optional.
-        The result is a tuple of all the overloads of that function.
-        If the third member evaluates to true, the result will include all members that matches the supplied name.
+        The second argument is a `string` that matches the name of
+        the member(s) to return.
+        The third argument is a `bool`, and is optional.  If `true`, the
+        result will include template overloads.
+        The result is a tuple of all the overloads of the supplied name.
         )
 
 ---


### PR DESCRIPTION
Spec change for https://github.com/dlang/dmd/pull/8195