### PR TITLE
Only include etc & std for the ddox source file list

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -722,7 +722,7 @@ $G/docs-latest.json : ${DMD_LATEST} ${DMD_LATEST_DIR} \
 	find ${DMD_LATEST_DIR}/src -name '*.d' > $G/.latest-files.txt
 	find ${DRUNTIME_LATEST_DIR}/src -name '*.d' | \
 		sed -e /unittest.d/d -e /gcstub/d >> $G/.latest-files.txt
-	find ${PHOBOS_LATEST_DIR} -name '*.d' -not -path '${PHOBOS_LATEST_DIR}/generated/*' | \
+	find ${PHOBOS_LATEST_DIR}/etc ${PHOBOS_LATEST_DIR}/std -name '*.d' \
 		sed -e /unittest.d/d | sort >> $G/.latest-files.txt
 	${DMD_LATEST} -J$(DMD_LATEST_DIR)/res -J$(dir $(DMD_LATEST)) -c -o- -version=CoreDdoc \
 		-version=MARS -version=CoreDdoc -version=StdDdoc -Df$G/.latest-dummy.html \
@@ -735,7 +735,7 @@ $G/docs-prerelease.json : ${DMD} ${DMD_DIR} ${DRUNTIME_DIR} | dpl-docs
 	find ${DMD_DIR}/src -name '*.d' > $G/.prerelease-files.txt
 	find ${DRUNTIME_DIR}/src -name '*.d' | \
 		sed -e /unittest/d >> $G/.prerelease-files.txt
-	find ${PHOBOS_DIR} -name '*.d' -not -path '${PHOBOS_DIR}/generated/*' | \
+	find ${PHOBOS_DIR}/etc ${PHOBOS_DIR}/std -name '*.d' | \
 		sed -e /unittest.d/d | sort >> $G/.prerelease-files.txt
 	${DMD} -J$(DMD_DIR)/res -J$(dir $(DMD)) -c -o- -version=MARS -version=CoreDdoc \
 		-version=StdDdoc -Df$G/.prerelease-dummy.html \


### PR DESCRIPTION
Required for https://github.com/dlang/phobos/pull/6579 as a `test` folder is added to Phobos and at the moment these files get included in the Ddox build.