### PR TITLE
ddoc: Better define section names

### DIFF
--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -199,9 +199,15 @@ $(H3 $(LNAME2 sections, Sections))
 
 $(P
 The document comment is a series of $(I Section)s.
-A $(I Section) is a name that is the first non-blank character on
+A $(I Section name) is a name that is the first non-blank character on
 a line immediately followed by a ':'. This name forms the section name.
 The section name is not case sensitive.
+)
+
+$(P
+Section names do not contain whitespace. Underscores will be replaced with spaces.
+For example, a section entitled 'New API' would be written with having its first line
+'New_API:'
 )
 
 $(P


### PR DESCRIPTION
Clarify difference in section and section name. Also explicilty describe that section names may not contain spaces, but that underscores will be replaced with spaces.