### PR TITLE
Bump archive version to 2.080

### DIFF
--- a/js/listanchors.js
+++ b/js/listanchors.js
@@ -34,7 +34,7 @@ function addAnchors()
 function addVersionSelector() {
   // Latest version offered by the archive builds
   // This needs to be manually updated after new versions have been archived
-  var currentArchivedVersion = 79;
+  var currentArchivedVersion = 80;
   // build URLs for dlang.org: DDoc + Dox
   var ddocModuleURL = document.body.id.replace(/[.]/g, "_") + ".html";
   var ddoxModuleURL = document.body.id.replace(/[.]/g, "/") + ".html";


### PR DESCRIPTION
See also: https://github.com/dlang/docarchives.dlang.io/commit/238adb5b30e5a5149bae8833c38a871ac82b98fe