### PR TITLE
spec/interfaceToC update: add warning about non-toplevel uses of extern (C)

### DIFF
--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -60,7 +60,7 @@ int myDfunction(char[] s)
         such as $(D extern (C)).)
         
         $(LI The strcmp declaration was toplevel. A nested declaration may well $(LINK2
-        https://issues.dlang.org/buglist.cgi?quicksearch=extern%20%28C%29 not do what you want),
+        https://issues.dlang.org/buglist.cgi?quicksearch=extern%20%28C%29, not do what you want),
         for example it may change calling conventions but not mangling.)
 
         $(LI There is no volatile type modifier in D. To declare a C function that uses

--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -59,9 +59,8 @@ int myDfunction(char[] s)
         $(LINK2 attribute.html#linkage, linkage attributes),
         such as $(D extern (C)).)
         
-        $(LI The strcmp declaration was toplevel. A nested declaration may well $(LINK2
-        https://issues.dlang.org/buglist.cgi?quicksearch=extern%20%28C%29, not do what you want),
-        for example it may change calling conventions but not mangling.)
+        $(LI The C function was declared at module scope. A nested declaration
+        with $(D extern (C)) will have C calling conventions but D name-mangling.)
 
         $(LI There is no volatile type modifier in D. To declare a C function that uses
         volatile, just drop the keyword from the declaration.)

--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -58,7 +58,7 @@ int myDfunction(char[] s)
         in D. These are handled by
         $(LINK2 attribute.html#linkage, linkage attributes),
         such as $(D extern (C)).)
-        
+
         $(LI The C function was declared at module scope. A nested declaration
         with $(D extern (C)) will have C calling conventions but D name-mangling.)
 

--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -58,6 +58,10 @@ int myDfunction(char[] s)
         in D. These are handled by
         $(LINK2 attribute.html#linkage, linkage attributes),
         such as $(D extern (C)).)
+        
+        $(LI The strcmp declaration was toplevel. A nested declaration may well $(LINK2
+        https://issues.dlang.org/buglist.cgi?quicksearch=extern%20%28C%29 not do what you want),
+        for example it may change calling conventions but not mangling.)
 
         $(LI There is no volatile type modifier in D. To declare a C function that uses
         volatile, just drop the keyword from the declaration.)


### PR DESCRIPTION
The link is to https://issues.dlang.org/buglist.cgi?quicksearch=extern%20%28C%29 , with seven issues, five of which are expressions of surprise at the current behavior. I found these issues and the recent change to `extern (C)` in mixin templates after independently making my own expression of surprise about an undefined reference to a mangled 'puts' in:

```d
#! /usr/bin/env rdmd

void main() {
    import std.string : toStringz;
    extern (C) int puts(const(char)* s);

    puts("Hello, world!".toStringz);
}
```