### PR TITLE
Fix argument/parameter mixup in function literal documentation

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1658,9 +1658,9 @@ $(GNAME FunctionLiteralBody):
         $(I Type) is the return type of the function or delegate,
         if omitted it is inferred from any $(I ReturnStatement)s
         in the $(I FunctionLiteralBody).
-        $(D $(LPAREN)) $(GLINK ArgumentList) $(D $(RPAREN))
-        forms the arguments to the function.
-        If omitted it defaults to the empty argument list $(D ( )).
+        $(GLINK ParameterWithAttributes) or $(GLINK ParameterWithMemberAttributes)
+        can be used to specify the parameters for the function. If these are
+        omitted, the function defaults to the empty parameter list $(D ( )).
         The type of a function literal is pointer to function or
         pointer to delegate.
         If the keywords $(D function) or $(D delegate) are omitted,


### PR DESCRIPTION
You can see [here](https://dlang.org/spec/expression.html#function_literals) that there's a bit of the grammar specification involving parameters, and then below the text in question there are examples of function parameters, so I'm pretty sure this was a mistake.