### PR TITLE
update example of UDA using the "alias equal traits" syntax

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -739,16 +739,11 @@ pragma(msg, __traits(getAttributes, s)); // prints tuple('c')
         )
 
 ---
-template Tuple (T...)
-{
-    alias Tuple = T;
-}
-
 enum EEE = 7;
 @("hello") struct SSS { }
 @(3) { @(4) @EEE @SSS int foo; }
 
-alias TP = Tuple!(__traits(getAttributes, foo));
+alias TP = __traits(getAttributes, foo);
 
 pragma(msg, TP); // prints tuple(3, 4, 7, (SSS))
 pragma(msg, TP[2]); // prints 7


### PR DESCRIPTION
Is allowed by spec since a few months but is fixed only since https://github.com/dlang/dmd/pull/10144 so now the use can be encouraged.