### PR TITLE
Fix broken link

### DIFF
--- a/spec/template.dd
+++ b/spec/template.dd
@@ -97,7 +97,7 @@ $(GNAME TemplateSingleArgument):
     $(D false)
     $(D null)
     $(D this)
-    $(GLINK2 traits, SpecialKeyword)
+    $(GLINK2 grammar, SpecialKeyword)
 )
 
     $(P Once instantiated, the declarations inside the template, called


### PR DESCRIPTION
Link `SpecialKeyword` in Section *Template Value Parameters* points to `traits.html` but should be `grammar.html`.