### PR TITLE
Fix broken stdlib links in regexes article

### DIFF
--- a/articles/regular-expression.dd
+++ b/articles/regular-expression.dd
@@ -285,6 +285,6 @@ $(D_S $(TITLE),
 )
 Macros:
 DOLLAR = $
-STD = $(LINK2 phobos/std_$0.html, std.$0)
+STD = $(LINK2 /phobos/std_$0.html, std.$0)
 SUBNAV=$(SUBNAV_ARTICLES)
 TITLE=Regular Expressions


### PR DESCRIPTION
Links to stdlib pages in https://dlang.org/articles/regular-expression.html are all broken.

I assume they worked fine until d5a1bf90b3e7513499614fea8f41b90af72b0260 relocated the page under /articles/, which broke them as they are relative links.

To fix this I propose turning them into absolute links.