### PR TITLE
improve Function Contracts section

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -132,7 +132,7 @@ $(GNAME ShortenedFunctionBody):
         $(P $(B Note:) The `ShortenedFunctionBody` form requires the `-preview=shortenedMethods`
         command-line switch, which is available starting in v2.096.0.)
 
-$(H3 Function contracts)
+$(H2 $(LNAME2 contracts, Function Contracts))
 
 $(GRAMMAR
 $(GNAME FunctionContracts):
@@ -166,33 +166,48 @@ $(GNAME OutStatement):
     $(D out) $(D $(LPAREN)) $(GLINK_LEX Identifier) $(D $(RPAREN)) $(GLINK2 statement, BlockStatement)
 )
 
-$(H2 $(LNAME2 contracts, Contracts))
-
-        $(P The $(D in) and $(D out) blocks or expressions of a function declaration specify
-        the pre- and post-conditions of the function. They are used in
-        $(LINK2 contracts.html, Contract Programming).
+        $(P Function Contracts specify the preconditions and postconditions of a function.
+        They are used in $(LINK2 contracts.html, Contract Programming).
         )
 
-        $(P The pre contracts specify the preconditions before a statement is executed. The most
-        typical use of this would be in validating the parameters to a function. The post
-        contracts validate the result of the statement. The most typical use of this
-        would be in validating the return value of a function and of any side effects it has.
-        In D, pre contracts begin with `in`, and post contracts begin with `out`. They
-        come at the end of the function signature and before the opening brace of the function body.)
+        $(P Preconditions and postconditions do not affect the type of the function.)
 
-        $(P Pre and post contracts can be written either in expression form (feature introduced in DMD
-        2.081.0), with a syntax similar to $(B assert), or as block statements
-        containing arbitrary code.)
+    $(H3 Preconditions)
+
+        $(P An $(GLINK InContractExpression) is a precondition.)
+
+        $(P The first $(GLINK2 expression, AssignExpression) of the $(GLINK2 expression, AssertArguments)
+        must evaluate to true. If it does not, the precondition has failed.)
+
+        $(P The second $(I AssignExpression), if present, must be implicitly convertible to type `const(char)[]`.
+        )
+
+        $(P An $(GLINK InStatement) is also a precondition. Any $(GLINK2 expression, AssertExpression) appearing
+        in an $(I InStatement) will be an $(I InContractExpression).
+        )
+
+        $(P Preconditions must semantically be satisfied before the function starts executing.
+        If it is not, the program enters an $(I Invalid State).
+        )
+
+        $(IMPLEMENTATION_DEFINED Whether the preconditions are actually run or not is implementation defined.
+        This is usually selectable with a compiler switch.
+        Its behavior upon precondition failure is also usually selectable with a compiler switch.
+        One option is to throw an `AssertError` with a message consisting of the optional second
+        $(I AssignExpression).
+        )
+
+        $(BEST_PRACTICE Use preconditions to validate that input arguments have values that are
+        expected by the function.)
+
+        $(BEST_PRACTICE Since preconditions may or may not be actually checked at runtime, avoid
+        using preconditions that have side effects.)
 
         $(P The expression form is:)
 
         ---
         in (expression)
         in (expression, "failure string")
-        out (identifier; expression)
-        out (identifier; expression, "failure string")
-        out (; expression)
-        out (; expression, "failure string")
         {
             ...function body...
         }
@@ -205,6 +220,59 @@ $(H2 $(LNAME2 contracts, Contracts))
         {
             ...contract preconditions...
         }
+        do
+        {
+            ...function body...
+        }
+        ---
+
+
+    $(H3 Postconditions)
+
+        $(P An $(GLINK OutContractExpression) is a postcondition.)
+
+        $(P The first $(GLINK2 expression, AssignExpression) of the $(GLINK2 expression, AssertArguments)
+        must evaluate to true. If it does not, the postcondition has failed.)
+
+        $(P The second $(I AssignExpression), if present, must be implicitly convertible to type `const(char)[]`.
+        )
+
+        $(P An $(GLINK OutStatement) is also a postcondition. Any $(GLINK2 expression, AssertExpression) appearing
+        in an $(I OutStatement) will be an $(I OutContractExpression).
+        )
+
+        $(P Postconditions must semantically be satisfied after the function finishes executing.
+        If it is not, the program enters an $(I Invalid State).
+        )
+
+        $(IMPLEMENTATION_DEFINED Whether the postconditions are actually run or not is implementation defined.
+        This is usually selectable with a compiler switch.
+        Its behavior upon postcondition failure is also usually selectable with a compiler switch.
+        One option is to throw an `AssertError` with a message consisting of the optional second
+        $(I AssignExpression).
+        )
+
+        $(BEST_PRACTICE Use postconditions to validate that the input arguments and return value have values that are
+        expected by the function.)
+
+        $(BEST_PRACTICE Since postconditions may or may not be actually checked at runtime, avoid
+        using postconditions that have side effects.)
+
+        $(P The expression form is:)
+
+        ---
+        out (identifier; expression)
+        out (identifier; expression, "failure string")
+        out (; expression)
+        out (; expression, "failure string")
+        {
+            ...function body...
+        }
+        ---
+
+        $(P The block statement form is:)
+
+        ---
         out
         {
             ...contract postconditions...
@@ -219,32 +287,10 @@ $(H2 $(LNAME2 contracts, Contracts))
         }
         ---
 
-        $(P The optional identifier in either type of `out` contract is set to the return value
-        of the function.)
+        $(P The optional identifier in either type of postcondition is set to the return value
+        of the function, and can be accessed from within the postcondition.)
 
-        $(P By definition, if a pre contract fails, then the function received bad
-        parameters. If a post contract fails, then there is a bug in the function. In either case,
-        an `assert` statement within the corresponding `in` or `out` block will throw an
-        `AssertError`.)
-
-        $(P The keyword `do` can be used to announce the function body. Although any number
-        of pre or post contracts of any form may follow each other, `do` is
-        required only when the last contract before the body is a block statement.
-        (Before the acceptance of
-        $(LINK2 https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1003.md, DIP1003),
-        the keyword `body` was required instead of `do`, and may still be encountered in
-        old code bases. In the long term, `body` may be deprecated, but for now it's allowed both
-        as a keyword in this context and as an identifier elsewhere, although `do` is preferred.) )
-
-        $(P Though any arbitrary D code is allowed in the `in` and `out` contract blocks,
-        their only function should be to verify incoming and outgoing data. It is important
-        to ensure that the
-        code has no side effects, and that the release version of the code
-        will not depend on any  effects of the code.
-        For a release build of the code, `in` and `out` contracts are not
-        inserted.)
-
-        $(P Here is an example function in both forms:)
+    $(H3 Example)
 
         ---
         int fun(ref int a, int b)
@@ -255,7 +301,9 @@ $(H2 $(LNAME2 contracts, Contracts))
         {
             // function body
         }
+        ---
 
+        ---
         int fun(ref int a, int b)
         in
         {
@@ -273,33 +321,30 @@ $(H2 $(LNAME2 contracts, Contracts))
         }
         ---
 
-        $(P The two functions are almost identical semantically. The expressions in the
-        first are lowered to contract blocks that look almost exactly like the second,
-        except that a separate block is created for each expression in the first, thus
-        avoiding shadowing variable names.)
+        $(P The two functions are identical semantically.)
 
-        $(H3 $(LNAME2 in_out_inheritance, In, Out and Inheritance))
+    $(H3 $(LNAME2 in_out_inheritance, In, Out and Inheritance))
 
         $(P If a function in a derived class overrides a function from its
-        super class, then only one of
-        the $(D in) contracts of the function and its base functions
+        super class, then only the preconditions of one of the
+        function and its overridden functions
         must be satisfied.
         Overriding
-        functions then becomes a process of $(I loosening) the $(D in)
-        contracts.
+        functions then becomes a process of $(I loosening) the preconditions.
         )
 
-        $(P A function without an $(D in) contract means that any values
-        of the function parameters are allowed. This implies that if any
-        function in an inheritance hierarchy has no $(D in) contract,
-        then any $(D in) contracts on functions overriding it have no useful
+        $(P A function without preconditions means its precondition is always
+        satisfied.
+        Therefore if any
+        function in an inheritance hierarchy has no preconditions,
+        then any preconditions on functions overriding it have no meaningful
         effect.
         )
 
-        $(P Conversely, all of the $(D out) contracts need to be satisfied,
-        so overriding functions becomes a processes of $(I tightening) the
-        $(D out)
-        contracts.
+        $(P Conversely, all of the postconditions of the function and its
+        overridden functions must to be satisfied.
+        Adding overriding functions then becomes a processes of $(I tightening) the
+        postconditions.
         )
 
 


### PR DESCRIPTION
Use more formal language. Mark IMPLEMENTATION_DEFINED and BEST_PRACTICE sections. Be more exact in specifying the behavior.