### PR TITLE
Slightly rephrase and actualize -preview=in section

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1406,18 +1406,21 @@ $(H3 $(LNAME2 param-storage, Parameter Storage Classes))
 
 $(H3 $(LNAME2 in-params, In Parameters))
 
+        $(B Note: The following requires the $(D -preview=in) switch$(COMMA) available in
+        $(LINK2 $(ROOT_DIR)changelog/2.094.0.html#preview-in, v2.094.0) or higher.
+        When not in use, `in` is equivalent to `const`.)
         $(P The parameter is an input to the function. Input parameters behave as if they have
-        the $(D const scope) storage classes. Input parameters may be passed by reference by the compiler.
-        Unlike $(D ref) parameters$(COMMA) $(D in) parameters can bind to both lvalues and rvalues (such as literals).
-        Types that would trigger a side effect if passed by value (such as types with copy constructor$(COMMA)
-        postblit$(COMMA) or destructor)$(COMMA) and types which cannot be copied$(COMMA)
-        e.g. if their copy constructor is marked as $(D @disable)$(COMMA) they will always be passed by reference.
+        the $(D const scope) storage classes. Input parameters may also be passed by reference by the compiler.)
+        $(P Unlike $(D ref) parameters$(COMMA) $(D in) parameters can bind to both lvalues and rvalues
+        (such as literals).)
+        $(P Types that would trigger a side effect if passed by value (such as types with copy constructor$(COMMA)
+        postblit$(COMMA) or destructor)$(COMMA) and types which cannot be copied
+        (e.g. if their copy constructor is marked as $(D @disable)) will always be passed by reference.
         Dynamic arrays$(COMMA) classes$(COMMA) associative arrays$(COMMA) function pointers$(COMMA) and delegates
-        will always be passed by value$(COMMA) to allow for covariance.
-        If the type of the parameter does not fall in one of those categories$(COMMA)
+        will always be passed by value.)
+        $(IMPLEMENTATION_DEFINED If the type of the parameter does not fall in one of those categories$(COMMA)
         whether or not it is passed by reference is implementation defined$(COMMA) and the backend is free
         to choose the method that will best fit the ABI of the platform.
-        $(B Note: This requires the $(D -preview=in) switch$(COMMA) available in v2.094.0 or higher.)
         )
 
 


### PR DESCRIPTION
Saw #2916 and realize it needed some tiny adjustments w.r.t. `-preview=in`.