### PR TITLE
Change Docker URL from dlanguage/dmd to dlang2/dmd-ubuntu

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -186,7 +186,7 @@ sudo apt-get update && sudo apt-get -y --allow-unauthenticated install --reinsta
 sudo apt-get update && sudo apt-get install dmd-compiler dub)
 )
 
-$(DOWNLOAD_OTHER $(DOCKER), $(LINK2 https://hub.docker.com/r/dlanguage/dmd, Docker), $(CONSOLE docker run --rm -ti -v $(DOLLAR)(pwd):/src dlanguage/dmd dmd))
+$(DOWNLOAD_OTHER $(DOCKER), $(LINK2 https://hub.docker.com/r/dlang2/dmd-ubuntu, Docker), $(CONSOLE docker run --rm -ti -v $(DOLLAR)(pwd):/src dlang2/dmd-ubuntu dmd))
 
 $(DOWNLOAD_OTHER $(OPENSUSE), $(LINK2 https://build.opensuse.org/package/show/devel:languages:D/dmd, OpenSUSE Tumbleweed), $(CONSOLE sudo zypper install dmd))
 


### PR DESCRIPTION
Download page points to [`dlanguage/dmd`](https://hub.docker.com/r/dlanguage/dmd), but it's not maintained for about 10 months.  [`dlang2/dmd-ubuntu`](https://hub.docker.com/r/dlang2/dmd-ubuntu) by @wilzbach is suitable for most of users.  See wilzbach/dlang-docker#5 