### PR TITLE
DDox: Fix fall-back JS code for loading jQuery

### DIFF
--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -229,7 +229,7 @@ html(lang='en-US')
     script(type='text/javascript', src='https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js')
     |     
     script(type='text/javascript').
-      window.jQuery || document.write('\\x3Cscript src="#{root_dir}js/jquery-1.7.2.min.js">\\x3C/script>')
+      window.jQuery || document.write('\x3Cscript src="#{root_dir}js/jquery-1.7.2.min.js">\x3C/script>')
     |     
     script(type='text/javascript', src='#{root_dir}js/codemirror-compressed.js')
     |     


### PR DESCRIPTION
The escapes may have been needed at some point, but now they appear verbatim in the output, breaking the code.