### PR TITLE
Expand on function parameters documentation, add -preview=in

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1219,39 +1219,58 @@ $(H2 $(LNAME2 parameters, Function Parameters))
 
 $(H3 $(LNAME2 param-storage, Parameter Storage Classes))
 
-        $(P Parameter storage classes are $(D in), $(D out),
-        $(D ref), $(D lazy), $(D const), $(D immutable), $(D shared),
-        $(D inout) or
-        $(D scope).
+        $(P Parameter storage classes are $(D in), $(D out), $(D ref), $(D lazy), $(D scope) and $(D inout).
+        Parameters can also take the type constructors $(D const), $(D immutable) and $(D shared).)
+
+        $(P $(D in), $(D ref), $(D out) and $(D lazy) are mutually exclusive. The first three are used to
+        denote input, input/output, and output parameters, respectively.
         For example:
         )
 ------
-int foo(in int x, out int y, ref int z, int q);
+int read(in char[] input, ref size_t count, out int errno);
 ------
 
-        $(P x is $(D in), y is $(D out), z is $(D ref), and q is none.
-        )
+        $(P In this example, $(D input) will only be read and no reference to it will be kept around,
+        while $(D count) will be read and written to, and $(D errno) will be set to a value from
+        within the function.
+        This approach gives a semantic meaning to the parameters and allows the compiler to potentially
+        optimize the generated code.)
 
-        $(UL
-        $(LI The function declaration makes it clear what the inputs and
-        outputs to the function are.)
-        $(LI It eliminates the need for IDL (interface description language) as a separate language.)
-        $(LI It provides more information to the compiler, enabling more
-        error checking and
-        possibly better code generation.)
+        $(P When talking about function parameters, the $(I parameter) is what the function prototype defines,
+        and the $(I argument) is the value that will $(I bind) to it.
+        For example, using the previous definition of $(D read):
         )
+------
+void main()
+{
+    size_t a = 42;
+    int b;
+    int r = read("Hello World", a, b);
+}
+------
+       $(P In this example, the argument $(D "Hello World") gets bind to $(D input),
+       $(D a) gets bind to $(D count) and $(D b) to $(D errno).
+       )
 
     $(TABLE_2COLS Parameter Storage Classes,
     $(THEAD Storage Class, Description)
-    $(TROW $(I none), parameter becomes a mutable copy of its argument)
-
-    $(TROW $(D in), defined as $(D scope const).  However $(D in) has not yet been properly
-    implemented so it's current implementation is equivalent to $(D const).  It is recommended
-    to avoid using $(D in) until it is properly defined and implemented.  Use $(D scope const)
-    or $(D const) explicitly instead.)
-    $(TROW $(D ref), parameter is passed by reference)
-    $(TROW $(D out), parameter is passed by reference and initialized upon function entry with the default value
-    for its type)
+    $(TROW $(I none), The parameter will be a mutable copy of its argument)
+    $(TROW $(D in), The parameter is an input to the function. Input parameters behaves as if they have
+    the $(D const scope) storage classes. Input parameters may be passed by reference by the compiler.
+    Unlike $(D ref) parameters$(COMMA) $(D in) parameters can bind to both lvalues and rvalues (such as literals).
+    Types that would trigger a side effect if passed by value (such as types with postblit$(COMMA)
+    copy constructor$(COMMA) or destructor)$(COMMA) and types which cannot be copied$(COMMA)
+    e.g. if their copy constructor is marked as $(D @disable)$(COMMA) will always be passed by reference.
+    Dynamic arrays$(COMMA) classes$(COMMA) associative arrays$(COMMA) function pointers$(COMMA) and delegates
+    will always be passed by value$(COMMA) to allow for covariance.
+    If the type of the parameter does not fall in one of those categories$(COMMA)
+    whether or not it is passed by reference is implementation defined$(COMMA) and the backend is free
+    to choose the method that will best fit the ABI of the platform.
+    $(B Note: This requires the $(D -preview=in) switch$(COMMA) available in v2.094.0 or higher.))
+    $(TROW $(D ref), The parameter is an $(I input/output) parameter$(COMMA) passed by reference.
+    It is expected that the function will both read and write to this parameter.)
+    $(TROW $(D out), The argument must be an lvalue$(COMMA) which will be passed by reference and initialized
+    upon function entry with the default value (`T.init`) of its type)
 
     $(TROW $(D scope), $(ARGS
     The parameter must not escape the function call


### PR DESCRIPTION
Underline the difference between argument and parameter.
Split the first sentence between type constructors and storage classes.
Finally, add documentation on what `in` will means with `-preview=in`.

Waiting on dlang/dmd#11000