### PR TITLE
Revert PR1914: `inout ref` parameters imply `return` attribute

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1496,15 +1496,6 @@ void venus()
 }
 ---
 
-$(P `inout ref` parameters imply the `return` attribute.)
-
----
-inout(int)* neptune(inout ref int i)
-{
-    return &i;  // ok
-}
----
-
 $(H3 $(LNAME2 return-scope-parameters, Return Scope Parameters))
 
         $(P Parameters marked as `return scope` that contain indirections


### PR DESCRIPTION
Reverts #1914 

In support of https://github.com/dlang/dmd/pull/10390