### PR TITLE
Fix DDoc DDLINK macro usage

### DIFF
--- a/gpg_keys.dd
+++ b/gpg_keys.dd
@@ -36,7 +36,7 @@ $(P You can also download them as $(LINK2 d-keyring.gpg,keyring) file.)
 
 $(H2 D Security Team)
 
-The $(DDLINK security, security team) has its own key:
+The $(DDLINK security, $(DASH) ,security team) has its own key:
 
 $(PRE
 pub   rsa4096/0x8FF049B29638EDD2 2018-07-05 [SC] [expires: 2020-07-04]


### PR DESCRIPTION
I don't know why, but `DDLINK` is defined as:

```
DDLINK=$(LINK2 $(ROOT_DIR)$1.html, $3)
```