### PR TITLE
D doesn't have SFINAE

### DIFF
--- a/articles/template-comparison.dd
+++ b/articles/template-comparison.dd
@@ -575,7 +575,7 @@ class Foo&lt; Bar&lt;T,U&gt; &gt;
 
         $(TR
         $(TD $(SFINAE))
-        $(TD Yes)
+        $(TD No)
         $(TD Yes)
         $(TD No change)
         )


### PR DESCRIPTION
The table was misleading.

From https://dlang.org/glossary.html#sfinae

If template argument deduction results in a type that is not valid, that specialization of the template is not considered further. It is not a compile error.

From Walter's comment on Reddit: https://www.reddit.com/r/programming/comments/97q9sq/why_d_is_a_good_choice_for_writing_a_language/e4bgtuq