### PR TITLE
[spec] Document ref and out parameters

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1265,13 +1265,13 @@ $(H3 $(LNAME2 ref-params, Ref and Out Parameters))
 
 $(SPEC_RUNNABLE_EXAMPLE_RUN
 ---
-void def(ref int x)
+void inc(ref int x)
 {
     x += 1;
 }
 
 int z = 3;
-def(z);
+inc(z);
 assert(z == 4);
 ------------
 )
@@ -1290,7 +1290,7 @@ void foo(out int x)
 
 int a = 3;
 foo(a);
-assert(x == 0);
+assert(a == 0);
 
 void abc(out int x)
 {

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1263,7 +1263,7 @@ $(H3 $(LNAME2 ref-params, Ref and Out Parameters))
     A Ref parameter takes an lvalue argument, so changes to its value will operate
     on the caller's argument.)
 
-$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 ---
 void def(ref int x)
 {
@@ -1272,24 +1272,23 @@ void def(ref int x)
 
 int z = 3;
 def(z);
-// z is now 4
+assert(z == 4);
 ------------
 )
 
     $(P An Out parameter `x` is similar to a Ref parameter, except it is initialized
     with `x.init` upon function invocation.)
 
-$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 ------
 void foo(out int x)
 {
-    // x is set to int.init,
-    // which is 0, at start of foo()
+    assert(x == 0);
 }
 
 int a = 3;
 foo(a);
-// a is now 0
+assert(x == 0);
 
 void abc(out int x)
 {
@@ -1298,7 +1297,7 @@ void abc(out int x)
 
 int y = 3;
 abc(y);
-// y is now 2
+assert(y == 2);
 ---
 )
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1260,7 +1260,7 @@ int foo(in int x, out int y, ref int z, int q);
 $(H3 $(LNAME2 ref-params, Ref and Out Parameters))
 
     $(P By default, parameters take rvalue arguments.
-    A Ref parameter takes an lvalue argument, so changes to its value will operate
+    A ref parameter takes an lvalue argument, so changes to its value will operate
     on the caller's argument.)
 
 $(SPEC_RUNNABLE_EXAMPLE_RUN
@@ -1275,8 +1275,10 @@ def(z);
 assert(z == 4);
 ------------
 )
+    $(P A ref parameter can also be returned by reference - see:
+    $(RELATIVE_LINK2 return-ref-parameters, $(D return ref) parameters.))
 
-    $(P An Out parameter `x` is similar to a Ref parameter, except it is initialized
+    $(P An out parameter `x` is similar to a ref parameter, except it is initialized
     with `x.init` upon function invocation.)
 
 $(SPEC_RUNNABLE_EXAMPLE_RUN

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1238,10 +1238,10 @@ int foo(in int x, out int y, ref int z, int q);
     implemented so it's current implementation is equivalent to $(D const).  It is recommended
     to avoid using $(D in) until it is properly defined and implemented.  Use $(D scope const)
     or $(D const) explicitly instead.)
-    $(TROW $(D out), parameter is initialized upon function entry with the default value
+    $(TROW $(D ref), parameter is passed by reference)
+    $(TROW $(D out), parameter is passed by reference and initialized upon function entry with the default value
     for its type)
 
-    $(TROW $(D ref),   parameter is passed by reference)
     $(TROW $(D scope), references in the parameter
     cannot be escaped (e.g. assigned to a global variable).
     Ignored for parameters with no references)
@@ -1256,6 +1256,28 @@ int foo(in int x, out int y, ref int z, int q);
     $(TROW $(D shared), argument is implicitly converted to a shared type)
     $(TROW $(D inout), argument is implicitly converted to an inout type)
     )
+
+$(H3 $(LNAME2 ref-params, Ref and Out Parameters))
+
+    $(P By default, parameters take rvalue arguments.
+    A Ref parameter takes an lvalue argument, so changes to its value will operate
+    on the caller's argument.)
+
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+---
+void def(ref int x)
+{
+    x += 1;
+}
+
+int z = 3;
+def(z);
+// z is now 4
+------------
+)
+
+    $(P An Out parameter `x` is similar to a Ref parameter, except it is initialized
+    with `x.init` upon function invocation.)
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ------
@@ -1277,19 +1299,10 @@ void abc(out int x)
 int y = 3;
 abc(y);
 // y is now 2
-
-void def(ref int x)
-{
-    x += 1;
-}
-
-int z = 3;
-def(z);
-// z is now 4
-------------
+---
 )
 
-        $(P For dynamic array and object parameters, which are passed
+        $(P For dynamic array and object parameters, which are always passed
         by reference, in/out/ref
         apply only to the reference and not the contents.
         )


### PR DESCRIPTION
* Split the `ref` example from the `out` examples, and put it first.
* Briefly describe each.
* Tweak the `scope` description.