### PR TITLE
Dimensions and indices are in reverse order.

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -456,17 +456,29 @@ double[][] matrix;
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---------
-double[3][3] matrix;
+double[6][3] matrix;
 ---------
 )
 
-        $(P declares a rectangular matrix with 3 rows and 3 columns, all contiguously in memory. In
+        $(P declares a rectangular matrix with 3 rows and 6 columns, all contiguously in memory. In
         other languages, this would be called a multidimensional array and be declared as:
         )
 
 ---------
-double matrix[3,3];
+double matrix[3,6];
 ---------
+
+        $(P Note that dimensions and indices appear in opposite orders. Dimensions in the
+        $(RELATIVE_LINK2 declarations, declaration) are read right to left whereas indices are read
+        left to right:
+        )
+
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+---------
+double[6][3] matrix;
+matrix[2][5] = 3.14; // Assignment to bottom right element.
+---------
+)
 
 $(H2 $(LNAME2 array-length, Array Length))
 

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -451,22 +451,16 @@ double[][] matrix;
         pointers to the array data.) Since the arrays can have varying sizes (being dynamically
         sized), this is sometimes called "jagged" arrays. Even worse for optimizing the code, the
         array rows can sometimes point to each other! Fortunately, D static arrays, while using
-        the same syntax, are implemented as a fixed rectangular layout:
+        the same syntax, are implemented as a fixed rectangular layout in a contiguous block of
+        memory:
         )
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---------
-double[6][3] matrix;
+double[6][3] matrix = 0; // Sets all elements to 0.
+writeln(matrix); // [[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]]
 ---------
 )
-
-        $(P declares a rectangular matrix with 3 rows and 6 columns, all contiguously in memory. In
-        other languages, this would be called a multidimensional array and be declared as:
-        )
-
----------
-double matrix[3,6];
----------
 
         $(P Note that dimensions and indices appear in opposite orders. Dimensions in the
         $(RELATIVE_LINK2 declarations, declaration) are read right to left whereas indices are read
@@ -475,8 +469,11 @@ double matrix[3,6];
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---------
-double[6][3] matrix;
+double[6][3] matrix = 0;
 matrix[2][5] = 3.14; // Assignment to bottom right element.
+writeln(matrix); // [[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 3.14]]
+
+static assert(!__traits(compiles, matrix[5][2])); // Array index out of bounds.
 ---------
 )
 


### PR DESCRIPTION
Remove ambiguity in rectangular array example and stress that dimensions and indices are in reverse order of each other. 

I keep making the mistake of giving the dimensions in the wrong order. I think ordering is confusing and different from other languages, so deserve a prominent reminder.