### PR TITLE
hashmap: document that structs automatically generate specialized opEquals/toHash that recurse over fields

### DIFF
--- a/spec/hash-map.dd
+++ b/spec/hash-map.dd
@@ -123,8 +123,8 @@ $(H2 $(LNAME2 using_struct_as_key, Using Structs or Unions as the KeyType))
 
         $(P If the $(I KeyType) is a struct or union type,
         a default mechanism is used
-        to compute the hash and comparisons of it based on the binary
-        data within the struct value. A custom mechanism can be used
+        to compute the hash and comparisons of it based on the
+        fields of the struct value. A custom mechanism can be used
         by providing the following functions as struct members:
         )
 


### PR DESCRIPTION
Consider the following code:

```
struct A
{
    string s;
}

void main()	
{
    assert(A("foo".idup) in [A("foo".idup): 2]);
}
```
It is plain to see that this code can only succeed if structs automatically generate opEquals/toHash that walk the struct's fields and call opEquals/toHash recursively. However, the documentation currently asserts that hashmaps do not do this:

> If the _KeyType_ is a struct or union type, a default mechanism is used to compute the hash and comparisons of it based on the **binary data** within the struct value.

(emphasis mine)

That is, the documentation currently implies that hashmaps perform a "flat" comparison, when the two "foo" strings would require a "deep" comparison.

As can be seen by throwing this code into run.dlang.io, this code started working in either 2.065 or 2.066. Also, an inspection of assembly shows that equality and hashing functions are in fact being generated and specialized for string comparison. As such, the documentation seems to be wrong. PR fixes it.