### PR TITLE
update download page

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -84,7 +84,7 @@ $(DIVC download_channels,
         $(SBTN $(SUSE32), i386) $(SBTN $(SUSE64), x86_64) $(SBTN $(ARCH linux, tar.xz), tar.xz)
     )
 
-    $(DOWNLOAD FreeBSD, $(FREEBSD), linux, Linux,
+    $(DOWNLOAD FreeBSD, $(FREEBSD), freebsd, FreeBSD,
          $(SBTN $(ARCH freebsd-64, tar.xz), x86_64)
     )
 
@@ -118,7 +118,7 @@ $(DIVC download_channels,
         $(SBTN $(B_SUSE32), i386) $(SBTN $(B_SUSE64), x86_64) $(SBTN $(B_ARCH linux, tar.xz), tar.xz)
     )
 
-    $(DOWNLOAD FreeBSD, $(FREEBSD), linux, Linux,
+    $(DOWNLOAD FreeBSD, $(FREEBSD), freebsd, FreeBSD,
         $(SBTN $(B_ARCH freebsd-64, tar.xz), x86_64)
     )
 
@@ -151,7 +151,7 @@ $(DIVC download_channels,
         $(SBTN $(N_ARCH linux, tar.xz), tar.xz)
     )
 
-    $(DOWNLOAD FreeBSD, $(FREEBSD), linux, Linux,
+    $(DOWNLOAD FreeBSD, $(FREEBSD), freebsd, FreeBSD,
         $(SBTN $(N_ARCH freebsd-64, tar.xz), x86_64)
     )
 

--- a/download.dd
+++ b/download.dd
@@ -85,7 +85,7 @@ $(DIVC download_channels,
     )
 
     $(DOWNLOAD FreeBSD, $(FREEBSD), linux, Linux,
-         $(SBTN $(ARCH freebsd-32, tar.xz), i386) $(SBTN $(ARCH freebsd-64, tar.xz), x86_64)
+         $(SBTN $(ARCH freebsd-64, tar.xz), x86_64)
     )
 
     $(INSTALL_SCRIPT curl -fsS https://dlang.org/install.sh | bash -s dmd)
@@ -119,7 +119,7 @@ $(DIVC download_channels,
     )
 
     $(DOWNLOAD FreeBSD, $(FREEBSD), linux, Linux,
-        $(SBTN $(B_ARCH freebsd-32, tar.xz), i386) $(SBTN $(B_ARCH freebsd-64, tar.xz), x86_64)
+        $(SBTN $(B_ARCH freebsd-64, tar.xz), x86_64)
     )
 
     $(INSTALL_SCRIPT curl -fsS https://dlang.org/install.sh | bash -s dmd-beta)
@@ -152,7 +152,7 @@ $(DIVC download_channels,
     )
 
     $(DOWNLOAD FreeBSD, $(FREEBSD), linux, Linux,
-        $(SBTN $(N_ARCH freebsd-32, tar.xz), i386) $(SBTN $(N_ARCH freebsd-64, tar.xz), x86_64)
+        $(SBTN $(N_ARCH freebsd-64, tar.xz), x86_64)
     )
 
     $(INSTALL_SCRIPT curl -fsS https://dlang.org/install.sh | bash -s dmd-nightly)

--- a/download.dd
+++ b/download.dd
@@ -125,38 +125,6 @@ $(DIVC download_channels,
     $(INSTALL_SCRIPT curl -fsS https://dlang.org/install.sh | bash -s dmd-beta)
     )
   )
-
-  $(DIVC download_channel,
-    $(H2 $(LNAME2 dmd-nightly,DMD Nightly))
-
-    $(BR)$(BR)
-
-    $(DOWNLOAD Windows, $(WINDOWS), windows, Windows,
-        $(SBTN $(N_ARCH windows, 7z), 7z)
-    )
-
-    $(DOWNLOAD macOS, $(OSX), osx, macOS,
-        $(SBTN $(N_ARCH osx, tar.xz), tar.xz)
-    )
-
-    $(DOWNLOAD Ubuntu/Debian, $(UBUNTU) &nbsp; $(DEBIAN), linux, Linux,
-        $(SBTN $(N_ARCH linux, tar.xz), tar.xz)
-    )
-
-    $(DOWNLOAD Fedora/CentOS, $(FEDORA) &nbsp; $(CENTOS), linux, Linux,
-        $(SBTN $(N_ARCH linux, tar.xz), tar.xz)
-    )
-
-    $(DOWNLOAD openSUSE, $(OPENSUSE), linux, Linux,
-        $(SBTN $(N_ARCH linux, tar.xz), tar.xz)
-    )
-
-    $(DOWNLOAD FreeBSD, $(FREEBSD), freebsd, FreeBSD,
-        $(SBTN $(N_ARCH freebsd-64, tar.xz), x86_64)
-    )
-
-    $(INSTALL_SCRIPT curl -fsS https://dlang.org/install.sh | bash -s dmd-nightly)
-  )
 )
 
 $(H3


### PR DESCRIPTION
- remove dropped FreeBSD-32 builds
- fix FreeBSD info links
- remove unmaintained nightly release channel

Also see https://dlang.org/changelog/2.094.0.html#ldc-built-releases.