### PR TITLE
TLS access is slower than classic global vars

### DIFF
--- a/articles/migrate-to-shared.dd
+++ b/articles/migrate-to-shared.dd
@@ -17,8 +17,8 @@ $(HEADERNAV_TOC)
 $(H2 $(LNAME2 performance, Performance of TLS variables))
 
         $(P Reading or writing TLS variables is slower than for classic
-        global variables. The exact difference depends, a.o., on compiler
-        code generation settings and the target architecture.
+        global variables. The exact difference depends, among others,
+        on compiler code generation settings and the target architecture.
         For PIC (position independent code), which is the default setting
         on Linux, TLS access is slower because a call to $(D __tls_get_addr)
         is required. However for non-PIC, the performance difference is

--- a/articles/migrate-to-shared.dd
+++ b/articles/migrate-to-shared.dd
@@ -16,14 +16,15 @@ $(HEADERNAV_TOC)
 
 $(H2 $(LNAME2 performance, Performance of TLS variables))
 
-        $(P Yes, reading or writing TLS variables will be slower
-        than for classic global variables. It'll be about 3
-        instructions rather than one.
-        But on Linux, at least, TLS will be slightly faster
-        than accessing classic globals using PIC (position
-        independent code) compiler code generation settings.
-        So it's hard to see that this would be an unacceptable
-        problem. But let's presume it is. What can we do about it?
+        $(P Reading or writing TLS variables is slower than for classic
+        global variables. The exact difference depends, a.o., on compiler
+        code generation settings and the target architecture.
+        For PIC (position independent code), which is the default setting
+        on Linux, TLS access is slower because a call to $(D __tls_get_addr)
+        is required. However for non-PIC, the performance difference is
+        smaller or even negligible.
+        Given that TLS access is slower than classic global variables,
+        what can we do about it?
         )
 
         $(OL


### PR DESCRIPTION
Fix the text discussing performance considerations of TLS globals (the difference is not 3 instructions, and TLS is not faster with or without PIC enabled).