### PR TITLE
Fix 21292: Link directly to https s3 downloads

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -238,9 +238,9 @@ Macros:
     SBTN=$(SPANC sig_btn,$(BTN $1,$+)<br>$(BTN $1.sig,sig))
     BTN=<a href="$1" class="btn">$+</a>
     H3I=<h3 class="download">$0</h3>
-    DLSITE=http://downloads.dlang.org/releases/2.x/$(DMDV2)/$0
-    B_DLSITE=http://downloads.dlang.org/pre-releases/2.x/$(B_DMDV2)/$0
-    N_DLSITE=http://downloads.dlang.org/nightlies/dmd-master/$0
+    DLSITE=https://s3.us-west-2.amazonaws.com/downloads.dlang.org/releases/2.x/$(DMDV2)/$0
+    B_DLSITE=https://s3.us-west-2.amazonaws.com/downloads.dlang.org/pre-releases/2.x/$(B_DMDV2)/$0
+    N_DLSITE=https://s3.us-west-2.amazonaws.com/downloads.dlang.org/dmd-master/2.x/$0
     DOWNLOAD =
     $(DIV,
         $(DIVC download_image, $2)

--- a/js/platform-downloads.js
+++ b/js/platform-downloads.js
@@ -30,7 +30,7 @@
     var html = '';
     for (var i = 0; i < files.length; ++i) {
         var f = files[i];
-        var url = 'http://downloads.dlang.org/releases/2.x/' + latest + '/' + f.name + f.suffix;
+        var url = 'https://s3.us-west-2.amazonaws.com/downloads.dlang.org/releases/2.x/' + latest + '/' + f.name + f.suffix;
         html += '<a href="' + url + '" class="btn action">Download ' + f.text + '</a>';
     }
     if (files.length > 1) {


### PR DESCRIPTION
Companion PR: dlang/downloads.dlang.org#6