### PR TITLE
State in language spec that null is a safe value

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -3109,7 +3109,7 @@ $(H3 $(LNAME2 safe-values, Safe Values))
         $(P For $(DDSUBLINK spec/type, basic-data-types, basic data types), all
         possible bit patterns are safe.)
 
-        $(P A pointer is safe when:)
+        $(P A pointer is safe when it is `null` or:)
         $(OL
             $(LI it can be dereferenced validly, and)
             $(LI the value of the pointee is safe.)


### PR DESCRIPTION
Previously this was only stated in the example.