### PR TITLE
Fix `do` being optional after a contract statement

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -99,7 +99,7 @@ $(GNAME FunctionLiteralBody):
 $(GNAME SpecifiedFunctionBody):
     $(D do)$(OPT) $(GLINK2 statement, BlockStatement)
     $(GLINK FunctionContracts)$(OPT) $(GLINK InOutContractExpression) $(D do)$(OPT) $(GLINK2 statement, BlockStatement)
-    $(GLINK FunctionContracts)$(OPT) $(GLINK InOutStatement) $(D do)$(OPT) $(GLINK2 statement, BlockStatement)
+    $(GLINK FunctionContracts)$(OPT) $(GLINK InOutStatement) $(D do) $(GLINK2 statement, BlockStatement)
 
 $(GNAME MissingFunctionBody):
     $(D ;)


### PR DESCRIPTION
Contrary to contract expressions, `in` and `out` statements require `do` to indicate the function body, but the grammar indicates `do` as optional.
The grammar changes in [DIP1009](https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1009.md#grammar) don't mark do as optional in this case, and DMD complains about a missing `do` with the following code:
```d
int main(string[] args)
in
{
}
{
	return 0;
}
```