### PR TITLE
Discourage use of the `in` storage class

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1180,7 +1180,10 @@ int foo(in int x, out int y, ref int z, int q);
     $(THEAD Storage Class, Description)
     $(TROW $(I none), parameter becomes a mutable copy of its argument)
 
-    $(TROW $(D in), equivalent to $(D const))
+    $(TROW $(D in), defined as $(D scope const).  However $(D in) has not yet been properly
+    implemented so it's current implementation is equivalent to $(D const).  It is recommended
+    to avoid using $(D in) until it is properly defined and implemented.  Use $(D scope const)
+    or $(D const) explicitly instead.)
     $(TROW $(D out), parameter is initialized upon function entry with the default value
     for its type)
 


### PR DESCRIPTION
We shouldn't be setting booby traps for users.

Also, the fewer usages there are in the wild, the easier it will be to properly implement later without disruption.

@WalterBright has set precedent for this with the following PRs:
https://github.com/dlang/phobos/pull/6575
https://github.com/dlang/phobos/pull/6574
https://github.com/dlang/phobos/pull/6573
https://github.com/dlang/phobos/pull/6572
https://github.com/dlang/phobos/pull/6571
https://github.com/dlang/phobos/pull/6568
https://github.com/dlang/phobos/pull/6567
https://github.com/dlang/phobos/pull/6566
https://github.com/dlang/phobos/pull/6564

See also https://forum.dlang.org/post/akrtdnphwhgjhlwkoood@forum.dlang.org