### PR TITLE
Add example `__traits(isZeroInit, void))`

### DIFF
--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -561,6 +561,9 @@ void test()
 class C { int x = -1; }
 
 static assert(__traits(isZeroInit, C));
+
+// For initializing arrays of element type `void`.
+static assert(__traits(isZeroInit, void));
 ---
 )
 


### PR DESCRIPTION
Spec says if the type's default initializer is all zero bits then true is returned, otherwise false.
void is neither.