### PR TITLE
Add a small paragraph about implicit conversion of strings

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -1064,13 +1064,16 @@ $(H2 $(LNAME2 implicit-conversions, Implicit Conversions))
         )
 
         $(P A dynamic array $(D T[]) can be implicitly converted to one of the
-        following ($(D U) is a base class of $(D T)):)
+        following ($(D U) is a base class of $(D T)) and neither U nor T are character types:)
 
         $(UL
         $(LI $(D const(U)[]))
         $(LI $(D const(U[])))
         $(LI $(D void[]))
         )
+
+        $(P Arrays of character are never implicitly converted,
+        to the exception of string literals because the compiler can create a literal with the right type.)
 
 $(SPEC_SUBNAV_PREV_NEXT statement, Statements, hash-map, Associative Arrays)
 )


### PR DESCRIPTION
Unless i missed it elsewhere the case is never mentioned. It can be confusing because implicit conversion works for string literals and not for other arrays of char so now it's explained that this case works because the conversion is done at compile time.