### PR TITLE
Error for implicit string concatenation

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -13,7 +13,7 @@ $(SPEC_S Deprecated Features,
         $(TROW $(DEPLINK Hexstring literals),                                     2.079, 2.079, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Class allocators and deallocators),                      &nbsp;, 2.080, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Implicit comparison of different enums),                 2.075,  2.075, 2.081, &nbsp;)
-        $(TROW $(DEPLINK Implicit string concatenation),                          2.072,  2.072, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK Implicit string concatenation),                          2.072,  2.072, 2.081, &nbsp;)
         $(TROW $(DEPLINK Using the result of a comma expression),                 2.072,  2.072,  2.079, &nbsp;)
         $(TROW $(DEPLINK delete),                                                 &nbsp;,  2.079, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK scope as a type constraint),                             future, &nbsp;, &nbsp;, &nbsp;)


### PR DESCRIPTION
PR to accompany https://github.com/dlang/dmd/pull/8220

See https://dlang.org/deprecate.html#Implicit%20string%20concatenation

This PR moves a deprecation forward, further narrowing the gap between specification and implementation.