### PR TITLE
Correct install options for install.sh

### DIFF
--- a/install.dd
+++ b/install.dd
@@ -112,7 +112,7 @@ $(H4 Options)
 
 $(DL
     $(DT
-        $(SWITCH $(SWNAME -a) $(SWNAME --active),
+        $(SWITCH $(SWNAME -a) $(SWNAME --activate),
             Only prints the path to the activate script)
         $(SWITCH $(SWNAME dmd|ldc|gdc),
             Installs the latest version of a compiler)


### PR DESCRIPTION
The `--active` option is incorrect, it is actually `--activate`.