### PR TITLE
Update spec to disallow invalid binary literals

### DIFF
--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -600,7 +600,7 @@ $(GNAME DecimalInteger):
     $(GLINK NonZeroDigit) $(GLINK DecimalDigitsUS)
 
 $(GNAME BinaryInteger):
-    $(GLINK BinPrefix) $(GLINK BinaryDigitsUS)
+    $(GLINK BinPrefix) $(GLINK BinaryDigitsNoSingleUS)
 
 $(GNAME BinPrefix):
     $(B 0b)
@@ -644,6 +644,12 @@ $(GNAME DecimalDigit):
 $(GNAME DecimalDigitUS):
     $(GLINK DecimalDigit)
     $(D _)
+
+$(GNAME BinaryDigitsNoSingleUS):
+    $(GLINK BinaryDigit)
+    $(GLINK BinaryDigit) $(GLINK BinaryDigitsUS)
+    $(GLINK BinaryDigitsUS) $(GLINK BinaryDigit)
+    $(GLINK BinaryDigitsUS) $(GLINK BinaryDigit) $(GLINK BinaryDigitsUS)
 
 $(GNAME BinaryDigitsUS):
     $(GLINK BinaryDigitUS)


### PR DESCRIPTION
This is the spec update for https://github.com/dlang/dmd/pull/8738 / https://issues.dlang.org/show_bug.cgi?id=19246
Binary literals like `0b` and `0b_` are now deprecated. A valid binary literal must now have at least one digit after the prefix.