### PR TITLE
adding keyring hint to the install.sh help page

### DIFF
--- a/install.dd
+++ b/install.dd
@@ -309,7 +309,7 @@ $(CONSOLE
 
 $(H3 $(LNAME2 update, Update))
 
-Update the installer itself.
+Update the installer itself and the keyring.
 
 $(CONSOLE
 ~/dlang/install.sh update


### PR DESCRIPTION
Add the keyring update info, which is a continuous reoccurring confusion, see also https://forum.dlang.org/post/tmnixwomwogmgjopsjqp@forum.dlang.org