### PR TITLE
Add more traits doc examples & make existing examples runnable

### DIFF
--- a/js/run.js
+++ b/js/run.js
@@ -101,6 +101,7 @@ var backends = {
     requestTransform: function(data) {
         var req = {
             source: data.code,
+            args: "-unittest",
             compiler: dmdCompilerBranch
         }
         // only send set attributes
@@ -450,7 +451,7 @@ function setupTextarea(el, opts)
     });
     openInEditorBtn.click(function(){
       var text = (editor && editor.getValue()) || prepareForMain();
-      var url = "https://run.dlang.io?compiler=" + dmdCompilerBranch + "&source=" + encodeURIComponent(opts.transformOutput(text));
+      var url = "https://run.dlang.io?compiler=" + dmdCompilerBranch + "&args=-unittest&source=" + encodeURIComponent(opts.transformOutput(text));
       window.open(url, "_blank");
     });
     return editor;

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -553,6 +553,7 @@ $(H2 $(GNAME isReturnOnStack))
         parameter to the function.
     )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
     ---
     struct S { int[20] a; }
     int test1();
@@ -561,6 +562,7 @@ $(H2 $(GNAME isReturnOnStack))
     static assert(__traits(isReturnOnStack, test1) == false);
     static assert(__traits(isReturnOnStack, test2) == true);
     ---
+)
 
     $(IMPLEMENTATION_DEFINED
         This is determined by the function ABI calling convention in use,
@@ -614,6 +616,7 @@ $(H2 $(GNAME identifier))
         $(P Takes one argument, a symbol. Returns the identifier
         for that symbol as a string literal.
         )
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -623,6 +626,7 @@ pragma(msg, typeof(__traits(identifier, var))); // string
 writeln(var);                                   // 123
 writeln(__traits(identifier, var));             // "var"
 ---
+)
 
 $(H2 $(GNAME getAliasThis))
 

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -112,25 +112,117 @@ $(H2 $(GNAME isFloating))
         $(P Works like $(D isArithmetic), except it's for floating
         point types (including imaginary and complex types).)
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+---
+import core.simd : float4;
+
+enum E : float { a, b }
+
+static assert(__traits(isFloating, float));
+static assert(__traits(isFloating, idouble));
+static assert(__traits(isFloating, creal));
+static assert(__traits(isFloating, E));
+static assert(__traits(isFloating, float4));
+
+static assert(!__traits(isFloating, float[4]));
+---
+)
+
 $(H2 $(GNAME isIntegral))
 
         $(P Works like $(D isArithmetic), except it's for integral
         types (including character types).)
+
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+---
+import core.simd : int4;
+
+enum E { a, b }
+
+static assert(__traits(isIntegral, bool));
+static assert(__traits(isIntegral, char));
+static assert(__traits(isIntegral, int));
+static assert(__traits(isIntegral, E));
+static assert(__traits(isIntegral, int4));
+
+static assert(!__traits(isIntegral, float));
+static assert(!__traits(isIntegral, int[4]));
+static assert(!__traits(isIntegral, void*));
+---
+)
 
 $(H2 $(GNAME isScalar))
 
         $(P Works like $(D isArithmetic), except it's for scalar
         types.)
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+---
+import core.simd : int4, void16;
+
+enum E { a, b }
+
+static assert(__traits(isScalar, bool));
+static assert(__traits(isScalar, char));
+static assert(__traits(isScalar, int));
+static assert(__traits(isScalar, float));
+static assert(__traits(isScalar, E));
+static assert(__traits(isScalar, int4));
+static assert(__traits(isScalar, void*)); // Includes pointers!
+
+static assert(!__traits(isScalar, int[4]));
+static assert(!__traits(isScalar, void16));
+static assert(!__traits(isScalar, void));
+static assert(!__traits(isScalar, typeof(null)));
+static assert(!__traits(isScalar, Object));
+---
+)
+
 $(H2 $(GNAME isUnsigned))
 
         $(P Works like $(D isArithmetic), except it's for unsigned
         types.)
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+---
+import core.simd : uint4;
+
+enum SignedEnum { a, b }
+enum UnsignedEnum : uint { a, b)
+
+static assert(__traits(isUnsigned, bool));
+static assert(__traits(isUnsigned, char));
+static assert(__traits(isUnsigned, uint));
+static assert(__traits(isUnsigned, UnsignedEnum));
+static assert(__traits(isUnsigned, uint4));
+
+static assert(!__traits(isUnsigned, int));
+static assert(!__traits(isUnsigned, float));
+static assert(!__traits(isUnsigned, SignedEnum));
+static assert(!__traits(isUnsigned, uint[4]));
+static assert(!__traits(isUnsigned, void*));
+---
+)
+
 $(H2 $(GNAME isStaticArray))
 
         $(P Works like $(D isArithmetic), except it's for static array
         types.)
+
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+---
+import core.simd : int4;
+
+enum E : int[4] { a = [1, 2, 3, 4] }
+
+static array = [1, 2, 3]; // Not a static array.
+
+static assert(__traits(isStaticArray, void[0]));
+static assert(__traits(isStaticArray, E));
+static assert(!__traits(isStaticArray, int4));
+static assert(!__traits(isStaticArray, array));
+---
+)
 
 $(H2 $(GNAME isAssociativeArray))
 

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -85,6 +85,7 @@ $(H2 $(GNAME isArithmetic))
         Otherwise, $(D false) is returned.
         If there are no arguments, $(D false) is returned.)
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -97,6 +98,7 @@ void main()
     writeln(__traits(isArithmetic, int*));
 }
 ---
+)
 
         Prints:
 
@@ -188,7 +190,7 @@ $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 import core.simd : uint4;
 
 enum SignedEnum { a, b }
-enum UnsignedEnum : uint { a, b)
+enum UnsignedEnum : uint { a, b }
 
 static assert(__traits(isUnsigned, bool));
 static assert(__traits(isUnsigned, char));
@@ -215,7 +217,7 @@ import core.simd : int4;
 
 enum E : int[4] { a = [1, 2, 3, 4] }
 
-static array = [1, 2, 3]; // Not a static array.
+static array = [1, 2, 3]; // Not a static array: the type is inferred as int[] not int[3].
 
 static assert(__traits(isStaticArray, void[0]));
 static assert(__traits(isStaticArray, E));
@@ -237,6 +239,7 @@ $(H2 $(GNAME isAbstractClass))
         Otherwise, $(D false) is returned.
         If there are no arguments, $(D false) is returned.)
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -251,6 +254,7 @@ void main()
     writeln(__traits(isAbstractClass, int*));
 }
 ---
+)
 
         Prints:
 
@@ -296,6 +300,7 @@ $(H2 $(GNAME isDisabled))
     $(P Takes one argument and returns `true` if it's a function declaration
     marked with `@disable`.)
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 struct Foo
 {
@@ -306,15 +311,18 @@ struct Foo
 static assert(__traits(isDisabled, Foo.foo));
 static assert(!__traits(isDisabled, Foo.bar));
 ---
+)
 
     $(P For any other declaration even if `@disable` is a syntactically valid
     attribute `false` is returned because the annotation has no effect.)
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 @disable struct Bar{}
 
 static assert(!__traits(isDisabled, Bar));
 ---
+)
 
 $(H2 $(GNAME isVirtualFunction))
 
@@ -329,6 +337,7 @@ $(H2 $(GNAME isVirtualMethod))
         Final functions that don't override anything return false.
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -348,6 +357,7 @@ void main()
     writeln(__traits(isVirtualMethod, S.bar));  // false
 }
 ---
+)
 
 $(H2 $(GNAME isAbstractFunction))
 
@@ -355,6 +365,7 @@ $(H2 $(GNAME isAbstractFunction))
         $(D true) is returned, otherwise $(D false).
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -380,6 +391,7 @@ void main()
     writeln(__traits(isAbstractFunction, AC.foo));  // true
 }
 ---
+)
 
 $(H2 $(GNAME isFinalFunction))
 
@@ -387,6 +399,7 @@ $(H2 $(GNAME isFinalFunction))
         $(D true) is returned, otherwise $(D false).
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -414,6 +427,7 @@ void main()
     writeln(__traits(isFinalFunction, FC.foo)); // true
 }
 ---
+)
 
 $(H2 $(GNAME isOverrideFunction))
 
@@ -421,6 +435,7 @@ $(H2 $(GNAME isOverrideFunction))
         $(D_KEYWORD override), $(D true) is returned, otherwise $(D false).
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -442,6 +457,7 @@ void main()
     writeln(__traits(isOverrideFunction, Foo.bar));  // false
 }
 ---
+)
 
 $(H2 $(GNAME isStaticFunction))
 
@@ -458,6 +474,7 @@ $(H2 $(GNAME isRef), $(GNAME isOut), $(GNAME isLazy))
         or $(D_KEYWORD lazy), otherwise $(D false).
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 void fooref(ref int x)
 {
@@ -480,6 +497,7 @@ void foolazy(lazy int x)
     static assert(__traits(isLazy, x));
 }
 ---
+)
 
 $(H2 $(GNAME isTemplate))
 
@@ -487,12 +505,14 @@ $(H2 $(GNAME isTemplate))
         otherwise $(D false).
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 void foo(T)(){}
 static assert(__traits(isTemplate,foo));
 static assert(!__traits(isTemplate,foo!int()));
 static assert(!__traits(isTemplate,"string"));
 ---
+)
 
 $(H2 $(GNAME isZeroInit))
 
@@ -565,6 +585,7 @@ $(H2 $(GNAME hasMember))
         $(D true) is returned, otherwise $(D false).
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -586,6 +607,7 @@ void main()
     writeln(__traits(hasMember, int, "sizeof")); // true
 }
 ---
+)
 
 $(H2 $(GNAME identifier))
 
@@ -620,6 +642,7 @@ $(SECTION2 $(GNAME getAttributes),
         For more information, see: $(DDSUBLINK spec/attribute, uda, User-Defined Attributes)
     )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 @(3) int a;
 @("string", 7) int b;
@@ -631,6 +654,7 @@ pragma(msg, __traits(getAttributes, a));
 pragma(msg, __traits(getAttributes, b));
 pragma(msg, __traits(getAttributes, c));
 ---
+)
 
         Prints:
 
@@ -657,6 +681,7 @@ $(SECTION2 $(GNAME getFunctionVariadicStyle),
         $(TROW $(D "typesafe"), typesafe variadic function, array on stack, $(D void def(int[] ...)))
     )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import core.stdc.stdarg;
 
@@ -675,6 +700,7 @@ static assert(__traits(getFunctionVariadicStyle, typesafe) == "typesafe");
 static assert(__traits(getFunctionVariadicStyle, (int[] a...) {}) == "typesafe");
 static assert(__traits(getFunctionVariadicStyle, typeof(cstyle)) == "stdarg");
 ---
+)
 )
 
 $(SECTION2 $(GNAME getFunctionAttributes),
@@ -701,6 +727,7 @@ $(SECTION2 $(GNAME getFunctionAttributes),
 
     For example:
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 int sum(int x, int y) pure nothrow { return x + y; }
 
@@ -715,13 +742,16 @@ struct S
 // prints ("const", "@system")
 pragma(msg, __traits(getFunctionAttributes, S.test));
 ---
+)
 
     $(P Note that some attributes can be inferred. For example:)
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 // prints ("pure", "nothrow", "@nogc", "@trusted")
 pragma(msg, __traits(getFunctionAttributes, (int x) @trusted { return x * 2; }));
 ---
+)
 )
 
 $(H2 $(GNAME getLinkage))
@@ -742,6 +772,7 @@ $(H2 $(GNAME getLinkage))
         $(LI $(D "System"))
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 extern (C) int fooc();
 alias aliasc = fooc;
@@ -757,6 +788,7 @@ static assert(__traits(getLinkage, FooCPPStruct) == "C++");
 static assert(__traits(getLinkage, FooCPPClass) == "C++");
 static assert(__traits(getLinkage, FooCPPInterface) == "C++");
 ---
+)
 
 $(H2 $(GNAME getMember))
 
@@ -766,6 +798,7 @@ $(H2 $(GNAME getMember))
         argument as an identifier.
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -782,10 +815,11 @@ void main()
     __traits(getMember, s, "mx") = 1;  // same as s.mx=1;
     writeln(__traits(getMember, s, "m" ~ "x")); // 1
 
-    __traits(getMember, S, "mx") = 1;  // error, no this for S.mx
+    // __traits(getMember, S, "mx") = 1;  // error, no this for S.mx
     __traits(getMember, S, "my") = 2;  // ok
 }
 ---
+)
 
 $(H2 $(GNAME getOverloads))
 
@@ -797,6 +831,7 @@ $(H2 $(GNAME getOverloads))
         The result is a tuple of all the overloads of the supplied name.
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -828,6 +863,7 @@ void main()
         writeln(t.stringof);
 }
 ---
+)
 
         Prints:
 
@@ -852,6 +888,7 @@ $(H2 $(GNAME getParameterStorageClasses))
         It returns a tuple of strings representing the storage classes of that parameter.
     )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 ref int foo(return ref const int* p, scope int* a, out int b, lazy int c);
 
@@ -862,6 +899,7 @@ static assert(__traits(getParameterStorageClasses, foo, 1)[0] == "scope");
 static assert(__traits(getParameterStorageClasses, foo, 2)[0] == "out");
 static assert(__traits(getParameterStorageClasses, typeof(&foo), 3)[0] == "lazy");
 ---
+)
 
 $(H2 $(GNAME getPointerBitmap))
 
@@ -875,29 +913,34 @@ $(H2 $(GNAME getPointerBitmap))
     For type T, there are $(D T.sizeof / size_t.sizeof) possible pointers represented
     by the bits of the array values.)
     $(P This array can be used by a precise GC to avoid false pointers.)
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
-class C
+void main()
 {
-    // implicit virtual function table pointer not marked
-    // implicit monitor field not marked, usually managed manually
-    C next;
-    size_t sz;
-    void* p;
-    void function () fn; // not a GC managed pointer
-}
+    static class C
+    {
+        // implicit virtual function table pointer not marked
+        // implicit monitor field not marked, usually managed manually
+        C next;
+        size_t sz;
+        void* p;
+        void function () fn; // not a GC managed pointer
+    }
 
-struct S
-{
-    size_t val1;
-    void* p;
-    C c;
-    byte[] arr;          // { length, ptr }
-    void delegate () dg; // { context, func }
-}
+    static struct S
+    {
+        size_t val1;
+        void* p;
+        C c;
+        byte[] arr;          // { length, ptr }
+        void delegate () dg; // { context, func }
+    }
 
-static assert (__traits(getPointerBitmap, C) == [6*size_t.sizeof, 0b010100]);
-static assert (__traits(getPointerBitmap, S) == [7*size_t.sizeof, 0b0110110]);
+    static assert (__traits(getPointerBitmap, C) == [6*size_t.sizeof, 0b010100]);
+    static assert (__traits(getPointerBitmap, S) == [7*size_t.sizeof, 0b0110110]);
+}
 ---
+)
 
 
 $(H2 $(GNAME getProtection))
@@ -906,6 +949,7 @@ $(H2 $(GNAME getProtection))
         The result is a string giving its protection level: "public", "private", "protected", "export", or "package".
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -926,6 +970,7 @@ void main()
     writeln(j);
 }
 ---
+)
 
         Prints:
 
@@ -940,10 +985,12 @@ $(H2 $(GNAME getTargetInfo))
         The result is an expression describing the requested target information.
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 version (CppRuntime_Microsoft)
     static assert(__traits(getTargetInfo, "cppRuntimeLibrary") == "libcmt");
 ---
+)
 
         $(P Keys are implementation defined, allowing relevant data for exotic targets.
         A reliable subset exists which are always available:
@@ -971,6 +1018,7 @@ $(H2 $(GNAME getVirtualMethods))
         It does not include final functions that do not override anything.
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -997,6 +1045,7 @@ void main()
     writeln(i);
 }
 ---
+)
 
         Prints:
 
@@ -1026,6 +1075,7 @@ $(H2 $(GNAME getUnitTests))
                 empty tuple.
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 module foo;
 
@@ -1076,6 +1126,7 @@ void main()
         test();
 }
 ---
+)
 
         $(P By default, the above will print:)
 
@@ -1122,6 +1173,7 @@ $(H2 $(GNAME allMembers))
         Builtin properties are not included.
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -1141,6 +1193,7 @@ void main()
     // "Monitor", "factory"]
 }
 ---
+)
 
         $(P The order in which the strings appear in the result
         is not defined.)
@@ -1156,6 +1209,7 @@ $(H2 $(GNAME derivedMembers))
         Builtin properties are not included.
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -1173,6 +1227,7 @@ void main()
     writeln(a);    // ["__ctor", "__dtor", "foo"]
 }
 ---
+)
 
         $(P The order in which the strings appear in the result
         is not defined.)
@@ -1182,6 +1237,7 @@ $(H2 $(GNAME isSame))
         $(P Takes two arguments and returns bool $(D true) if they
         are the same symbol, $(D false) if not.)
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -1200,6 +1256,7 @@ void main()
     writeln(__traits(isSame, std, std)); // true
 }
 ---
+)
 
         $(P If the two arguments are expressions made up of literals
         or enums that evaluate to the same value, true is returned.)
@@ -1285,6 +1342,7 @@ $(H2 $(GNAME compiles))
 
         $(P If there are no arguments, the result is $(D false).)
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 import std.stdio;
 
@@ -1311,6 +1369,7 @@ void main()
     writeln(__traits(compiles, 1,2,3,int,long,3[1])); // false
 }
 ---
+)
 
         $(P This is useful for:)
 

--- a/tools/dspec_tester.d
+++ b/tools/dspec_tester.d
@@ -161,6 +161,7 @@ auto compileAndCheck(R)(R buffer, CompileConfig config)
 
     string[] args = [.config.dmdBinPath];
     args ~= config.args;
+    args ~= "-unittest";
     with (CompileConfig.TestMode)
     final switch (config.mode)
     {


### PR DESCRIPTION
The motivation for the new examples is to demonstrate:

* Pointers are considered scalar but not arithmetic or integral.
* `__vector`s have the same traits as their element type.
* `enum`s have the same traits as the underlying type.

Also made most of the existing code examples runnable while I was at it.