### PR TITLE
Typo in example.

### DIFF
--- a/spec/property.dd
+++ b/spec/property.dd
@@ -157,7 +157,7 @@ $(H2 $(LNAME2 stringof, .stringof Property))
 
     enum Color { Red }
 
-    int b = 4;
+    int i = 4;
 
     void main()
     {


### PR DESCRIPTION
This makes the example compile.