### PR TITLE
Revert "Indent continuation lines with 2 indentations"

### DIFF
--- a/dstyle.dd
+++ b/dstyle.dd
@@ -27,16 +27,6 @@ $(UL
     $(LI Use spaces instead of hardware tabs.)
 
     $(LI Each indentation level will be four columns.)
-
-    $(LI For line breaks inside parentheses the continuation shall be indented
-         two indentation levels beyond the first line.
-
--------------------------------
-myFunction(foo,
-        bar,
-        baz);
--------------------------------
-    )
 )
 
 $(H3 $(LNAME2 naming_conventions, Naming Conventions))


### PR DESCRIPTION
Reverts dlang/dlang.org#2766

Motivation:

Changes to the DStyle guide can't be made solely based on one's preference. Only changes match the currently established practices can be "codified" via a lightly reviewed PR. Otherwise DStyle changes need the consensus of the majority of active contributors.
That said, such changes don't need a DIP, since this is not change that affects any users of the language, only the contributors.