### PR TITLE
Update extern(C++) grammar to support string namespaces

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -90,6 +90,7 @@ $(GNAME LinkageType):
 
 $(GNAME NamespaceList):
     $(GLINK2 expression, ConditionalExpression)
+    $(GLINK2 expression, ConditionalExpression)$(COMMA)
     $(GLINK2 expression, ConditionalExpression)$(COMMA) $(I NamespaceList)
 )
 

--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -78,6 +78,7 @@ $(GRAMMAR
 $(GNAME LinkageAttribute):
     $(D extern) $(D $(LPAREN)) $(GLINK LinkageType) $(D $(RPAREN))
     $(D extern) $(D $(LPAREN)) $(D C++), $(GLINK2 declaration, IdentifierList) $(D $(RPAREN))
+    $(D extern) $(D $(LPAREN)) $(D C++), $(GLINK2 attribute, NamespaceList) $(D $(RPAREN))
 
 $(GNAME LinkageType):
     $(D C)
@@ -86,6 +87,10 @@ $(GNAME LinkageType):
     $(D Windows)
     $(D System)
     $(D Objective-C)
+
+$(GNAME NamespaceList):
+    $(GLINK2 expression, ConditionalExpression)
+    $(GLINK2 expression, ConditionalExpression)$(COMMA) $(I NamespaceList)
 )
 
         $(P D provides an easy way to call C functions and operating


### PR DESCRIPTION
The grammar is missing the string-style `extern(C++, "a", "b")` declaration. The `ArgumentList` isn't quite right here as it allows a trailing comma but the current implementation in dmd does not. However, this seems more like a bug in dmd since it's inconsistent with the rest of the grammar.