### PR TITLE
Bring eponymous template spec in line with implementation

### DIFF
--- a/spec/template.dd
+++ b/spec/template.dd
@@ -906,9 +906,8 @@ $(H2 $(LNAME2 template_parameter_def_values, Template Parameter Default Values))
 $(H2 $(LNAME2 implicit_template_properties, Eponymous Templates))
 
     $(P If a template contains members whose name is the same as the
-        template identifier and if the type or the parameters type of these
-        members include at least all the template parameters then these members
-        are assumed to be referred to in a template instantiation:)
+        template identifier then these members are assumed to be referred
+        to in a template instantiation:)
 
         ------
         template foo(T)


### PR DESCRIPTION
According to the spec, a template instantiation only refers to an eponymous member if that member's declaration includes all of the template's parameters. As of DMD v2.090.0, this is not the actual behavior of the implementation, as demonstrated by the following example:

```d
template foo(T)
{
    // Does not include T
    enum foo = 42;
}

// Passes, but should fail according to spec
static assert(foo!void == 42);
```

This change updates the spec to match the actual behavior of the compiler.