### PR TITLE
Error for implicit comparison of different enums

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -12,7 +12,7 @@ $(SPEC_S Deprecated Features,
         $(THEAD Feature,                                                          Spec,  Dep,    Error,  Gone)
         $(TROW $(DEPLINK Hexstring literals),                                     2.079, 2.079, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Class allocators and deallocators),                      &nbsp;, 2.080, &nbsp;, &nbsp;)
-        $(TROW $(DEPLINK Implicit comparison of different enums),                 2.075,  2.075, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK Implicit comparison of different enums),                 2.075,  2.075, 2.081, &nbsp;)
         $(TROW $(DEPLINK Implicit string concatenation),                          2.072,  2.072, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Using the result of a comma expression),                 2.072,  2.072,  2.079, &nbsp;)
         $(TROW $(DEPLINK delete),                                                 &nbsp;,  2.079, &nbsp;, &nbsp;)
@@ -137,8 +137,8 @@ $(H3 $(DEPNAME Implicit comparison of different enums))
         }
         enum OtherStatus
         {
-            ok
-            no,
+            ok,
+            no
         }
         static assert(Status.good == OtherStatus.ok);
         ---


### PR DESCRIPTION
PR to accompany https://github.com/dlang/dmd/pull/8221

See https://dlang.org/deprecate.html#Implicit%20comparison%20of%20different%20enums

This PR moves a deprecation forward, further narrowing the gap between specification and implementation.