### PR TITLE
Document how to run unittests in -betterC

### DIFF
--- a/spec/betterc.dd
+++ b/spec/betterc.dd
@@ -82,7 +82,33 @@ $(H2 $(LNAME2 retained, Retained Features))
     $(LI COM classes and C++ classes)
     $(LI `assert` failures are directed to the C runtime library)
     $(LI `switch` with strings)
+    $(LI `unittest`)
     )
+
+$(H3 $(LNAME2 unittests, Running unittests in `-betterC`))
+
+While, testing can be done without the $(TT -betterC) flag, it is sometimes desirable to run the testsuite in `-betterC` too.
+`unittest` blocks can be listed with the $(DDSUBLINK spec/traits, getUnitTests, `getUnitTests`) trait:
+
+---
+unittest
+{
+   assert(0);
+}
+
+extern(C) void main()
+{
+    static foreach(u; __traits(getUnitTests, __traits(parent, main)))
+        u();
+}
+---
+
+$(CONSOLE
+> dmd -betterC -unittest -run test.d
+dmd_runpezoXK: foo.d:3: Assertion `0' failed.
+)
+
+However, in `-betterC` `assert` expressions don't use Druntime's assert and are directed to `assert` of the C runtime library instead.
 
 $(H2 $(LNAME2 consequences, Unavailable Features))
 
@@ -98,7 +124,6 @@ $(OL
     $(LI `final switch`)
     $(LI `synchronized` and $(MREF core, sync))
     $(LI Static module constructors or destructors)
-    $(LI `unittest` (testing can be done without the $(TT -betterC) flag))
 )
 
 


### PR DESCRIPTION
I think this isn't obvious to people, especially as it was listed in the "Not Available" features section.