### PR TITLE
Remove duplicated release-schedule entry from sitemap

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -325,7 +325,7 @@ SPEC_ROOT=$(addprefix spec/, \
 	abi simd betterc)
 SPEC_DD=$(addsuffix .dd,$(SPEC_ROOT))
 
-CHANGELOG_FILES:=$(basename $(subst _pre.dd,.dd,$(wildcard changelog/*.dd))) changelog/release-schedule
+CHANGELOG_FILES:=$(basename $(subst _pre.dd,.dd,$(wildcard changelog/*.dd)))
 ifneq (1,$(ENABLE_RELEASE))
  CHANGELOG_FILES+=changelog/pending
 endif


### PR DESCRIPTION
I found duplicate release-schedule entries on the sitemap page.
However I'm not sure why this is added separately.