### PR TITLE
Change deprecation to error for C-style array syntax

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -20,7 +20,7 @@ $(SPEC_S Deprecated Features,
         $(TROW $(DEPLINK Imaginary and complex types),                            future, &nbsp;, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Implicit catch statement),                               2.072, 2.072,  2.081, &nbsp; )
         $(TROW $(DEPLINK .sort and .reverse properties for arrays),               ?,     2.072,  &nbsp;, 2.075)
-        $(TROW $(DEPLINK C-style array pointers),                                 ?,     2.072, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK C-style array pointers),                                 ?,     2.072,  2.082, &nbsp;)
         $(TROW $(DEPLINK Floating point NCEG operators),                          2.079, 2.066,  2.072,  2.080 )
         $(TROW $(DEPLINK clear),                                                  2.060, 2.066,  &nbsp;, 2.068 )
         $(TROW $(DEPLINK .min property for floating point types),                 N/A,   2.065,  2.067,  2.072 )


### PR DESCRIPTION
Documentation update to accompany https://github.com/dlang/dmd/pull/8438