### PR TITLE
Update the eBay tsv-utils repo URL to the new name.

### DIFF
--- a/areas-of-d-usage.dd
+++ b/areas-of-d-usage.dd
@@ -212,7 +212,7 @@ $(AREA_SECTION3 $(LNAME2 data_science, Data science), $(ARTICLE_FA_ICON area-cha
     Read Adroll's testimonial
     $(HTTP tech.adroll.com/blog/data/2014/11/17/d-is-for-data-science.html, "D is for Data Science")
     on why D is a keystone language for their critical infrastructure.
-    eBay recently open-sourced their internal $(HTTPS github.com/eBay/tsv-utils-dlang, data processing utilities)
+    eBay recently open-sourced their internal $(HTTPS github.com/eBay/tsv-utils, data processing utilities)
     used in their large-scale data mining environment.
 ))
 

--- a/orgs-using-d.dd
+++ b/orgs-using-d.dd
@@ -83,7 +83,7 @@ $(DIVC orgs-using-d center,
             Large scale data mining tools.
             $(HTTPS dlang.org/blog/2017/05/24/faster-command-line-tools-in-d/, Command line tools in D)
             $(LINK_ROW
-                $(FA_GITHUB eBay/tsv-utils-dlang)
+                $(FA_GITHUB eBay/tsv-utils)
             )
     )
     $(DORG ecratum, http://www.ecratum.com, ecratum.png,


### PR DESCRIPTION
The github repo for eBay's TSV Utilities was changed from `eBay/tsv-utils-dlang` to `eBay/tsv-utils` last year. This PR updates the url references to point to the new location.