### PR TITLE
Fix inaccuracy in overload set example

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1178,10 +1178,10 @@ void foo(int i) { }
 import A;
 import B;
 
-void bar(C c)
+void bar(C c , long i)
 {
     foo();    // calls A.foo()
-    foo(1L);  // calls A.foo(long)
+    foo(i);  // calls A.foo(long)
     foo(c);   // calls B.foo(C)
     foo(1,2); // error, does not match any foo
     foo(1);   // error, matches A.foo(long) and B.foo(int)


### PR DESCRIPTION
 In the previous version, the function call foo(1L) matched both
A.foo(long) and B.foo(int), because the literal 1L can implicitly
convert to int via value range propagation (VRP). Using a long variable
instead of a literal causes it to match only A.foo(long), as intended.