### PR TITLE
dstyle: Avoid newlines in DDoc sections

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -412,12 +412,9 @@ enum myFancyConstant;
 /**
 Checks whether a number is positive.
 `0` isn't considered as positive number.
-
 Params:
     number = number to be checked
-
 Returns: `true` if the number is positive, `0` otherwise.
-
 See_Also: $(LREF isNegative)
 */
 bool isPositive(int number)
@@ -430,6 +427,7 @@ bool isPositive(int number)
     $(LI Either Block comments (`/**`) or nesting block comments (`/++`) should be used except when the ddoc comment is a ditto comment such as `/// Ditto`)
     $(LI Documentation comments should not have leading stars on each line.)
     $(LI Text example blocks should use three dashes (`---`) only.)
+    $(LI Unless there's a compelling reason for it, avoid newlines between sections as it reduces the amount of code one can view on a screen)
 )
 
 $(BR)


### PR DESCRIPTION
This is to accommodate @WalterBright's preference state at https://github.com/dlang/dmd/pull/8572#discussion_r211086434 ...

> All these blank lines detract a bit from readability, as one has less code that fits on the screen.

... so that we can enforce a consistent coding style in DMD.

EDIT: I'm not really in favor of this, but it's impossible to be productive and consistent with contributors if @WalterBright is not on board with our coding conventions and style.  Either he has to bend to our preferences (unlikely in my experience), or we have to bend to his.  I'm getting frustrated enforcing these style conventions only to have @WalterBright recommend the opposite later.  It makes us look inept, and contributors, understandably, get annoyed by the mixed messages.