### PR TITLE
hasMember doc: add import module effect to example

### DIFF
--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -448,6 +448,8 @@ import std.stdio;
 struct S
 {
     int m;
+
+    import std.stdio; // imports write
 }
 
 void main()
@@ -457,6 +459,7 @@ void main()
     writeln(__traits(hasMember, S, "m")); // true
     writeln(__traits(hasMember, s, "m")); // true
     writeln(__traits(hasMember, S, "y")); // false
+    writeln(__traits(hasMember, S, "write")); // true
     writeln(__traits(hasMember, int, "sizeof")); // true
 }
 ---


### PR DESCRIPTION
It was very surprising to me that all imported functions because "members" of the struct according to "hasMember" trait. Let's add that behavior to the documentation.