### PR TITLE
Fix mistake in C++ code

### DIFF
--- a/articles/cpptod.dd
+++ b/articles/cpptod.dd
@@ -638,7 +638,7 @@ struct Integer&lt; 16 &gt;
 
 struct Integer&lt; 32 &gt;
 {
-    typedef int int_type ;
+    typedef long int_type ;
 };
 
 struct Integer&lt; 64 &gt;


### PR DESCRIPTION
`int` is not guaranteed to be at least 32 bits,
it can be as small as 16 bits in some implementations (e.g. AVR chips).
`long` on the other hand is guaranteed to be at least 32 bits.