### PR TITLE
Remove old & invalid msie < 9 support code

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -386,7 +386,9 @@ _=
 RELATIVE_LINK2=$(ALOCAL $1, $+)
 _=
 
-RUNNABLE_EXAMPLE=$(DIVC runnable-examples, $1)
+RUNNABLE_EXAMPLE=<div class="runnable-examples">
+$1
+</div>
 RUNNABLE_EXAMPLE_STDIN=<code class="runnable-examples-stdin">$0</code>
 RUNNABLE_EXAMPLE_ARGS=<code class="runnable-examples-args">$0</code>
 

--- a/js/run.js
+++ b/js/run.js
@@ -282,18 +282,13 @@ function setupTextarea(el, opts)
 
     var prepareForMain = function()
     {
-        var src = $.browser.msie && $.browser.version < 9.0 ? orgSrc[0].innerText : orgSrc.text();
+        var src = orgSrc.text();
         var arr = src.split("\n");
         var str = "";
-        for ( i = 0; i < arr.length; i++)
+        for (var i = 0; i < arr.length; i++)
         {
             str += arr[i]+"\n";
         }
-        if ($.browser.msie && $.browser.version < 9.0)
-            str = str.substr(0, str.length - 1);
-        else
-            str = str.substr(0, str.length - 2);
-
         return str;
     };
 


### PR DESCRIPTION
Turns out that DDox's macro processor doesn't insert a newline when newlines occur in macros.
The workaround is to use good, old HTML.

The old MSIE < 9 support code lead to the final "}" being removed.

See also: https://github.com/rejectedsoftware/ddox/issues/204