### PR TITLE
download.dd: Fix local DMD link

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -8,8 +8,8 @@ $(TABLEC download-compilers,
     $(H2 Choose a compiler)
   )
   $(TR
-    $(TD $(LINK2 #dmd                                         , $(IMG compiler-dmd.png)))
-    $(TD $(LINK2 http://gdcproject.org/downloads              , $(IMG compiler-gdc.svg)))
+    $(TD $(LINK2 #dmd,                                               $(IMG compiler-dmd.png)))
+    $(TD $(LINK2 http://gdcproject.org/downloads,                    $(IMG compiler-gdc.svg)))
     $(TD $(LINK2 https://github.com/ldc-developers/ldc#installation, $(IMG compiler-ldc.png)))
   )
   $(TR


### PR DESCRIPTION
Trailing whitespace caused the link to be broken in some Firefox versions.