### PR TITLE
Add GSOC 2019 to DLF intro

### DIFF
--- a/foundation/about.dd
+++ b/foundation/about.dd
@@ -33,10 +33,9 @@ $(UL
     $(LI pays for hardware costs
         (e.g. this website, $(LINK2 http://dlang.org/download.html, dmd downloads),
         the $(LINK2 https://tour.dlang.org, D tour) and more))
-    $(LI is an accepted
-        $(HTTPS summerofcode.withgoogle.com/organizations/5078256051027968/,
-        Google Summer of Code organization) and hosted four projects during
-        the summer of 2016.
+    $(LI is an accepted Google Summer of Code (GSOC) organization, with projects hosted during
+        $(HTTPS summerofcode.withgoogle.com/archive/2016/organizations/4688223091556352/, GSOC 2016) and
+        $(HTTPS summerofcode.withgoogle.com/archive/2019/organizations/6223494952517632/, GSOC 2019).
     )
 )
 

--- a/foundation/donate.dd
+++ b/foundation/donate.dd
@@ -19,10 +19,9 @@ $(UL
     $(LI pays for hardware costs
         (e.g. this website, $(LINK2 http://dlang.org/download.html, dmd downloads),
         the $(LINK2 https://tour.dlang.org, D tour) and more))
-    $(LI is an accepted
-        $(HTTPS summerofcode.withgoogle.com/organizations/5078256051027968/,
-        Google Summer of Code organization) and hosted four projects during
-        the summer of 2016.
+    $(LI is an accepted Google Summer of Code (GSOC) organization, with projects hosted during
+        $(HTTPS summerofcode.withgoogle.com/archive/2016/organizations/4688223091556352/, GSOC 2016) and
+        $(HTTPS summerofcode.withgoogle.com/archive/2019/organizations/6223494952517632/, GSOC 2019).
     )
 )
 


### PR DESCRIPTION
The intro on the foundation/about page was a little out of date. And it's supposed to be mirrored on the foundation/donate page, too.