### PR TITLE
Add reference to `toDelegate` in the spec.

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2368,7 +2368,7 @@ void main()
 )
 
         $(P Function pointers can be passed to functions taking a delegate argument by passing
-        them through the $(REF toDelegate, std,funtional) template, which converts any callable
+        them through the $(REF toDelegate, std,functional) template, which converts any callable
         to a delegate without context.
         )
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2367,6 +2367,11 @@ void main()
 ---
 )
 
+        $(P Function pointers can be passed to functions taking a delegate argument by passing
+        them through the $(REF toDelegate, std,funtional) template, which converts any callable
+        to a delegate without context.
+        )
+
         $(P $(B Future directions:) Function pointers and delegates may merge
         into a common syntax and be interchangeable with each other.
         )


### PR DESCRIPTION
Documenting how function pointers can be converted to delegates, to clarify that no function overloads are necessary that replace delegates with function arguments. It complements the previous paragraph that shows that delegates can be initialized referencing any function, but they cannot be assigned like that; `toDelegate` fills that gap.

Motivated by https://forum.dlang.org/post/jueqsawmegwznoycdmjy@forum.dlang.org