### PR TITLE
Dead link to info about Bartosz Milewski

### DIFF
--- a/acknowledgements.dd
+++ b/acknowledgements.dd
@@ -28,7 +28,7 @@ $(P
         Thomas Kuehne,
         Helmut Leitner,
         Lubomir Litchev,
-        $(LINK2 http://www.relisoft.com/, Bartosz Milewski),
+        $(LINK2 https://bartoszmilewski.com/, Bartosz Milewski),
         Christopher E. Miller,
         Pavel Minayev,
         Antonio Monteiro,


### PR DESCRIPTION
Old link:
http://www.relisoft.com/

New link:
https://bartoszmilewski.com/