### PR TITLE
Improve front page for small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1552,11 +1552,13 @@ textarea.d_code_stdin, textarea.d_code_args
     background: white;
     margin-left: 2px;
     outline: none;
+    hyphens: none;
 }
 
 pre.d_code_output {
     border: none;
     max-height: 30em;
+    overflow: auto;
 }
 
 div.d_code {margin: 0; padding: 0; background: #F5F5F5;}
@@ -1571,6 +1573,16 @@ div.d_code_output, div.d_code_stdin, div.d_code_args, div.d_code_unittest
 }
 
 .d_code_title {font-weight: bold;padding: 5px;}
+
+@media only screen and (max-width: 500px)
+{
+    pre.d_code
+    {
+        overflow-x: auto;
+        white-space: pre;
+        word-wrap: unset;
+    }
+}
 
 .CodeMirror-wrap {padding: 3px;}
 .CodeMirror {line-height: normal; border: 1px solid #CCC; background: #FCFCFC; height: auto}

--- a/css/style.css
+++ b/css/style.css
@@ -1574,14 +1574,11 @@ div.d_code_output, div.d_code_stdin, div.d_code_args, div.d_code_unittest
 
 .d_code_title {font-weight: bold;padding: 5px;}
 
-@media only screen and (max-width: 500px)
+pre.d_code
 {
-    pre.d_code
-    {
-        overflow-x: auto;
-        white-space: pre;
-        word-wrap: unset;
-    }
+    overflow-x: auto;
+    white-space: pre;
+    word-wrap: unset;
 }
 
 .CodeMirror-wrap {padding: 3px;}

--- a/index.dd
+++ b/index.dd
@@ -768,6 +768,7 @@ Macros:
             padding-left: 1em;
             position: relative;
             width: 32em;
+            max-width: 32em;
         }
 
         body#Home #content > .intro #your-code-here .tip


### PR DESCRIPTION
adds scroll bars to non-fitting output & to readonly code starting at 500px

before:
![unmodified frontpage](https://wfr.moe/f6jjB6.png)
![unmodified output](https://wfr.moe/f6jUOg.png)

after:
![modified frontpage](https://wfr.moe/f6jjk8.png)
![modified output](https://wfr.moe/f6j4p8.png)