### PR TITLE
Add community Discord join link to the community section

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -261,6 +261,7 @@ $(SUBMENU_MANUAL
     $(SUBMENU_LINK $(ROOT_DIR)calendar.html, Calendar)
     $(SUBMENU_LINK_DIVIDER https://forum.dlang.org, Forums)
     $(SUBMENU_LINK irc://irc.freenode.net/d, IRC)
+    $(SUBMENU_LINK https://discord.gg/bMZk9Q4, Community Discord)
     $(SUBMENU_LINK https://wiki.dlang.org, Wiki)
     $(SUBMENU_LINK_DIVIDER https://github.com/dlang, GitHub)
     $(SUBMENU_LINK $(ROOT_DIR)bugstats.html, Issues)


### PR DESCRIPTION
Old PR: https://github.com/dlang/dlang.org/pull/2539
Old reverted in: https://github.com/dlang/dlang.org/pull/2541

I've recreated this PR after this topic have been brought up again in our Discord server.
We still think that it would be a good idea to have a more official and visible Discord server for those that prefer Discord over IRC. As brought up in the other PR we are willing to make changes to the server, if requested. Difference from the last PR is that it now says "Community Discord" instead of just "Discord".

**This should not be merged without further discussion and approval of multiple people.**

---
Text from the old PR:

Adds the Discord chat link for "D Language Code Club" (previously known as "D Code Club" and "Wilds Code Club") to the Community section. (in the following referred to as "Server") Discord is a lot like Slack.

The server currently has 500 members, where we usually have around 100 online users. (comparable to IRC) It is the official chat of dplug, code-d and PowerNex. We have topic channels around general Programming, web development and OS development, a user-submitted D resources collection, a user-submitted D projects collection and a News channel about D news from the Announce forum and announcing new dub projects. There are also some off-topic channels. We are currently also working on a imaging library inside a channel on the server there too, which is supposed to eventually also become a GUI library. With that workgroup we are trying to improve certain areas in D.

We help a lot of users with their programming questions on the server. Currently the server is administered by @WebFreak001, @M4GNV5 and me. @0xEAB, @rikkimax and @p0nce are additional moderators.

I think adding the Discord server to the list is a valuable addition because so far it seems that a lot of "younger" people visit our Discord instead of the IRC, which is considered a bit dated.