### PR TITLE
Revert "Added a note to the doc saying that the feature is not yet implemented."

### DIFF
--- a/spec/hash-map.dd
+++ b/spec/hash-map.dd
@@ -337,8 +337,6 @@ $(H2 $(LNAME2 advanced_updating, Advanced updating))
 
 $(H2 $(LNAME2 static_initialization, Static Initialization of AAs))
 
-        NOTE: Not yet implemented.
-
         ---------
         immutable long[string] aa = [
           "foo": 5,


### PR DESCRIPTION
This reverts commit 8b96e90cd7afb965ab908dfe24b6df1514dbc702.

Static Initialization of AAs is implemented in D. This note is misleading and
people can interpret this wrongly.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Reference-to: #2623

In fact, this code doesn't work on global scope:

```d
immutable long[string] aa = [
  "foo": 5,
  "bar": 10,
  "baz": 2000
];

unittest
{
    assert(aa["foo"] == 5);
    assert(aa["bar"] == 10);
    assert(aa["baz"] == 2000);
}
```

But inside a function, static initialization perfectly works:

```d
void main() {
    immutable long[string] aa = [
      "foo": 5,
      "bar": 10,
      "baz": 2000
    ];

    assert(aa["foo"] == 5);
    assert(aa["bar"] == 10);
    assert(aa["baz"] == 2000);
}
```

The example code could be changed to reflect the working example and this should be rather an issue.