### PR TITLE
Un-document D_NoBoundsChecks and replace it with D_BoundsChecks

### DIFF
--- a/spec/version.dd
+++ b/spec/version.dd
@@ -329,8 +329,8 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
         $(TROW $(ARGS $(D D_AVX)) , $(ARGS AVX Vector instructions are supported))
         $(TROW $(ARGS $(D D_AVX2)) , $(ARGS AVX2 Vector instructions are supported))
         $(TROW $(ARGS $(D D_Version2)) , $(ARGS This is a D version 2 compiler))
-        $(TROW $(ARGS $(D D_NoBoundsChecks)) , $(ARGS Array bounds checks are disabled
-                (command line switch $(DDSUBLINK dmd, switch-boundscheck, $(TT -boundscheck=off)))))
+        $(TROW $(ARGS $(D D_BoundsChecks)) , $(ARGS Array bounds checks are enabled
+                (on by default, command line switch $(DDSUBLINK dmd, switch-boundscheck, $(TT -boundscheck=off)) turns this off)))
         $(TROW $(ARGS $(D D_ObjectiveC)) , $(ARGS The target supports interfacing with Objective-C))
         $(TROW $(ARGS $(D Core)) , $(ARGS Defined when building the standard runtime))
         $(TROW $(ARGS $(D Std)) , $(ARGS Define when building the standard library))


### PR DESCRIPTION
As explained in dlang/dmd#8532 the prefered style is positive version identifiers.
The DMD PR adds the new version identifier to be used for at least a release before D_NoBoundsChecks is deprecated.
In the meantime, it can already be undocumented.