### PR TITLE
Add Discord join link to the community section

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -260,6 +260,7 @@ $(SUBMENU_MANUAL
     $(SUBMENU_LINK $(ROOT_DIR)calendar.html, Calendar)
     $(SUBMENU_LINK_DIVIDER https://forum.dlang.org, Forums)
     $(SUBMENU_LINK irc://irc.freenode.net/d, IRC)
+    $(SUBMENU_LINK https://discord.gg/fva44g2, Discord)
     $(SUBMENU_LINK https://wiki.dlang.org, Wiki)
     $(SUBMENU_LINK_DIVIDER https://github.com/dlang, GitHub)
     $(SUBMENU_LINK $(ROOT_DIR)bugstats.html, Issues)


### PR DESCRIPTION
Adds the [Discord](https://discordapp.com/) chat link for "D Language Code Club" (previously known as "D Code Club" and "Wilds Code Club") to the Community section. (in the following referred to as "Server") Discord is a lot like Slack.

The server currently has 378 members, where we usually have around 100 online users. (comparable to IRC) It is the official chat of [dplug](https://code.dlang.org/packages/dplug), [code-d](https://github.com/Pure-D/code-d) and [PowerNex](https://github.com/PowerNex/PowerNex). We have topic channels around general Programming, web development and OS development, a user-submitted D resources collection, a user-submitted D projects collection and a News channel about D news from the Announce forum and announcing new dub projects. There are also some off-topic channels. We are currently also working on a imaging library inside a channel on the server there too, which is supposed to eventually also become a GUI library. With that workgroup we are trying to improve certain areas in D.

We help a lot of users with their programming questions on the server. Currently the server is administered by @Vild, @M4GNV5 and me. @0xEAB, @rikkimax and @p0nce are additional moderators.

I think adding the Discord server to the list is a valuable addition because so far it seems that a lot of "younger" people visit our Discord instead of the IRC, which is considered a bit dated.