### PR TITLE
[class.dd] Move Objective-C method specifics to subsection

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -209,26 +209,17 @@ $(H2 $(LNAME2 super_class, Super Class))
         it inherits from $(REF1 Object, object). `Object` forms the root
         of the D class inheritance hierarchy.
 
-$(H2 $(LNAME2 member-functions, Member Functions))
+$(H2 $(LNAME2 member-functions, Member Functions (a.k.a. Methods)))
 
-        $(P Non-static member functions or static member functions with
-        `Objective-C` linkage have an extra hidden parameter called $(I this)
-        through which the class object's other members can be accessed.
-        )
-
-        $(P Member functions with the Objective-C linkage has an additional
-        hidden, anonymous, parameter which is the selector the function was
-        called with.
+        $(P Non-static member functions have an extra hidden parameter
+        called $(I this) through which the class object's other members 
+        can be accessed.
         )
 
         $(P Non-static member functions can have, in addition to the usual
         $(GLINK2 function, FunctionAttribute)s, the attributes
         $(D const), $(D immutable), $(D shared), or $(D inout).
         These attributes apply to the hidden $(I this) parameter.
-        )
-
-        $(P Static member functions with the Objective-C linkage are placed in
-        the hidden nested metaclass as non-static member functions.
         )
 ---
 class C
@@ -244,6 +235,22 @@ class C
     }
 }
 ---
+
+$(H3 $(LNAME2 objc-member-functions, Objective-C linkage))
+
+        $(P Static member functions with
+        `Objective-C` linkage also have an extra hidden parameter called $(I this)
+        through which the class object's other members can be accessed.
+        )
+
+        $(P Member functions with Objective-C linkage have an additional
+        hidden, anonymous, parameter which is the selector the function was
+        called with.
+        )
+
+        $(P Static member functions with Objective-C linkage are placed in
+        the hidden nested metaclass as non-static member functions.
+        )
 
 
 $(H2 $(LNAME2 synchronized-classes, Synchronized Classes))

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -212,7 +212,7 @@ $(H2 $(LNAME2 super_class, Super Class))
 $(H2 $(LNAME2 member-functions, Member Functions (a.k.a. Methods)))
 
         $(P Non-static member functions have an extra hidden parameter
-        called $(I this) through which the class object's other members 
+        called $(I this) through which the class object's other members
         can be accessed.
         )
 

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -110,7 +110,7 @@ $(H2 $(LNAME2 access_control, Access Control))
 
 $(H2 $(LNAME2 fields, Fields))
 
-        $(P Class members are always accessed with the . operator.
+        $(P Class members are always accessed with the `.` operator.
         )
 
         $(P Members of a base class can be accessed by prepending the name of
@@ -206,8 +206,8 @@ void test(Foo foo)
 $(H2 $(LNAME2 super_class, Super Class))
 
         All classes inherit from a super class. If one is not specified,
-        it inherits from Object. Object forms the root of the D class
-        inheritance hierarchy.
+        it inherits from $(REF1 Object, object). `Object` forms the root
+        of the D class inheritance hierarchy.
 
 $(H2 $(LNAME2 member-functions, Member Functions))
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -801,7 +801,7 @@ class Bar : Foo
         )
 
         $(P
-            Functions with `Objective-C` linkage has an additional hidden,
+            Functions with `Objective-C` linkage have an additional hidden,
             unnamed, parameter which is the selector it was called with.
         )
 


### PR DESCRIPTION
The Objective-C method specifics (added in #2540) make it hard to read the docs for people not interested in Objective-C linkage. This moves the details to a subsection.

Also:
* Mention that member functions are also called methods (which is used in some places in class.dd already).
* 2 minor tweaks to surrounding class docs.