### PR TITLE
Add LDC to list of snap packages available to download

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -192,7 +192,14 @@ $(DOWNLOAD_OTHER $(OPENSUSE), $(LINK2 https://build.opensuse.org/package/show/de
 
 
 $(DOWNLOAD_OTHER $(SNAP), $(LINK2 https://snapcraft.io/dmd, Snap),
-    $(CONSOLE sudo snap install --classic dmd && sudo snap install --classic dub))
+    $(CONSOLE # install DMD compiler (including RDMD)
+sudo snap install --classic dmd
+
+# install DUB package/build manager
+sudo snap install --classic dub
+
+# install LDC compiler with LLVM backend
+sudo snap install --classic ldc2))
 
 $(H2 Other Downloads)
 


### PR DESCRIPTION
As presented in my DConf 2019 lightning talk, there is a big discrepancy in usage between the DMD and DUB snap packages, and LDC.  One might well assume that this is because the first two are listed on the downoad page but LDC is not.

This patch corrects the discrepancy, and splits out the install commands into separate lines with helpful comments.