### PR TITLE
Fix local Latex PDF build

### DIFF
--- a/spec/latex.ddoc
+++ b/spec/latex.ddoc
@@ -399,8 +399,9 @@ DDOC=% Copyright (c) 1999-$(YEAR) by Digital Mars
 \usepackage{hyperref}
 \usepackage{multicol}
 \usepackage{longtable}
-\usepackage[T1]{fontenc}
 \usepackage{MnSymbol}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
 
 % For reproducible builds, fix the date if run on DAutoTest (empty by default)
 $(LATEX_NO_DATE)

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -544,7 +544,7 @@ $(H2 $(LNAME2 escape_sequences, Escape Sequences))
         or $(D 255) in decimal))
     $(TROW $(D \u)$(I nnnn), Unicode character U+$(I nnnn)$(COMMA) where
         $(I nnnn) are four hexadecimal digits.$(BR)For example$(COMMA)
-        $(D \u042F) represents the Unicode character Я (U+42F).)
+        $(D \u03B3) represents the Unicode character $(GAMMA) (U+03B3 - GREEK SMALL LETTER GAMMA).)
     $(TROW $(D \U)$(I nnnnnnnn), Unicode character U+$(I nnnnnnnn)$(COMMA)
         where $(I nnnnnnnn) are 8 hexadecimal digits.$(BR)For example$(COMMA)
         $(D \U0001F603) represents the Unicode character U+1F603 (SMILING FACE


### PR DESCRIPTION
At least on my system the PDF build doesn't default to UTF-8 anymore.
Also, there seems to be an issue with the cyrillic letters, so for the sake of simplicity I used one of the already predefined variables which are correctly encoded for HTML, ebook and TEX.