### PR TITLE
Improve the dlang.org changelog setup

### DIFF
--- a/changelog/prerelease.ddoc
+++ b/changelog/prerelease.ddoc
@@ -8,7 +8,7 @@ $4
 )
 
 PHOBOS_PATH=$(ROOT_DIR)phobos-prerelease/
-CHANGELOG_SOURCE_FILE=$(DIVC changelog-source-edit-btn, $(LINK2 https://github.com/dlang/$1/edit/master/$2, $(TC i, fa fa-edit)))
+CHANGELOG_SOURCE_FILE=$(DIVC changelog-source-edit-btn, $(LINK2 https://github.com/dlang/$1/edit/stable/$2, $(TC i, fa fa-edit)))
 EXTRA_HEADERS=$(T style,
     .changelog-source-edit-btn {
         float: right;

--- a/ddoc/dub.sdl
+++ b/ddoc/dub.sdl
@@ -3,6 +3,7 @@ description "Preprocesses source code before running Ddoc over it"
 dependency "libdparse" version="~>0.8.7"
 dependency "dmd" path="../../dmd"
 versions "DdocOptions"
+buildRequirements "disallowDeprecations"
 configuration "executable" {
 	versions "IsExecutable"
 	targetType "executable"

--- a/ddoc/source/assert_writeln_magic.d
+++ b/ddoc/source/assert_writeln_magic.d
@@ -196,10 +196,9 @@ private auto assertWritelnModuleImpl(string fileText)
 {
     import std.string : representation;
     auto fl = FileLines(fileText);
-    auto visitor = new TestVisitor!(typeof(fl))(fl);
+    scope visitor = new TestVisitor!(typeof(fl))(fl);
     // libdparse doesn't allow to work on immutable source code
     parseString(cast(ubyte[]) fileText.representation, visitor);
-    delete visitor;
     return fl;
 }
 
@@ -274,9 +273,8 @@ version(unittest)
     {
         import std.string : representation;
         auto mock = FileLinesMock(sourceCode.split("\n"));
-        auto visitor = new TestVisitor!(typeof(mock))(mock);
+        scope visitor = new TestVisitor!(typeof(mock))(mock);
         parseString(sourceCode.representation.dup, visitor);
-        delete visitor;
         return mock;
     }
 }

--- a/ddoc/source/preprocessor.d
+++ b/ddoc/source/preprocessor.d
@@ -346,7 +346,13 @@ auto genChangelogVersion(string fileName, string fileText)
             }
             else
             {
-                macros ~="\n$(CHANGELOG_NAV %s, %s)".format(versions[el.index - 1], versions[el.index + 1]);
+                const prevVersion = versions[el.index - 1].to!string;
+                auto nextVersion = versions[el.index + 1].to!string;
+                // the next version is the beta release
+                if (el.index == versions.length - 2 && hasPrerelease)
+                    nextVersion = std.array.replace(nextVersion, "_pre", "");
+
+                macros ~="\n$(CHANGELOG_NAV %s, %s)".format(prevVersion, nextVersion);
             }
             macros ~= "\n_=";
         }


### PR DESCRIPTION
- fix edit links from the beta release page (should point to stable)
- disallow deprecations and fix them (they should be fixed by the one introducing the deprecation in the future)
- Fix changelog links from the stable page pointing to the beta release (see e.g. https://dlang.org/changelog/2.082.1.html)