### PR TITLE
(trivial) fix lunesu.com link by adding www.

### DIFF
--- a/spec/interface.dd
+++ b/spec/interface.dd
@@ -294,7 +294,7 @@ $(SECTION2 $(LEGACY_LNAME2 COM-Interfaces, com-interfaces, COM Interfaces),
     )
 
     $(P For more information, see
-    $(LINK2 http://lunesu.com/uploads/ModernCOMProgramminginD.pdf, Modern COM Programming in D)
+    $(LINK2 http://www.lunesu.com/uploads/ModernCOMProgramminginD.pdf, Modern COM Programming in D)
     )
 
 )


### PR DESCRIPTION
This link from the Interfaces section of the spec is broken currently. If you've been to the correct link, your browser can silently fix it, and then hide the 'www.' prefix in the address bar to further confuse. Best to check with curl:

```
$ curl -I http://lunesu.com/uploads/ModernCOMProgramminginD.pdf
curl: (7) Failed to connect to lunesu.com port 80: Connection refused

$ curl -I http://www.lunesu.com/uploads/ModernCOMProgramminginD.pdf
HTTP/1.1 200 OK
Server: GitHub.com
Content-Type: application/pdf
...
```