### PR TITLE
Remove documentation for .classinfo

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -249,7 +249,7 @@ class C
 $(H2 $(LNAME2 synchronized-classes, Synchronized Classes))
 
         $(P All member functions of synchronized classes are synchronized.
-        A static member function is synchronized on the $(I classinfo)
+        A static member function is synchronized on the $(I TypeInfo_Class)
         object for the class, which means that one monitor is used
         for all static member functions for that synchronized class.
         For non-static functions of a synchronized class, the monitor

--- a/spec/property.dd
+++ b/spec/property.dd
@@ -62,11 +62,6 @@ $(TROW $(D .im), imaginary part)
 
 $(BR)
 
-$(TABLE2 Properties for Class Types,
-$(THEAD Property, Description)
-$(TROW $(RELATIVE_LINK2 classinfo, $(D .classinfo)), Information about the dynamic type of the class)
-)
-
 $(H2 $(LNAME2 init, .init Property))
 
         $(P $(D .init) produces a constant expression that is the default
@@ -242,15 +237,6 @@ $(H2 $(LNAME2 mangleof, .mangleof Property))
     match what the associated C or C++ compiler does.)
     )
     )
-
-$(H2 $(LNAME2 classinfo, .classinfo Property))
-
-$(P $(CODE .classinfo) provides information about the dynamic type of a class
-object. It returns a reference to type $(DDLINK phobos/object, TypeInfo_Class,
-$(D object.TypeInfo_Class)).)
-
-$(P $(CODE .classinfo) applied to an interface gives the information for the
-interface, not the class it might be an instance of.)
 
 $(H2 $(LNAME2 classproperties, User-Defined Properties))
 


### PR DESCRIPTION
In support of dlang/dmd#11033.

Please don't pull until the aforementioned PR has been pulled.