### PR TITLE
Live Functions: Swap auto for int* where needed

### DIFF
--- a/spec/ob.dd
+++ b/spec/ob.dd
@@ -45,7 +45,7 @@ void release(int*); // deallocate a memory object
 
 @live void test()
 {
-    auto p = void;
+    int* p = void;
     release(p); // error, p does not have a defined value
 }
 


### PR DESCRIPTION
`auto p = void` won't compile even with live value enforcement turned off