### PR TITLE
improve definition of assign expression behaviour

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -261,6 +261,18 @@ $(GNAME AssignExpression):
     occurs. The resulting expression is a modifiable lvalue.
     )
 
+	$(P Operands of an assign expression are evaluated before the assign expression. 
+	The expression)
+        --------------
+        a op= b
+        --------------
+
+        is exactly the same as:
+
+        --------------
+        a = a op b
+        --------------
+
     $(UNDEFINED_BEHAVIOR
     If either operand is a reference type and one of the following:
     $(OL

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -75,6 +75,8 @@ subexpression `h()` has no smallest short-circuit expression.
 
 $(H2 $(LNAME2 order-of-evaluation, Order Of Evaluation))
 
+$(P Operands are evaluated before operators are executed. Arguments are evaluated before functions are called.)
+
 $(P Built-in prefix unary expressions `++` and `--` are evaluated as if lowered (rewritten) to
 assignments as follows: `++expr` becomes `((expr) += 1)`, and `--expr` becomes `((expr) -= 1)`.
 Therefore, the result of prefix `++` and `--` is the lvalue after the side effect has been
@@ -260,18 +262,6 @@ $(GNAME AssignExpression):
     operand, and the value is the value of the left operand after assignment
     occurs. The resulting expression is a modifiable lvalue.
     )
-
-	$(P Operands of an assign expression are evaluated before the assign expression. 
-	The expression)
-        --------------
-        a op= b
-        --------------
-
-        is exactly the same as:
-
-        --------------
-        a = a op b
-        --------------
 
     $(UNDEFINED_BEHAVIOR
     If either operand is a reference type and one of the following:


### PR DESCRIPTION
The spec appears to not specify that an assign expression must be evaluated after it's operands.
It also helps to define that it must do the same thing as an asignment of the binary operator.

I believe this is the intention of the language, so that it has the same operator behaviour as C++.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97843