### PR TITLE
Remove GNEX ltd.

### DIFF
--- a/orgs-using-d.dd
+++ b/orgs-using-d.dd
@@ -120,13 +120,6 @@ $(DIVC orgs-using-d center,
             $(FA_HIRING www.funkwerk.com/karriere/stellenangebote)
         )
     )
-    $(DORG GNEX, https://globalnet-ex.com, gnex.png,
-        Digital Marketing Solutions Company.,
-        $(LINK_ROW
-            $(FA_GITHUB gnexltd) $(FA_SEPARATOR)
-            $(FA_HIRING globalnet-ex.com/employment/engineer)
-        )
-    )
     $(DORG Infognition, http://www.infognition.com, infognition.svg,
         Video processing,
         $(FA_QUOTE


### PR DESCRIPTION
## about

I am an engineer of GNEX ltd. (See screenshot).
GNEX has finished using DLang. Please delete from orgs-using-d page.

## refs

![screen shot 2018-10-07 at 17 37 34](https://user-images.githubusercontent.com/6993514/46580036-c1f7ad00-ca57-11e8-9951-1ab8418d6cfb.png)

https://github.com/orgs/gnexltd/people