### PR TITLE
Partially revert "Fix bug in code example"

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -640,11 +640,12 @@ import core.stdc.stdlib;
 void livingDangerously()
 {
     // Access to C's malloc and free primitives
-    auto buf = malloc(1024 * 1024);
+    enum bytes = float.sizeof * 1024 * 1024;
+    auto buf = malloc(bytes);
     // free automatically upon scope exit
     scope(exit) free(buf);
     // Interprets memory as an array of floats
-    auto floats = cast(float[]) buf[0 .. 1024 * 1024];
+    auto floats = cast(float[]) buf[0 .. bytes];
     // Even stack allocation is possible
     auto moreBuf = alloca(4096 * 100);
     //...

--- a/index.dd
+++ b/index.dd
@@ -640,7 +640,7 @@ import core.stdc.stdlib;
 void livingDangerously()
 {
     // Access to C's malloc and free primitives
-    auto buf = malloc(float.sizeof * 1024 * 1024);
+    auto buf = malloc(1024 * 1024);
     // free automatically upon scope exit
     scope(exit) free(buf);
     // Interprets memory as an array of floats


### PR DESCRIPTION
This reverts commit 8c3e5ea9d334864477c526a5cdddabbfc1b3946b.

`buf[0 .. 1024 * 1024]` creates a `void[]`  (length 1024 * 1024) which is then casted to a `float[]` (length ((1024 * 1024)) / float.sizeof)