### PR TITLE
Link users to the OpenCollective main page

### DIFF
--- a/foundation/donate.dd
+++ b/foundation/donate.dd
@@ -61,7 +61,7 @@ $(DONATE_ITEM Donate through OpenCollective, users,
     a note letting us know!
     $(BR) $(BR)
 
-<a href="https://opencollective.com/dlang/donate" target="_blank">
+<a href="https://opencollective.com/dlang" target="_blank">
   <img src="https://opencollective.com/dlang/donate/button@2x.png?color=blue" width=250 />
 </a>
 )


### PR DESCRIPTION
To avoid this from happening:

![image](https://user-images.githubusercontent.com/4370550/55690672-ea278080-5994-11e9-906b-1739b55ac11e.png)
