### PR TITLE
Fixes 19944 - Unit test failures in std.file

### DIFF
--- a/js/run_examples.js
+++ b/js/run_examples.js
@@ -28,7 +28,7 @@ function wrapIntoMain(code) {
         var codeOut = "void main()\n{\n";
         codeOut += "    import " + currentPackage + ";\n";
         // writing to the stdout is probably often used
-        codeOut += "    import std.stdio: write, writeln, writef, writefln;\n    ";
+        codeOut += (currentPackage == "std.file") ? "    import std.stdio: writeln, writef, writefln;\n    " : "    import std.stdio: write, writeln, writef, writefln;\n    ";
         codeOut += code.split("\n").join("\n    ");
         codeOut += "\n}";
     }


### PR DESCRIPTION
Issue in focus: https://issues.dlang.org/show_bug.cgi?id=19944

The appending of `import std.stdio: write, writeln, writef, writefln;` to the code conflicts when trying to access `std.file.write`

Before:
![alt text](https://i.imgur.com/Yhc6QTV.png)

After:
![alt text](https://i.imgur.com/IA7zSkO.png)