### PR TITLE
[SAOC] [WIP] Rvalue type constructor

### DIFF
--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -481,6 +481,7 @@ $(GNAME TypeModifiers):
     $(GLINK Shared) $(GLINK Wild)
     $(GLINK Shared) $(GLINK Wild) $(GLINK Const)
     $(GLINK Immutable)
+    $(GLINK Rvalue)
 
 $(GNAME Shared):
     $(B O)
@@ -493,6 +494,12 @@ $(GNAME Immutable):
 
 $(GNAME Wild):
     $(B Ng)
+
+$(GNAME Wild):
+    $(B Ng)
+
+$(GNAME Rvalue):
+    $(B Nr)
 
 $(GNAME TypeArray):
     $(B A) $(GLINK Type)

--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -41,6 +41,7 @@ $(GNAME AtAttribute):
     $(D @) $(RELATIVE_LINK2 safe, $(D safe))
     $(D @) $(RELATIVE_LINK2 safe, $(D system))
     $(D @) $(RELATIVE_LINK2 safe, $(D trusted))
+    $(D @ rvalue)
     $(GLINK UserDefinedAttribute)
 
 $(GNAME Property):

--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -33,6 +33,7 @@ $(GNAME Attribute):
     $(RELATIVE_LINK2 pure, $(D pure))
     $(RELATIVE_LINK2 ref, $(D ref))
     $(RELATIVE_LINK2 return, $(D return))
+    $(D __rvalue)
 
 $(GNAME AtAttribute):
     $(D @) $(RELATIVE_LINK2 disable, $(D disable))

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -95,6 +95,7 @@ $(GNAME TypeCtor):
     $(D inout)
     $(D shared)
     $(D @ rvalue)
+    $(D __rvalue)
 
 $(GNAME BasicType):
     $(GLINK BasicTypeX)
@@ -189,6 +190,7 @@ $(MULTICOLS 5,     $(GLINK2 attribute, LinkageAttribute)
     $(D pure)
     $(D ref))
     $(D @ rvalue)
+    $(D __rvalue)
 )
 
 $(GRAMMAR

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -94,6 +94,7 @@ $(GNAME TypeCtor):
     $(D immutable)
     $(D inout)
     $(D shared)
+    $(D @ rvalue)
 
 $(GNAME BasicType):
     $(GLINK BasicTypeX)
@@ -187,6 +188,7 @@ $(MULTICOLS 5,     $(GLINK2 attribute, LinkageAttribute)
     $(D nothrow)
     $(D pure)
     $(D ref))
+    $(D @ rvalue)
 )
 
 $(GRAMMAR

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2047,6 +2047,7 @@ $(GNAME TypeSpecialization):
     $(D inout)
     $(D shared)
     $(D @ rvalue)
+    $(D __rvalue)
     $(D return)
     $(D __parameters)
     $(D module)

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2046,6 +2046,7 @@ $(GNAME TypeSpecialization):
     $(D immutable)
     $(D inout)
     $(D shared)
+    $(D @ rvalue)
     $(D return)
     $(D __parameters)
     $(D module)


### PR DESCRIPTION
Grammar definition for `@rvalue` / `__rvalue` type constructor.

DMD implementation: https://github.com/dlang/dmd/pull/10426
