### PR TITLE
Not all functions return rvalues

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -164,7 +164,7 @@ $(H2 $(LNAME2 contracts, Contracts))
 
 $(H2 $(LNAME2 function-return-values, Function Return Values))
 
-        $(P Function return values are considered to be rvalues.
+        $(P Function return values not marked as $(D ref) are considered to be rvalues.
         This means they cannot be passed by reference to other functions.
         )
 


### PR DESCRIPTION
Add an exception for `ref'