### PR TITLE
Fix typos

### DIFF
--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -618,7 +618,7 @@ $(H4 $(LNAME2 reference_links, Reference Links))
 
 $(P
 Reference-style links enclose a reference label in square brackets. They may
-optionally be preceeded by some link text, also enclosed in square brackets.
+optionally be preceded by some link text, also enclosed in square brackets.
 )
 
 $(P
@@ -640,7 +640,7 @@ definition then the reference definition is used.
 
 $(P
 The generated links to D symbols are relative if they have the same root package
-as the module being documented. If not, their URLs are preceeded by a
+as the module being documented. If not, their URLs are preceded by a
 `$(DOLLAR)(DDOC_ROOT_pkg)` macro, where `pkg` is the root package of the symbol
 being linked to. Links to D symbols are generated with a `$(DOLLAR)(DOC_EXTENSION)`
 macro after the module name. So the generated URL for `[Object]` in the above
@@ -707,7 +707,7 @@ a period:
 ---
 
 $(P
-Start an unordered list with a hypen (`-`), an asterisk (`*`) or a plus (`+`).
+Start an unordered list with a hyphen (`-`), an asterisk (`*`) or a plus (`+`).
 Subsequent items in the same list must also start with the same symbol:
 )
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2277,7 +2277,7 @@ void foo()
         alias S = T;
     alias U = T;                   // error, T is not defined
 
-    static if (is(E V == enum))    // satisified, E is an enum
+    static if (is(E V == enum))    // satisfied, E is an enum
         V v;                       // v is declared to be a byte
 }
 -------------

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -587,7 +587,7 @@ $(H2 $(LNAME2 optional-parenthesis, Optional Parentheses))
     }
     ---
 
-    $(P If a function returns a delegate or function pointer, the parantheses are required if the
+    $(P If a function returns a delegate or function pointer, the parentheses are required if the
     returned value is to be called.
     )
 
@@ -998,7 +998,7 @@ void test()
 }
 ------
 
-        $(P If a derived class overrides a base class member function with diferrent
+        $(P If a derived class overrides a base class member function with different
         $(GLINK FunctionAttributes), the missing attributes will be
         automatically compensated by the compiler.)
 
@@ -1771,7 +1771,7 @@ import core.vararg;
         $(D _argptr), which is a $(D core.vararg)
     reference to the first of the variadic
         arguments. To access the arguments, $(D _argptr) must be used
-    in conjuction with $(D va_arg):)
+    in conjunction with $(D va_arg):)
 
 ------
 import core.vararg;

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -416,7 +416,7 @@ $(P Note: Hex Strings are $(B deprecated). Please use $(REF hexString, std,conv)
 $(H3 $(LNAME2 delimited_strings, Delimited Strings))
 
         $(P Delimited strings use various forms of delimiters.
-        The delimiter, whether a character or identifer,
+        The delimiter, whether a character or identifier,
         must immediately follow the " without any intervening whitespace.
         The terminating delimiter must immediately precede the closing "
         without any intervening whitespace.

--- a/spec/module.dd
+++ b/spec/module.dd
@@ -485,7 +485,7 @@ void main()
 $(H2 $(LNAME2 module_scope_operators, Module Scope Operator))
 
     $(P A leading `.` causes the
-    identifer to be looked up in the module scope.)
+    identifier to be looked up in the module scope.)
 
 ---------
 int x;

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -163,7 +163,7 @@ $(H2 $(LNAME2 static_struct_init, Static Initialization of Structs))
         $(P If a $(GLINK2 declaration, StructInitializer) is supplied, the
         fields are initialized by the $(GLINK2 declaration, StructMemberInitializer) syntax.
         $(I StructMemberInitializers) with the $(I Identifier : NonVoidInitializer) syntax
-        may be appear in any order, where $(I Identifier) is the field identifer.
+        may be appear in any order, where $(I Identifier) is the field identifier.
         $(I StructMemberInitializer)s with the $(GLINK2 declaration, NonVoidInitializer) syntax
         appear in the lexical order of the fields in the $(GLINK StructDeclaration).
         )
@@ -753,8 +753,8 @@ $(H2 $(LNAME2 field-init, Field initialization inside constructor))
             this(long j)
             {
                 j ? (num = 3) : (num = 4); // ok
-                j || (ber = 3);  // Error: intialized on only one path
-                j && (ber = 3);  // Error: intialized on only one path
+                j || (ber = 3);  // Error: initialized on only one path
+                j && (ber = 3);  // Error: initialized on only one path
             }
         }
         ---
@@ -1178,7 +1178,7 @@ struct X
         $(OL
         $(LI `const`. When a postblit is qualified with `const` as in
         $(D this(this) const;) or $(D const this(this);) then the postblit
-        is succesfully called on mutable (unqualified), `const`,
+        is successfully called on mutable (unqualified), `const`,
         and `immutable` objects, but the postblit cannot modify the object
         because it regards it as `const`; hence `const` postblits are of
         limited usefulness. Example:)
@@ -1297,7 +1297,7 @@ void main()
 
         $(P The following table lists all the possibilities of grouping
         qualifiers for a postblit associated with the type of object that
-        needs to be used in order to succesfully invoke the postblit:)
+        needs to be used in order to successfully invoke the postblit:)
 
         $(TABLE_10 $(ARGS Qualifier Groups),
         $(VERTROW object type to be invoked on, $(D const), $(D immutable), $(D shared)),

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -1104,13 +1104,13 @@ $(H2 $(LNAME2 function-templates, Function Templates))
 
         short[] arr;
         bar(1, arr);
-        // arr is short[], and the interger literal 1 is
+        // arr is short[], and the integer literal 1 is
         // implicitly convertible to short.
         // then T will be deduced to short.
 
         bar(1, [2.0, 3.0]);
         // the array literal is analyzed as double[],
-        // and the interger literal 1 is implicitly convertible to double.
+        // and the integer literal 1 is implicitly convertible to double.
         // then T will be deduced to double.
         ------
 

--- a/spec/unittest.dd
+++ b/spec/unittest.dd
@@ -107,7 +107,7 @@ $(H2 $(LNAME2 attributes_unittest, Attributed Unittests))
 
     $(BEST_PRACTICE
     $(OL
-    $(LI Using unit tests in conjuction with coverage testing
+    $(LI Using unit tests in conjunction with coverage testing
     (such as $(DDSUBLINK dmd, switch-cov, $(B -cov)))
     is effective.)
     $(LI A unit test for a function should appear immediately

--- a/spec/version.dd
+++ b/spec/version.dd
@@ -718,7 +718,7 @@ $(GNAME StaticAssert):
         )
 
         $(P Unlike $(GLINK2 expression, AssertExpression)s, $(I StaticAssert)s are always
-        checked and evaluted by the compiler unless they appear in an
+        checked and evaluated by the compiler unless they appear in an
         unsatisfied conditional.
         )
 


### PR DESCRIPTION
Hey,

This huge PR will fix : 

- 3 typos in `spec/ddoc.dd`
- 1 typo in `spec/expression.dd`
- 3 typos in `spec/function.dd`
- 1 typo in `spec/lex.dd`
- 1 typo in `spec/module.dd`
- 5 typos in `spec/struct.dd`
- 2 typos in `spec/template.dd`
- 1 typo in `spec/unittest.dd`
- 1 typo in `spec/version.dd`



Cheers! :robot: