### PR TITLE
Tiny English improvements + comments...

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -312,7 +312,7 @@ $(GNAME AutoDeclarationY):
 static x = 3;      // x is type int
 auto y = 4u;       // y is type uint
 
-auto s = "Apollo"; // s is type immutable(char)[]
+auto s = "Apollo"; // s is type immutable(char)[] i.e., string
 
 class C { ... }
 
@@ -553,8 +553,8 @@ $(GNAME Typeof):
         --------------------
 
         $(P
-        $(I Expression) is not evaluated, just the type of it is
-        generated:
+        The $(I Expression) is not evaluated, it is used purely to
+        generate the type:
         )
 
         --------------------
@@ -648,14 +648,14 @@ $(GNAME VoidInitializer):
         $(OL
         $(LI Void initializers are useful when a static array is on the stack,
         but may only be partially used, such as as a temporary buffer.
-        Void initializers will speed up the code, but of course one must be careful
-        that array elements are actually set before read.)
+        Void initializers will potentially speed up the code, but they introduce risk, since one must ensure
+        that array elements are always set before read.)
         $(LI The same is true for structs.)
         $(LI Use of void initializers is rarely useful for individual local variables,
         as a modern optimizer will remove the dead store of its initialization if it is
         initialized later.)
-        $(LI For hot code paths, it is worthwhile to check to see if the void initializer
-        actually improves results before using it.)
+        $(LI For hot code paths, it is worth profiling to see if the void initializer
+        actually improves results.)
         )
         )
 


### PR DESCRIPTION
1. There ought to be a cross-ref. from the `function` keyword (lines 251-3) to the `delegate` docs.
2. I added mention of `string` on line 315 because the term is used elsewhere in this document.
3. Line 319 says "c is a handle to an instance of class C". This is the first time in the D docs I've come across the term "handle". Ought it to be "reference"?
4. Should the Best Practice lines 614+ also mention the use of `return typeof(return) *tuple-expression*` or similar? (If yes, it would need an experienced D person to come up with a suitable example.)