### PR TITLE
[SAOC] [WIP] Rvalue ref attribute

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -41,6 +41,7 @@ $(GNAME AtAttribute):
     $(D @) $(RELATIVE_LINK2 safe, $(D safe))
     $(D @) $(RELATIVE_LINK2 safe, $(D system))
     $(D @) $(RELATIVE_LINK2 safe, $(D trusted))
+    $(GLINK RvalueRef)
     $(GLINK UserDefinedAttribute)
 
 $(GNAME Property):
@@ -49,6 +50,9 @@ $(GNAME Property):
 $(GNAME DeclarationBlock):
     $(GLINK2 module, DeclDef)
     $(D {) $(GLINK2 module, DeclDefs)$(OPT) $(D })
+
+$(GNAME RvalueRef):
+    $(D @ rvalue ref)
 )
 
         $(P Attributes are a way to modify one or more declarations.

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -187,6 +187,7 @@ $(MULTICOLS 5,     $(GLINK2 attribute, LinkageAttribute)
     $(D nothrow)
     $(D pure)
     $(D ref))
+    $(GLINK2 attribute, RvalueRef)
 )
 
 $(GRAMMAR

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1621,11 +1621,15 @@ $(H3 $(LNAME2 function_literals, Function Literals))
 
 $(GRAMMAR
 $(GNAME FunctionLiteral):
-    $(D function) $(D ref)$(OPT) $(GLINK2 declaration, Type)$(OPT) $(GLINK ParameterWithAttributes) $(OPT) $(GLINK FunctionLiteralBody)
-    $(D delegate) $(D ref)$(OPT) $(GLINK2 declaration, Type)$(OPT) $(GLINK ParameterWithMemberAttributes) $(OPT) $(GLINK FunctionLiteralBody)
-    $(D ref)$(OPT) $(GLINK ParameterMemberAttributes) $(GLINK FunctionLiteralBody)
+    $(D function) $(GLINK Ref)$(OPT) $(GLINK2 declaration, Type)$(OPT) $(GLINK ParameterWithAttributes) $(OPT) $(GLINK FunctionLiteralBody)
+    $(D delegate) $(GLINK Ref)$(OPT) $(GLINK2 declaration, Type)$(OPT) $(GLINK ParameterWithMemberAttributes) $(OPT) $(GLINK FunctionLiteralBody)
+    $(GLINK Ref)$(OPT) $(GLINK ParameterMemberAttributes) $(GLINK FunctionLiteralBody)
     $(GLINK FunctionLiteralBody)
     $(GLINK Lambda)
+
+$(GNAME Ref):
+    $(GLINK2 attribute, RvalueRef)
+    $(D ref)
 
 $(GNAME ParameterWithAttributes):
     $(GLINK2 function, Parameters) $(GLINK2 function, FunctionAttributes)$(OPT)
@@ -1775,9 +1779,9 @@ $(H3 $(LNAME2 lambdas, Lambdas))
 
 $(GRAMMAR
 $(GNAME Lambda):
-    $(D function) $(D ref)$(OPT) $(GLINK2 declaration, Type)$(OPT) $(GLINK ParameterAttributes) $(D =>) $(GLINK AssignExpression)
-    $(D delegate) $(D ref)$(OPT) $(GLINK2 declaration, Type)$(OPT) $(GLINK ParameterMemberAttributes) $(D =>) $(GLINK AssignExpression)
-    $(D ref)$(OPT) $(GLINK ParameterMemberAttributes) $(D =>) $(GLINK AssignExpression)
+    $(D function) $(GLINK Ref)$(OPT) $(GLINK2 declaration, Type)$(OPT) $(GLINK ParameterAttributes) $(D =>) $(GLINK AssignExpression)
+    $(D delegate) $(GLINK Ref)$(OPT) $(GLINK2 declaration, Type)$(OPT) $(GLINK ParameterMemberAttributes) $(D =>) $(GLINK AssignExpression)
+    $(GLINK Ref)$(OPT) $(GLINK ParameterMemberAttributes) $(D =>) $(GLINK AssignExpression)
     $(IDENTIFIER) $(D =>) $(GLINK AssignExpression)
 )
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1008,6 +1008,7 @@ $(GRAMMAR
 $(GNAME CastExpression):
     $(D cast $(LPAREN)) $(GLINK2 declaration, Type) $(D $(RPAREN)) $(GLINK UnaryExpression)
     $(D cast $(LPAREN)) $(GLINK2 declaration, TypeCtors)$(OPT) $(D $(RPAREN)) $(GLINK UnaryExpression)
+    $(D cast $(LPAREN) @ rvalue ref $(RPAREN))
 )
 
     $(P A $(I CastExpression) converts the $(I UnaryExpression)

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -59,6 +59,7 @@ $(GNAME InOut):
     $(D ref)
     $(RELATIVE_LINK2 return-ref-parameters, $(D return ref))
     $(D scope)
+    $(GLINK2 attribute, RvalueRef)
 )
 
 $(H3 Function attributes)

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -40,6 +40,7 @@ $(GNAME TraitsKeyword):
     $(GLINK isOverrideFunction)
     $(GLINK isTemplate)
     $(GLINK isRef)
+    $(GLINK isRvalueRef)
     $(GLINK isOut)
     $(GLINK isLazy)
     $(GLINK isReturnOnStack)


### PR DESCRIPTION
This is the grammar definition of the `@rvalue ref` attribute.

DMD implementation: https://github.com/dlang/dmd/pull/10426.