### PR TITLE
Fixing FreeBSD info link

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -118,7 +118,7 @@ $(DIVC download_channels,
         $(SBTN $(B_SUSE32), i386) $(SBTN $(B_SUSE64), x86_64) $(SBTN $(B_ARCH linux, tar.xz), tar.xz)
     )
 
-    $(DOWNLOAD FreeBSD, $(FREEBSD), linux, Linux,
+    $(DOWNLOAD FreeBSD, $(FREEBSD), freebsd, FreeBSD,
         $(SBTN $(B_ARCH freebsd-32, tar.xz), i386) $(SBTN $(B_ARCH freebsd-64, tar.xz), x86_64)
     )
 
@@ -151,7 +151,7 @@ $(DIVC download_channels,
         $(SBTN $(N_ARCH linux, tar.xz), tar.xz)
     )
 
-    $(DOWNLOAD FreeBSD, $(FREEBSD), linux, Linux,
+    $(DOWNLOAD FreeBSD, $(FREEBSD), freebsd, FreeBSD,
         $(SBTN $(N_ARCH freebsd-32, tar.xz), i386) $(SBTN $(N_ARCH freebsd-64, tar.xz), x86_64)
     )
 


### PR DESCRIPTION
This change fixes the info tooltip from "Linux setup and usage information" to "FreeBSD setup and usage information".
Also fixes the url from https://dlang.org/dmd-linux.html to https://dlang.org/dmd-freebsd.html