### PR TITLE
Revert "Add Discord join link to the community section"

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -260,7 +260,6 @@ $(SUBMENU_MANUAL
     $(SUBMENU_LINK $(ROOT_DIR)calendar.html, Calendar)
     $(SUBMENU_LINK_DIVIDER https://forum.dlang.org, Forums)
     $(SUBMENU_LINK irc://irc.freenode.net/d, IRC)
-    $(SUBMENU_LINK https://discord.gg/fva44g2, Discord)
     $(SUBMENU_LINK https://wiki.dlang.org, Wiki)
     $(SUBMENU_LINK_DIVIDER https://github.com/dlang, GitHub)
     $(SUBMENU_LINK $(ROOT_DIR)bugstats.html, Issues)


### PR DESCRIPTION
Reverts dlang/dlang.org#2539 as it was merged a bit too hastily and without any proper discussion (and as dlang.org her's auto-deployed this change is now live).