### PR TITLE
Added missing argument in compile command example

### DIFF
--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -309,7 +309,7 @@ $(P Compiling, linking, and running produces the output:)
 
 $(CONSOLE
 > g++ base.cpp
-> dmd main.d base.o && ./main
+> dmd main.d base.o -L-lstdc++ && ./main
 5
 20
 a = 1


### PR DESCRIPTION
The current compile line example does not works because the C++ sample code use std. The option -L-lstdc++ was missing in the compile line example, which is needed in order to compile the sample code.