### PR TITLE
add FunctionAttributeKwd to grammar to factor out redundancy

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -29,10 +29,13 @@ $(GNAME Attribute):
     $(RELATIVE_LINK2 shared, $(D shared))
     $(RELATIVE_LINK2 gshared, $(D __gshared))
     $(GLINK AtAttribute)
-    $(RELATIVE_LINK2 nothrow, $(D nothrow))
-    $(RELATIVE_LINK2 pure, $(D pure))
+    $(GLINK FunctionAttributeKwd)
     $(RELATIVE_LINK2 ref, $(D ref))
     $(RELATIVE_LINK2 return, $(D return))
+
+$(GNAME FunctionAttributeKwd):
+    $(RELATIVE_LINK2 nothrow, $(D nothrow))
+    $(RELATIVE_LINK2 pure, $(D pure))
 
 $(GNAME AtAttribute):
     $(D @) $(RELATIVE_LINK2 disable, $(D disable))

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -69,8 +69,7 @@ $(GNAME FunctionAttributes):
     $(GLINK FunctionAttribute) $(I FunctionAttributes)
 
 $(GNAME FunctionAttribute):
-    $(D nothrow)
-    $(D pure)
+    $(GLINK2 attribute, FunctionAttributeKwd)
     $(GLINK2 attribute, Property)
 
 $(GNAME MemberFunctionAttributes):


### PR DESCRIPTION
Having `nothrow` and `pure` appearing twice for function attributes should be tightened up.
