### PR TITLE
Discourage usage of property functions

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -592,6 +592,10 @@ $(H2 $(LNAME2 optional-parenthesis, Optional Parentheses))
 
 $(H2 $(LNAME2 property-functions, Property Functions))
 
+    $(P WARNING: The definition and usefulness of property functions is being reviewed, and the implementation
+    is currently incomplete.  Using property functions is not recommended until the definition is
+    more certain and implementation more mature.)
+
     $(P Properties are functions that can be syntactically treated
     as if they were fields or variables. Properties can be read from or written to.
     A property is read by calling a method or function with no arguments;


### PR DESCRIPTION
There is significant debate over what's happening with the `@property` feature demonstrated in the review of https://github.com/dlang/dmd/pull/8320

The uncertainty and lack of direction on this feature is causing too much confusion and conflict accompanied by speculative claims.

If there is any truth to the claims that `@property` was a mistake, then we need to make that known instead of setting traps for users by remaining silent.
