### PR TITLE
spec: close a loophole in definition of `@trusted`

### DIFF
--- a/spec/const3.dd
+++ b/spec/const3.dd
@@ -262,14 +262,18 @@ char[] p = "world"; // error, cannot implicitly convert immutable
 
         $(P
         The second way is to cast data to immutable.
-        When doing so, it is up to the programmer to ensure that no
-        other mutable references to the same data exist.
+        When doing so, it is up to the programmer to ensure that any mutable
+        references to the same data are not used to modify the data after the
+        cast.
         )
 
 ---
-char[] s = ...;
-immutable(char)[] p = cast(immutable)s;     // undefined behavior
-immutable(char)[] p = cast(immutable)s.dup; // ok, unique reference
+char[] s = ['a'];
+s[0] = 'b'; // ok
+immutable(char)[] p = cast(immutable)s; // ok, if data is not mutated
+                                        // through s anymore
+s[0] = 'c'; // undefined behavior
+immutable(char)[] q = cast(immutable)s.dup; // always ok, unique reference
 ---
 
         $(P

--- a/spec/const3.dd
+++ b/spec/const3.dd
@@ -274,6 +274,13 @@ immutable(char)[] p = cast(immutable)s; // ok, if data is not mutated
                                         // through s anymore
 s[0] = 'c'; // undefined behavior
 immutable(char)[] q = cast(immutable)s.dup; // always ok, unique reference
+
+char[][] s2 = [['a', 'b'], ['c', 'd']];
+immutable(char[][]) p2 = cast(immutable)s2.dup; // dangerous, only the first
+                                                // level of elements is unique
+s2[0] = ['x', 'y']; // ok, doesn't affect p2
+s2[1][0] = 'z'; // undefined behavior
+immutable(char[][]) q2 = [s2[0].dup, s2[1].dup]; // always ok, unique references
 ---
 
         $(P

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2756,6 +2756,40 @@ $(H3 $(LNAME2 trusted-functions, Trusted Functions))
         ensure that these guarantees are upheld.
         )
 
+        $(P Example:)
+
+        ---
+        immutable(int)* f(int* p) @trusted
+        {
+            version (none) p[2] = 13;
+            // Invalid. p[2] is out of bounds. This line would exhibit undefined
+            // behavior.
+
+            version (none) p[1] = 13;
+            // Invalid. In this program, p[1] happens to be in-bounds, so the
+            // line would not exhibit undefined behavior, but a trusted function
+            // is not allowed to rely on this.
+
+            version (none) return cast(immutable) p;
+            // Invalid. @safe code still has mutable access and could trigger
+            // undefined behavior by overwriting the value later on.
+
+            int* p2 = new int;
+            *p2 = 42;
+            return cast(immutable) p2;
+            // Valid. No @safe code can have knowledge of p2.
+        }
+
+        void main() @safe
+        {
+            int[2] a = [10, 20];
+            int* mp = &a[0];
+            immutable(int)* ip = f(mp);
+            assert(a[1] == 20); // Guaranteed. f cannot access a[1].
+            assert(ip !is mp); // Guaranteed. f cannot introduce unsafe aliasing.
+        }
+        ---
+
         $(P Trusted functions may call safe, trusted, or system functions.
         )
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2749,8 +2749,11 @@ $(H3 $(LNAME2 trusted-functions, Trusted Functions))
 
         $(P Trusted functions are marked with the $(CODE @trusted) attribute.)
 
-        $(P Trusted functions are guaranteed by the programmer to not exhibit
-        any undefined behavior if called by a safe function.
+        $(P Trusted functions are guaranteed to not exhibit any undefined
+        behavior if called by a safe function. Furthermore, calls to trusted
+        functions cannot lead to undefined behavior in @safe code that is
+        executed afterwards. It is the responsibility of the programmer to
+        ensure that these guarantees are upheld.
         )
 
         $(P Trusted functions may call safe, trusted, or system functions.

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2751,7 +2751,7 @@ $(H3 $(LNAME2 trusted-functions, Trusted Functions))
 
         $(P Trusted functions are guaranteed to not exhibit any undefined
         behavior if called by a safe function. Furthermore, calls to trusted
-        functions cannot lead to undefined behavior in @safe code that is
+        functions cannot lead to undefined behavior in `@safe` code that is
         executed afterwards. It is the responsibility of the programmer to
         ensure that these guarantees are upheld.
         )

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2795,7 +2795,7 @@ $(H3 $(LNAME2 trusted-functions, Trusted Functions))
 
         $(P Trusted functions are covariant with safe or system functions.)
 
-        $(BEST_PRACTICE Generally, trusted functions should be kept small so
+        $(BEST_PRACTICE Trusted functions should be kept small so
         that they are easier to manually verify.
         )
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2751,14 +2751,16 @@ $(H3 $(LNAME2 trusted-functions, Trusted Functions))
 
         $(P Trusted functions are guaranteed by the programmer to not exhibit
         any undefined behavior if called by a safe function.
-        Generally, trusted functions should be kept small so that they are
-        easier to manually verify.
         )
 
         $(P Trusted functions may call safe, trusted, or system functions.
         )
 
         $(P Trusted functions are covariant with safe or system functions.)
+
+        $(BEST_PRACTICE Generally, trusted functions should be kept small so
+        that they are easier to manually verify.
+        )
 
 $(H3 $(LNAME2 system-functions, System Functions))
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2777,7 +2777,7 @@ $(H3 $(LNAME2 trusted-functions, Trusted Functions))
             int* p2 = new int;
             *p2 = 42;
             return cast(immutable) p2;
-            // Valid. No @safe code can have knowledge of p2.
+            // Valid. After f returns, no mutable aliases of p2 can exist.
         }
 
         void main() @safe


### PR DESCRIPTION
This would solidify my preferred interpretation of `@trusted` in the spec. Others have disagreed with me on what `@trusted` should mean exactly, so this might be controversial.