### PR TITLE
Fix nightly download links

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -261,7 +261,7 @@ Macros:
     H3I=<h3 class="download">$0</h3>
     DLSITE=http://downloads.dlang.org/releases/2.x/$(DMDV2)/$0
     B_DLSITE=http://downloads.dlang.org/pre-releases/2.x/$(B_DMDV2)/$0
-    N_DLSITE=//downloads.dlang.org/nightlies/dmd-master/$0
+    N_DLSITE=http://downloads.dlang.org/nightlies/dmd-master/$0
     DOWNLOAD =
     $(DIV,
         $(DIVC download_image, $2)


### PR DESCRIPTION
tl;dr: the S3 bucket in use doesn't support HTTP.
HTTP works: http://downloads.dlang.org/nightlies/