### PR TITLE
posix.mak: Only include .di file for DMD documentation

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -722,7 +722,8 @@ $W/library-prerelease/.htaccess : dpl_prerelease_htaccess
 
 $G/docs-latest.json : ${DMD_LATEST} ${DMD_LATEST_DIR} \
 			${DRUNTIME_LATEST_DIR} | dpl-docs
-	find ${DMD_LATEST_DIR}/src -name '*.d' -o -name '*.di' > $G/.latest-files.txt
+	find ${DMD_LATEST_DIR}/src -name '*.d' -o -name '*.di' | sort -r | \
+		gawk '!n[gensub(/\.di?$$/, "", 1)]++' > $G/.latest-files.txt
 	find ${DRUNTIME_LATEST_DIR}/src -name '*.d' | \
 		sed -e /unittest.d/d -e /gcstub/d >> $G/.latest-files.txt
 	find ${PHOBOS_LATEST_DIR}/etc ${PHOBOS_LATEST_DIR}/std -name '*.d' | \
@@ -735,7 +736,8 @@ $G/docs-latest.json : ${DMD_LATEST} ${DMD_LATEST_DIR} \
 	rm -f $G/.latest-files.txt $G/.latest-dummy.html
 
 $G/docs-prerelease.json : ${DMD} ${DMD_DIR} ${DRUNTIME_DIR} | dpl-docs
-	find ${DMD_DIR}/src -name '*.d' -o -name '*.di' > $G/.prerelease-files.txt
+	find ${DMD_DIR}/src -name '*.d' -o -name '*.di' | sort -r | \
+		gawk '!n[gensub(/\.di?$$/, "", 1)]++' > $G/.prerelease-files.txt
 	find ${DRUNTIME_DIR}/src -name '*.d' | \
 		sed -e /unittest/d >> $G/.prerelease-files.txt
 	find ${PHOBOS_DIR}/etc ${PHOBOS_DIR}/std -name '*.d' | \


### PR DESCRIPTION
Given a .d and .di file with the same name, pick only the .di file.
Otherwise, include all .d and .di files.

For https://github.com/dlang/dmd/pull/8447#issuecomment-403256949