### PR TITLE
Indent continuation lines with 2 indentations

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -27,6 +27,16 @@ $(UL
     $(LI Use spaces instead of hardware tabs.)
 
     $(LI Each indentation level will be four columns.)
+
+    $(LI For line breaks inside parentheses the continuation shall be indented
+         two indentation levels beyond the first line.
+
+-------------------------------
+myFunction(foo,
+        bar,
+        baz);
+-------------------------------
+    )
 )
 
 $(H3 $(LNAME2 naming_conventions, Naming Conventions))


### PR DESCRIPTION
It is a D Style proposal. The suggestion is to state explicitly how continuation lines should be indented.

One logical line can be written as two or more lines (so called line continuation or line wrapping). One example is a long argument list, that can be made more readable if written in multiple lines. And I propose to use two indentation levels (8 spaces) for line wrapping.

So:
```d
my_func_name(arg1,
        arg2);
```
instead of

```d
my_func_name(arg1,
    arg2);
```

### Rationale

- This is how dfmt formats the code and it can't be configured: https://github.com/dlang-community/dfmt/issues/257
- Phobos or at least some Phobos maintainers seem to enforce this guideline (e.g. see the remarks to this PR: https://github.com/dlang/phobos/pull/7105)
