### PR TITLE
Improve the wording of struct copy ctor spec.

### DIFF
--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -902,8 +902,8 @@ $(H3 $(LEGACY_LNAME2 StructCopyConstructor, struct-copy-constructor, Struct Copy
     ---
     )
 
-    $(P When a copy constructor is defined for a `struct`, all
-    implicit blitting is disabled for that `struct`:
+    $(P When a copy constructor is defined for a `struct` (or marked `@disable`), the compiler no
+    longer implicitly generates default copy/blitting constructors for that `struct`:
     )
     ---
     struct A
@@ -917,7 +917,7 @@ $(H3 $(LEGACY_LNAME2 StructCopyConstructor, struct-copy-constructor, Struct Copy
     void main()
     {
         immutable A a;
-        fun(a);          // error: copy constructor cannot be called with types (immutable) immutable
+        fun(a);        // error: copy constructor cannot be called with types (immutable) immutable
     }
     ---
 


### PR DESCRIPTION
The "implicit blitting" of the text can be read as "implicit calling of copy constructor", leading to incorrect meaning of the text.