### PR TITLE
Remove dummy name from the vibe.d example

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -146,7 +146,6 @@ $(EXTRA_EXAMPLE Start a minimal web server,
 ----
 #!/usr/bin/env dub
 /+ dub.sdl:
-name "hello_vibed"
 dependency "vibe-d" version="~>0.8.0"
 +/
 void main()


### PR DESCRIPTION
It's been 1.5 years now since https://github.com/dlang/dub/pull/1081 has been merged.

In other words all supported D versions of Vibe.d come with a DUB with default names (>=1.5.0).