### PR TITLE
Fix typo in code

### DIFF
--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -199,7 +199,7 @@ $(H3 $(LNAME2 slice_unary_operators, Overloading Slice Unary Operators))
 
         $(P For backward compatibility, if the above rewrites fail and
         $(D opSliceUnary) is defined, then the rewrites
-        $(D a.opSliceUnary!(op)(a, i, j)) and
+        $(D a.opSliceUnary!(op)(i, j)) and
         $(D a.opSliceUnary!(op)) are tried instead, respectively.)
 
 $(H2 $(LEGACY_LNAME2 Cast, cast, Cast Operator Overloading))

--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -197,7 +197,7 @@ $(H3 $(LNAME2 slice_unary_operators, Overloading Slice Unary Operators))
         )
         )
 
-        $(P For backward compatibility, if the above rewrites fail and
+        $(P For backward compatibility, if the above rewrites fail to compile and
         $(D opSliceUnary) is defined, then the rewrites
         $(D a.opSliceUnary!(op)(i, j)) and
         $(D a.opSliceUnary!(op)) are tried instead, respectively.)


### PR DESCRIPTION
> For backward compatibility [...] the rewrites `a.opSliceUnary!(op)(a, i, j)` [...] are tried instead, respectively.

To:

> For backward compatibility [...] the rewrites `a.opSliceUnary!(op)(i, j)` [note: without `a` in parameter list] [...] are tried instead, respectively.

The compiler does not do the former rewrite, and looks like a small error.