### PR TITLE
fix Issue 19402 - specs for promotion rule of shift exp is wrong (without anything else)

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -724,7 +724,7 @@ $(GNAME ShiftExpression):
     $(I ShiftExpression) $(D >)$(D >)$(D >) $(GLINK AddExpression)
 )
 
-    $(P The operands must be integral types, and undergo the $(USUAL_ARITHMETIC_CONVERSIONS).
+    $(P The operands must be integral types, and undergo the $(INTEGER_PROMOTIONS).
         The result type is the type of the left operand after
         the promotions. The result value is the result of shifting the bits
         by the right operand's value.


### PR DESCRIPTION
There already is #2578 attempting to fix it, but that is stalled because it also attempts to describe shift amounts out of range as undefined behavior, which is not agreed upon. In the mean time the blatant error in the spec persists, so this PR addresses only that so it can be merged sooner.