### PR TITLE
Add PR manager responsibilities page

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -494,6 +494,7 @@ $(SUBNAV_TEMPLATE
         https://dconf.org, DConf,
         $(ROOT_DIR)foundation/sponsors.html, Sponsors,
         $(ROOT_DIR)foundation/contributors.html, Contributors,
+        $(ROOT_DIR)foundation/prman.html, Pull-Request/Issue Managers,
     ))
 )
 

--- a/foundation/index.dd
+++ b/foundation/index.dd
@@ -45,6 +45,16 @@ $(D_S D Language Foundation,
                     to D's source code and helped to make D possible.)
             )
         )
+        $(DIVC row,
+            $(DIVC item,
+                $(H4 $(LINK2 $(ROOT_DIR)foundation/prman.html, Pull-Request/Issue Managers))
+                $(P Learn about the responsibilities of the people managing our
+                    pull requests and reported issues.)
+            )
+            $(DIVC item,
+                &nbsp;
+            )
+        )
     )
 )
 

--- a/foundation/prman.dd
+++ b/foundation/prman.dd
@@ -1,0 +1,92 @@
+Ddoc
+
+$(D_S $(TITLE))
+
+$(P The D Language Foundation employs two part-time pull-request managers thanks
+to the sponsorship of Symmetry Investments. One of them is intended to fill an
+administrative/managerial role, the other a more technically-oriented role. This
+document outlines their general responsibilities in managing the pull requests
+submitted to $(LINK2 https://github.com/dlang, the D Programming Language Github
+organization repositories), and the issues submitted to $(LINK2
+https://issues.dlang.org/, issues.dlang.org).)
+
+$(P The primary goal for the creation of these positions is to streamline the
+contribution process. We are grateful to the volunteers who have been doing the
+work of maintaining our Issue and PR queues over the past several years, but the
+loose nature of our process has been such that too many contributions grow stale
+(no one takes an interest, they become bottlenecked on one maintainer, etc).
+Contributors should have confidence that their submissions, be they bug reports
+or content contributions, will be reviewed and shepherded to a conclusion
+without languishing for long periods of time. With paid staff overseeing the
+process, we expect the process will become more efficient, and contributors will
+have a primary point of contact to assist with tracking and resolving their
+contributions.)
+
+$(P The following list is divided into Administrative and Technical
+responsibilities. Some may overlap, and there may be loose boundaries between
+others. We trust the PR managers to establish their own approach to carrying out
+these responsibilities.)
+
+$(P In the text below, $(B APR) refers the Administrative PR Manager Role, $(B
+TPR) refers to the Technical PR Manager Role.)
+
+$(H2 Administrative Responsibilities)
+$(P In order to effectively carry out his responsibilities, the APR needs to be
+aware of which core contributors are responsible for which areas and which
+community members to contact when necessary to resolve issues, and have an
+understanding of the general direction the language and ecosystem are going
+(i.e., for any given PR, the APR should be able to answer the question, "Do we
+do this?").)
+
+$(UL
+    $(LI $(B Maintain the contribution guide) - $(LINK2
+    https://github.com/dlang/dmd/blob/master/CONTRIBUTING.md, the contribution
+    guide) establishes best practices for submitting issues and pull requests. The
+    APR should work with the TPR to evolve these details as needed and ensure the
+    document is up to date.)
+    $(LI $(B Triage issues and PRs) - ensure that each issue report is properly
+    prioritized and, where possible, assigned to someone who can resolve it;
+    establish criteria to ensure that pull requests get as much time as they
+    need for a proper review before being merged (e.g., trivial vs. complex,
+    routine vs. controversial, etc); establish criteria to close issues/PRs;
+    recognize when a pull request should first be incorporated as a DIP; etc.)
+    $(LI $(B Keep track of progress) - the APR should establish some means of
+    keeping up to date on the status of every issue and PR in our system, and
+    will be the primary point of contact for queries about the status of any
+    issue or PR.)
+    $(LI $(B Communicate with relevant parties) - communication is vital to
+    ensuring the efficient handling of issues and pull requests. Contributors
+    will need to be sought out to resolve issues that are not picked up
+    voluntarily; non-trivial pull requests will need to be reviewed by an
+    appropriate core contributor/maintainer; contributors will need to be kept
+    abreast of the status of their contributions when they cannot be resolved
+    quickly; etc.)
+)
+
+$(H2 Technical Responsibilities)
+$(P In order to effectively carry out the responsibilities of this role, the TPR
+needs a solid understanding of the architecture of our GitHub projects (i.e.,
+for any given PR, the TPR should be able to answer the question, "Can we do
+this?").)
+
+$(UL
+    $(LI $(B Ensure compliance with contribution guide) - each issue and pull
+    request should meet the guidelines established in $(LINK2
+    https://github.com/dlang/dmd/blob/master/CONTRIBUTING.md, the contribution
+    guide). The TPR will work with contributors to ensure these guidelines are
+    met (reduced test cases, proper commit message format, changelog entries,
+    resolve merge conflicts, etc).)
+    $(LI $(B Identify and resolve regressions) - sometimes bugs are reported
+    that are regressions, but not marked as such. The TPR should identify such
+    issues, attempt to pinpoint the source of all reported regressions, and take
+    steps to resolve them (e.g., contact the author/reviewer of the offending
+    PR).)
+    $(LI $(B Review trivial PRs) - pull requests that need no specialized review
+    should be reviewed and merged by the TPR.)
+    $(LI $(B Fix trivial issues) - the TPR is free to fix trivial issues and
+    submit such fixes as pull requests, but must request review from a competent
+    reviewer.)
+)
+
+Macros:
+    TITLE=Pull-Request/Issue Manager Responsibilities

--- a/posix.mak
+++ b/posix.mak
@@ -349,7 +349,7 @@ PAGES_ROOT=$(SPEC_ROOT) 404 acknowledgements areas-of-d-usage $(ARTICLE_FILES) \
 	gsoc2011 gsoc2012 gsoc2012-template gsoc2013 gsoc2013-template \
 	howto-promote htod index install \
 	menu orgs-using-d overview rdmd resources search security tuple wc windbg \
-	$(addprefix foundation/, index about donate sponsors upb-scholarship)
+	$(addprefix foundation/, index about donate prman sponsors upb-scholarship)
 
 # The contributors listing is dynamically generated
 ifneq (1,$(DIFFABLE))


### PR DESCRIPTION
This adds a new page to the web site documenting the responsibilities of the two new pull-request managers. It does not belong in the main menu (which is cluttered enough) and is accessible from the Foundation page.