### PR TITLE
Clarify 'body' keyword deprecation

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -10,7 +10,7 @@ $(SPEC_S Deprecated Features,
 
     $(TABLE2 Deprecated Features,
         $(THEAD Feature,                                                          Spec,  Dep,    Error,  Gone)
-        $(TROW $(DEPLINK body keyword),                                           2.075, 2.091, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK body keyword),                                           2.075, &nbsp;, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Hexstring literals),                                     2.079, 2.079, 2.086, &nbsp;)
         $(TROW $(DEPLINK Class allocators and deallocators),                      &nbsp;, 2.080, 2.087, &nbsp;)
         $(TROW $(DEPLINK Implicit comparison of different enums),                 2.075,  2.075, 2.081, &nbsp;)
@@ -91,6 +91,12 @@ $(H4 Rationale)
         Since D grammar aims to be context free, this common word was reserved,
         which led to frequent trouble for people interfacing with other languages
         (e.g. javascript) or auto-generating code.
+    )
+    $(P Note that given the large amount of code relying on the 'body' keyword
+        (essentially any code using contracts), and the fact that the benefit
+        of DIP1003 to the user are mostly the ability to use 'body' as an identifier,
+        the deprecation has been postponed beyond its original goal of 2.091.0.
+        Users are still encouraged to use 'do' for future-proofness.
     )
 
 $(H3 $(DEPNAME Hexstring literals))


### PR DESCRIPTION
The deprecation was reverted in DMD PR 10763.