### PR TITLE
Add Flipcause to the donate page.

### DIFF
--- a/foundation/donate.dd
+++ b/foundation/donate.dd
@@ -33,7 +33,7 @@ We $(LINK2 sponsors.html, welcome contributions) from both organizations and ind
 $(DONATE_ITEM Donate through Flipcause, users,
 
     Flipcause helps non-profit organizations like the D Language Foundation manage their
-    donations and provide more value to donors. Donating through Flipcause can enable us 
+    donations and provide more value to donors. Donating through Flipcause can enable us
     to more efficiently put your donation to use.
     $(BR)$(BR)
 

--- a/foundation/donate.dd
+++ b/foundation/donate.dd
@@ -30,6 +30,16 @@ $(H3 How can I donate?)
 
 We $(LINK2 sponsors.html, welcome contributions) from both organizations and individuals. Your help is highly appreciated.
 
+$(DONATE_ITEM Donate through Flipcause, users,
+
+    Flipcause helps non-profit organizations like the D Language Foundation manage their
+    donations and provide more value to donors. Donating through Flipcause can enable us 
+    to more efficiently put your donation to use.
+    $(BR)$(BR)
+
+    <iframe style="height:325px; width:300px; border:medium none; " src="https://www.flipcause.com/embed/html_widget/NDMzMzE=" scrolling="no"></iframe>
+)
+
 $(DONATE_ITEM Donate through OpenCollective, users,
 
     Make a $(I transparent) donation and select the package you're comfortable.


### PR DESCRIPTION
We've signed up with Flipcause to create and manage targeted donation campaigns. The general fund campaign is permanent and ongoing, and needs to be on the donate page.