### PR TITLE
Fix confusing grammar in Assignment Overload spec

### DIFF
--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -1411,7 +1411,7 @@ $(H2 $(LEGACY_LNAME2 AssignOverload, assign-overload, Identity Assignment Overlo
 
         $(P While copy construction takes care of initializing
         an object from another object of the same type,
-        assignment is defined as copying the contents of a source 
+        assignment is defined as copying the contents of a source
         object over those of a destination object, calling the
         destination object's destructor if it has one in the process:
         )

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -1412,8 +1412,8 @@ $(H2 $(LEGACY_LNAME2 AssignOverload, assign-overload, Identity Assignment Overlo
         $(P While copy construction takes care of initializing
         an object from another object of the same type,
         assignment is defined as copying the contents of a source 
-        object over those of a destination object, calling any 
-        destructors on the destination in the process:
+        object over those of a destination object, calling the
+        destination object's destructor if it has one in the process:
         )
 
         ---

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -1411,9 +1411,9 @@ $(H2 $(LEGACY_LNAME2 AssignOverload, assign-overload, Identity Assignment Overlo
 
         $(P While copy construction takes care of initializing
         an object from another object of the same type,
-        or elaborate destruction is needed for the type,
-        assignment is defined as copying the contents of one
-        object over another, already initialized, type:
+        assignment is defined as copying the contents of a source 
+        object over those of a destination object, calling any 
+        destructors on the destination in the process:
         )
 
         ---


### PR DESCRIPTION
A previous commit (823d8a4) clarified that destructors are called upon assignment to an initialized object. In doing so it spliced the sentence in a very unnatural way. I've attempted to correct the sentence grammar while preserving the semantics.

It's not clear to me if calling the dtor on assignment to initialized objects is necessary, or if it's just an optional thing the default opAssign is meant to do. I'd appreciate clarification on this.