### PR TITLE
Add guideline for contracts

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -300,6 +300,7 @@ $(LISTSECTION phobos_whitespace, Whitespace,
 -------------------------------
 for (…) { … }
 foreach (…) { … }
+static foreach (…) { … }
 if (x) { … }
 static if (x) { … }
 while (…) { … }
@@ -381,6 +382,19 @@ $(LISTSECTION phobos_declarations, Declarations,
 -------------------------------
 void foo(R)(R r)
 if (R == 1)
+-------------------------------
+    $(LI Pre and post contracts should have the same indentation level as their
+         declaration. Put no space between `in`/`out` and an open parenthesis:)
+-------------------------------
+int foo(int r)
+in(r == 0)
+out(result; result == 0)
+do { … }
+
+int foo(int r)
+in { … }
+out(result) { … }
+do { … }
 -------------------------------
 )
 $(LISTSECTION phobos_class_struct_field_declaration, Class/Struct Field Declarations,


### PR DESCRIPTION
- Pre and post contracts should have the same indentation level as their
declaration. Put no space between `in`/`out` and an open parenthesis:
```d
int foo(int r)
in(r == 0)
out(result; result == 0)
do { … }
```
```d
int foo(int r)
in { … }
out(result) { … }
do { … }
```