### PR TITLE
fix link to DMD installer

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -58,7 +58,7 @@ $(H2 $(LNAME2 requirements, Requirements and Downloads))
 $(H2 $(LNAME2 installation, Installation))
 
     $(WINDOWS
-$(MESSAGE_BOX gray, $(B Hint) - The official $(LINK2 $(ROOT_DIR)download.sh, installer)
+$(MESSAGE_BOX gray, $(B Hint) - The official $(LINK2 $(ROOT_DIR)download.html, installer)
 performs these steps automatically.
 )
     $(P Open a console window (for Windows XP this is done by


### PR DESCRIPTION
The original link was pointing to download.sh which doesn't exist.