### PR TITLE
Fix a few visual flaws in the DMD help page

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -914,7 +914,6 @@ Macros:
     DMD_CONF=$(RELATIVE_LINK2 dmd-conf, dmd.conf)
     SC_INI=$(RELATIVE_LINK2 sc-ini, $(DMDDIR)\windows\bin\sc.ini)
     DMC=$(LINK2 http://www.digitalmars.com/ctg/sc.html, dmc)
-    LIB=$(LINK2 http://www.digitalmars.com/ctg/lib.html, lib)
     OPTLINK=$(LINK2 http://www.digitalmars.com/ctg/optlink.html, link.exe)
     DUB=$(LINK2 https://github.com/dlang/dub, dub$(BINEXT))
     RDMD=$(LINK2 $(ROOT_DIR)rdmd.html, rdmd$(BINEXT))

--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -891,10 +891,10 @@ Macros:
         SUBNAV=$(SUBNAV_CLI_REFERENCE)
     INSTALLATION_SCRIPT_HINT=
 $(P
-$(MESSAGE_BOX gray, $(B Hint) - The official $(LINK2 $(ROOT_DIR)download.sh, packages)
+$(MESSAGE_BOX gray, $(B Hint) - The official $(LINK2 $(ROOT_DIR)download.html, packages)
 performs these steps automatically.
 Alternatively, you can install DMD in your user directory with
-the $(LINK2 $(ROOT_DIR)install.sh, install script).
+the $(LINK2 $(ROOT_DIR)install.html, install script).
 ))
 )
     _ =

--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -85,21 +85,52 @@ C:\&gt;unzip dmc.zip
 
     $(INSTALLATION_SCRIPT_HINT)
 
-    It will create
-    a $(D ~/dmd) directory with all the files in it.
+    Unzip the archive into your home directory.
+    It will create a $(D ~/dmd) directory with all the files in it.
 
     All the tools are command line tools, which means
-    they are run from a console window.)
-    $(LI All tools can be run directly from the archive:
+    they are run from a console window.
+    All tools can be run directly from the archive:
 $(CONSOLE
 ~/dmd/linux/bin64/dmd
 )
-    To install $(D dmd) globally, add this bin folder to your $(B PATH).
+    To install $(D dmd) globally, add the `~/dmd/linux/bin64` folder to your $(B PATH).
+$(CONSOLE
+export PATH="$HOME/dmd/linux/bin64:$PATH"
+)
+
+    Alternatively, you can install dmd locally yourself by:
+    $(P $(UL
+
+    $(LI Copy $(D $(DMD_CONF)) to $(D /etc):
+
+$(CONSOLE
+sudo cp $(DMDDIR)/linux/bin64/dmd.conf /etc/$(DMD_CONF)
+)
+
+
+    $(LI Copy binaries to $(D /usr/local/bin):
+
+$(CONSOLE
+sudo cp $(DMDDIR)/linux/bin64/{dmd,$(DUMPOBJ),$(OBJ2ASM),$(SHELL),rdmd} /usr/local/bin
+)
+    )
+
+    $(LI Copy the library to $(D /usr/local/lib):
+
+$(CONSOLE
+sudo cp $(DMDDIR)/linux/lib64/$(LIB) /usr/local/lib
+)
+    )
+
+    ))
     )
 
     $(FREEBSD
 
     $(INSTALLATION_SCRIPT_HINT)
+
+    $(P $(UL
 
     $(LI Unzip the archive into your home directory.
     It will create
@@ -124,10 +155,13 @@ $(CONSOLE
 cp $(DMDDIR)/freebsd/lib/$(LIB) /usr/lib
 )
     )
+    ))
     )
     $(OSX
 
     $(INSTALLATION_SCRIPT_HINT)
+
+    $(P $(UL
 
     $(LI Put the dmd zip file into your home directory,
     and unzip it:
@@ -180,6 +214,7 @@ $(CONSOLE
 sudo cp $(DMDDIR)/osx/lib/$(LIB) /usr/local/lib
 )
     )
+    ))
     )
 
 $(WINDOWS

--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -102,17 +102,19 @@ export PATH="$HOME/dmd/linux/bin64:$PATH"
     Alternatively, you can install dmd locally yourself by:
     $(P $(UL
 
-    $(LI Copy $(D $(DMD_CONF)) to $(D /etc):
+    $(LI Create a configuration file in $(D /etc/dmd.conf):
 
-$(CONSOLE
-sudo cp $(DMDDIR)/linux/bin64/dmd.conf /etc/$(DMD_CONF)
-)
+---
+[Environment64]
+DFLAGS=-I/usr/local/include/d/dmd -L-L/usr/local/lib -L--export-dynamic -fPIC
+---
 
+    )
 
     $(LI Copy binaries to $(D /usr/local/bin):
 
 $(CONSOLE
-sudo cp $(DMDDIR)/linux/bin64/{dmd,$(DUMPOBJ),$(OBJ2ASM),$(SHELL),rdmd} /usr/local/bin
+sudo cp $(DMDDIR)/linux/bin64/{dmd,$(DUMPOBJ),$(OBJ2ASM),rdmd,ddemangle,dub,dustmite} /usr/local/bin
 )
     )
 
@@ -122,6 +124,13 @@ $(CONSOLE
 sudo cp $(DMDDIR)/linux/lib64/$(LIB) /usr/local/lib
 )
     )
+
+    $(LI Copy the standard library and runtime sources to $(D /usr/include/d/dmd):
+
+$(CONSOLE
+sudo mkdir -p /usr/include/d/dmd
+sudo cp $(DMDDIR)/{phobos/std,phobos/etc,druntime/import} /usr/include/d/dmd
+)
 
     ))
     )
@@ -138,21 +147,36 @@ sudo cp $(DMDDIR)/linux/lib64/$(LIB) /usr/local/lib
     All the tools are command line tools, which means
     they are run from a console window.)
 
-    $(LI Copy $(D $(DMD_CONF)) to $(D /etc):
+    $(LI Create a configuration file in $(D /etc/dmd.conf):
 
-$(CONSOLE
-cp $(DMDDIR)/freebsd/bin/dmd.conf /etc
-)
+---
+[Environment64]
+DFLAGS=-I/usr/local/include/d/dmd -L-L/usr/local/lib -L--export-dynamic -fPIC
+---
+
     )
+
 
     $(LI Put $(D $(DMDDIR)/freebsd/bin) on your $(B PATH),
     or copy the FreeBSD executables
-    to $(D /usr/local/bin))
+    to $(D /usr/local/bin):)
+
+$(CONSOLE
+sudo cp $(DMDDIR)/linux/bin64/{dmd,$(DUMPOBJ),$(OBJ2ASM),rdmd,ddemangle,dub,dustmite} /usr/local/bin
+)
 
     $(LI Copy the library to $(D /usr/lib):
 
 $(CONSOLE
-cp $(DMDDIR)/freebsd/lib/$(LIB) /usr/lib
+sudo cp $(DMDDIR)/freebsd/lib/$(LIB) /usr/lib
+)
+    )
+
+    $(LI Copy the standard library and runtime sources to $(D /usr/include/d/dmd):
+
+$(CONSOLE
+sudo mkdir -p /usr/include/d/dmd
+sudo cp $(DMDDIR)/{phobos/std,phobos/etc,druntime/import} /usr/include/d/dmd
 )
     )
     ))
@@ -203,7 +227,7 @@ hello world!
     $(LI Copy binaries to $(D /usr/local/bin):
 
 $(CONSOLE
-sudo cp $(DMDDIR)/osx/bin/{dmd,$(DUMPOBJ),$(OBJ2ASM),$(SHELL),rdmd} /usr/local/bin
+sudo cp $(DMDDIR)/osx/bin/{dmd,$(DUMPOBJ),$(OBJ2ASM),rdmd,dub,ddemangle,dustmite} /usr/local/bin
 sudo cp $(DMDDIR)/osx/bin/dmdx.conf /usr/local/bin/$(DMD_CONF)
 )
     )
@@ -214,6 +238,15 @@ $(CONSOLE
 sudo cp $(DMDDIR)/osx/lib/$(LIB) /usr/local/lib
 )
     )
+
+    $(LI Copy the standard library and runtime sources to $(D /usr/local/include/d/dmd):
+
+$(CONSOLE
+sudo mkdir -p /usr/include/d/dmd
+sudo cp $(DMDDIR)/{phobos/std,phobos/etc,druntime/import} /usr/include/d/dmd
+)
+    )
+
     ))
     )
 

--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -132,6 +132,7 @@ sudo mkdir -p /usr/include/d/dmd
 sudo cp $(DMDDIR)/{phobos/std,phobos/etc,druntime/import} /usr/include/d/dmd
 )
 
+    )
     ))
     )
 
@@ -962,6 +963,6 @@ $(MESSAGE_BOX gray, $(B Hint) - The official $(LINK2 $(ROOT_DIR)download.html, p
 performs these steps automatically.
 Alternatively, you can install DMD in your user directory with
 the $(LINK2 $(ROOT_DIR)install.html, install script).
-))
+)
 )
     _ =


### PR DESCRIPTION
- Fix overwritten LIB macro (the macro was never used, but overwrote the actual LIB macro)
- Use individual install steps for Linux (all other pages have them too) + fix list indentation
- Fix links to the packages and install script

This page is quite complicated, so it's better to check the resulting diff of DAutoTest here.