### PR TITLE
fix issue 19592 - Rule for IdentifierList is wrong

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -155,6 +155,7 @@ $(GNAME IdentifierList):
     $(GLINK_LEX Identifier) $(D .) $(I IdentifierList)
     $(GLINK2 template, TemplateInstance)
     $(GLINK2 template, TemplateInstance) $(D .) $(I IdentifierList)
+    $(GLINK_LEX Identifier) $(D [) $(GLINK2 expression, AssignExpression) $(D])
     $(GLINK_LEX Identifier) $(D [) $(GLINK2 expression, AssignExpression) $(D].) $(I IdentifierList)
 )
 


### PR DESCRIPTION
The problem is revealed for example when you try to follow the rules for a BaseClass made of an element of a TList.