### PR TITLE
Fix broken twitter embed

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -357,9 +357,8 @@ $(DIVID news,
     <iframe src="https://forum.dlang.org/frame-discussions"></iframe>
     )
     $(DIVID twitter,
-    <a class="twitter-timeline"  href="https://twitter.com/hashtag/dlang" data-widget-id="684452777939058688">#dlang Tweets</a>
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-
+    <a class="twitter-timeline" data-height="420" href="https://twitter.com/D_Programming?ref_src=twsrc%5Etfw">Tweets by D_Programming</a>
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     )
 )
 


### PR DESCRIPTION
Twitter changed their policy and implementation for embedded timelines. They no longer allow embeds of hashtag searches. That broke the twitter box in index.html -- it was showing a link instead. This edit replaces it with an embedded timeline for @D_Programming, which is the best we can do now.