### PR TITLE
Document issue 21340 - `extern(C++, (expression))` now accepts empty tuples

### DIFF
--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -186,6 +186,13 @@ module ns;
 extern (C++, `ns`)
 {
     int foo() { return 1; }
+}
+---
+    $(P or with a compile time computed expression that resolves to a, possibly empty, tuple of strings.
+      If the expression removes to an empty tuple it is equivalent to `extern (C++)`)
+---
+extern(C++, (expression))
+{
     int bar() { return 2; }
 }
 ---

--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -188,8 +188,8 @@ extern (C++, `ns`)
     int foo() { return 1; }
 }
 ---
-    $(P or with a compile time computed expression that resolves to a, possibly empty, tuple of strings.
-      If the expression removes to an empty tuple it is equivalent to `extern (C++)`)
+    $(P Any expression that resolves to either a tuple of strings or an empty tuple is accepted.
+      When the expression resolves to an empty tuple, it is equivalent to `extern (C++)`)
 ---
 extern(C++, (expression))
 {


### PR DESCRIPTION
see also https://github.com/dlang/dmd/pull/11905