### PR TITLE
Mark CatchParameter's Identifier as optional

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1579,7 +1579,7 @@ $(GNAME Catch):
     $(D catch $(LPAREN)) $(GLINK CatchParameter) $(D $(RPAREN)) $(PS0)
 
 $(GNAME CatchParameter):
-    $(GLINK2 declaration, BasicType) $(GLINK_LEX Identifier)
+    $(GLINK2 declaration, BasicType) $(GLINK_LEX Identifier)$(OPT)
 
 $(GNAME FinallyStatement):
     $(D finally) $(PS0)


### PR DESCRIPTION
This brings the spec in line with the behavior of the implementation.