### PR TITLE
Fix alphabetic order

### DIFF
--- a/orgs-using-d.dd
+++ b/orgs-using-d.dd
@@ -21,15 +21,6 @@ $(DIVC orgs-using-d center,
             $(FA_TESTIMONIAL) $(I $(HTTP tech.adroll.com/blog/data/2014/11/17/d-is-for-data-science.html, D is for Data Science))
          )
     )
-    $(DORG Autonomous Intelligent Driving GmbH - subsidiary of AUDI AG, https://aid-driving.eu, aid-driving.png,
-        Autonomous Driving,
-        $(FA_QUOTE
-            For us, the future isn’t about merely making vehicles more autonomous, it’s about making people more autonomous. D helps us accomplish this mission in the verification and validation process.
-        )
-        $(LINK_ROW
-            $(FA_HIRING aid-driving.eu/jobs)
-        )
-    )
     $(DORG ArabiaWeather, http://corporate.arabiaweather.com, arabiaweather.png,
         Leading weather services provider in the Arab world,
         $(FA_QUOTE
@@ -58,6 +49,15 @@ $(DIVC orgs-using-d center,
             $(FA_GITHUB AuburnSounds/dplug) $(FA_SEPARATOR)
             $(FA_TESTIMONIAL) $(LINK2 http://www.auburnsounds.com/blog/2016-02-08_Making-a-Windows-VST-plugin-with-D.html, Testimonial)
          )
+    )
+    $(DORG Autonomous Intelligent Driving GmbH - subsidiary of AUDI AG, https://aid-driving.eu, aid-driving.png,
+        Autonomous Driving,
+        $(FA_QUOTE
+            For us, the future isn’t about merely making vehicles more autonomous, it’s about making people more autonomous. D helps us accomplish this mission in the verification and validation process.
+        )
+        $(LINK_ROW
+            $(FA_HIRING aid-driving.eu/jobs)
+        )
     )
     $(DORG CERERIS, http://www.myriad-corp.com, cereris.png,
         Hardware and Software development,


### PR DESCRIPTION
While the current order seems reasonable when arguing that "Autonomous Intelligent Driving" may be abbreviated by "AID", then also "ArabiaWeather" -> "AW" and "Symmetry Investments" -> "SI" would need to sit in different positions.