### PR TITLE
exorcise the word 'you' from the spec

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -666,14 +666,15 @@ array.length = i;
 ---------
 )
 
-        $(P Picking a good initial guess is an art, but you usually can
-        pick a value covering 99% of the cases.
+        $(P Base selection of the initial size on expected common
+        use cases, which can be determined by instrumenting the code,
+        or simply using good judgement.
         For example, when gathering user
         input from the console - it's unlikely to be longer than 80.
         )
 
-        $(P Also, you may wish to utilize the $(D reserve)
-        function to pre-allocate array data to use with the append operator.)
+        $(P The $(D reserve)
+        function expands an array's capacity for use by the append operator.)
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---------

--- a/spec/const3.dd
+++ b/spec/const3.dd
@@ -370,7 +370,7 @@ struct S
     }
 }
 ---
-    $(P To make the return type $(D_KEYWORD immutable), you need to surround the return type with parentheses:
+    $(P To make the return type $(D_KEYWORD immutable), surround it with parentheses:
     )
 
 ---
@@ -381,7 +381,7 @@ struct S
     }
 }
 ---
-    $(P To make both the return type and the method $(D_KEYWORD immutable), you can write:
+    $(P To make both the return type and the method $(D_KEYWORD immutable), write:
     )
 ---
 struct S

--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -220,7 +220,7 @@ $(P File `ns/package.d`:)
 module ns;
 public import a, b;
 ---
-$(P Then you can import the package containing the extern C++ declarations as follows:)
+$(P Then import the package containing the extern C++ declarations as follows:)
 
 ---
 import ns;

--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -631,8 +631,8 @@ The generated links to D symbols are relative if they have the same root package
 as the module being documented. If not, their URLs are preceded by a
 `$(DOLLAR)(DDOC_ROOT_pkg)` macro, where `pkg` is the root package of the symbol
 being linked to. Links to D symbols are generated with a `$(DOLLAR)(DOC_EXTENSION)`
-macro after the module name. So the generated URL for `[Object]` in the above
-example is as if you had written:
+macro after the module name. Then the generated URL for `[Object]` in the above
+example is as if it had been written:
 )
 
 ---
@@ -640,7 +640,7 @@ $(DOLLAR)(DOC_ROOT_object)object$(DOLLAR)(DOC_EXTENSION)#.Object
 ---
 
 $(P
-You may define your own `DOC_ROOT_` macros for any external packages you wish
+`DOC_ROOT_` macros can be defined for any external packages
 to link to using a $(LINK2 #macros, Macros section).
 )
 
@@ -813,7 +813,7 @@ underscores or hyphens:
 $(P
 As with $(LINK2 #lists, lists), note that the initial `*` in the example above
 will be stripped because it is part of a documentation comment that is delimited
-with asterisks, so you need at least three subsequent asterisks.
+with asterisks. At least three subsequent asterisks are needed.
 )
 
 $(P
@@ -847,7 +847,7 @@ $(P
 )
 
 $(P
-You can insert a literal asterisk by $(LINK2 #punctuation_escapes,
+Insert a literal asterisk by $(LINK2 #punctuation_escapes,
 backslash-escaping) it: `\*` is rendered as *.
 )
 
@@ -893,7 +893,7 @@ $(P
 $(H3 $(LNAME2 punctuation_escapes, Punctuation Escapes))
 
 $(P
-    You can escape any ASCII punctuation symbol with a backslash `\`.
+    Escape any ASCII punctuation symbol with a backslash `\`.
     Doing so outputs the original character without the backslash, except for
     the following characters which output predefined macros instead:
 )

--- a/spec/enum.dd
+++ b/spec/enum.dd
@@ -281,7 +281,7 @@ template Bar(T)
 
     // ... use of 'size' at compile time ...
 
-    // If you take the address of Foo!T.size, it would also go into exe file.
+    // Taking the address of Foo!T.size also causes it to go into the exe file.
     auto p = &Foo!T.size;
 }
 ---

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1991,7 +1991,7 @@ $(GNAME ImportExpression):
     )
 
     $(P Note that by default an import expression will not compile unless
-        you pass one or more paths via the $(B -J) switch. This tells the compiler
+        one or more paths are passed via the $(B -J) switch. This tells the compiler
         where it should look for the files to import. This is a security feature.)
 
         ---

--- a/spec/garbage.dd
+++ b/spec/garbage.dd
@@ -447,7 +447,7 @@ $(H2 $(LNAME2 gc_config, Configuring the Garbage Collector))
 
 $(H2 $(LNAME2 precise_gc, Precise Heap Scanning))
 
-    $(P If you select `precise` as the garbage collector via the options above, type
+    $(P Selecting `precise` as the garbage collector via the options above means type
         information will be used to identify actual or possible pointers or
         references within heap allocated data objects. Non-pointer data will not
         be interpreted as a reference to other memory as a "false pointer". The collector
@@ -455,9 +455,9 @@ $(H2 $(LNAME2 precise_gc, Precise Heap Scanning))
         an integer value, it will still be scanned (e.g. in a `union`).
     )
 
-    $(P If you use the GC memory functions from `core.memory`, and plan to use it
-        for data with a mixture of pointers and non-pointer data you should pass the
-        TypeInfo of your allocated struct, class or type as the optional parameter.
+    $(P To use the GC memory functions from `core.memory`
+        for data with a mixture of pointers and non-pointer data, pass the
+        TypeInfo of the allocated struct, class, or type as the optional parameter.
         The default `null` is interpreted as memory that might contain pointers everywhere.)
         ---------
         struct S { size_t hash; Data* data; }
@@ -465,9 +465,9 @@ $(H2 $(LNAME2 precise_gc, Precise Heap Scanning))
         ---------
 
     $(P $(RED Attention:) Enabling precise scanning needs slightly more caution with
-        type declarations. For example, if you reserve a buffer as part of a struct and later
-        emplace an object instance with references to other allocations into this memory,
-        you must not use basic integer types to reserve the space. Doing so will cause the
+        type declarations. For example, when reserving a buffer as part of a struct and later
+        emplacing an object instance with references to other allocations into this memory,
+        do not use basic integer types to reserve the space. Doing so will cause the
         garbage collector not to detect the references. Instead, use an array type that
         will scan this area conservatively. Using `void*` is usually the best option as it also
         ensures proper alignment for pointers being scanned by the GC.
@@ -494,9 +494,9 @@ $(H2 $(LNAME2 precise_dataseg, Precise Scanning of the DATA and TLS segment))
 
 
     $(P $(RED Attention:) Enabling precise scanning needs slightly more caution typing
-        global memory. For example, if you pre-allocate memory in the DATA/TLS segment and later
+        global memory. For example, to pre-allocate memory in the DATA/TLS segment and later
         emplace an object instance with references to other allocations into this memory,
-        you must not use basic integer types to reserve the space. Doing so will cause the
+        do not use basic integer types to reserve the space. Doing so will cause the
         garbage collector not to detect the references. Instead, use an array type that
         will scan this area conservatively. Using `void*` is usually the best option as it also
         ensures proper alignment for pointers being scanned by the GC.)
@@ -510,8 +510,8 @@ $(H2 $(LNAME2 precise_dataseg, Precise Scanning of the DATA and TLS segment))
         }
         Singleton singleton() { return cast(Singleton)singleton_store.ptr; }
         ---------
-        For precise typing of that area, you can also let the compiler generate the class
-        instance into the DATA segment for you:
+        For precise typing of that area, let the compiler generate the class
+        instance into the DATA segment:
         ---------
         class Singleton { void[] mem; }
         shared(Singleton) singleton = new Singleton;
@@ -524,7 +524,7 @@ $(H2 $(LNAME2 gc_parallel, Parallel marking))
     $(P By default the garbage collector uses all available CPU cores to mark the heap.)
 
     $(P This might affect your application if it has threads that are not suspended
-        during the mark phase of the collection. You can configure the number of
+        during the mark phase of the collection. Configure the number of
         additional threads used for marking by GC option `parallel`,
         e.g. by passing `--DRT-gcopt=parallel:2` on the command
         line or embedding the option into the binary via `rt_options`.
@@ -567,8 +567,8 @@ $(H2 $(LNAME2 gc_registry, Adding your own Garbage Collector))
         extern (C) __gshared string[] rt_options = ["gcopt=gc:mygc"];
         ---
 
-    $(P You can also remove the standard GC implementation from a statically
-        linked binary by redefining the function `extern(C) void* register_default_gcs()`.
+    $(P The standard GC implementation from a statically
+        linked binary can be removed by redefining the function `extern(C) void* register_default_gcs()`.
         If no custom garbage collector has been registered
         all attempts to allocate GC managed memory will terminate
         the application with an appropriate message.)

--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -307,7 +307,7 @@ $(H2 $(LNAME2 structs_and_unions, Structs and Unions))
         do the right shift and masks.
         )
 
-    $(P D does not support declaring variables of anonymous struct types. In such a case you can define a named struct in D and make it private:)
+    $(P D does not support declaring variables of anonymous struct types. In such a case, define a named struct in D and make it private:)
 
 $(CCODE
 union Info  // C code
@@ -387,7 +387,7 @@ $(H2 $(LEGACY_LNAME2 Using C Libraries, using-c-libraries, Using Existing C Libr
 
         $(P For popular C libraries, the first place to look for the corresponding
         D interface file is the $(LINK2 https://github.com/D-Programming-Deimos/, Deimos Project).
-        If it isn't there already, and you write one, please contribute it
+        If it isn't there already, please write and contribute one
         to the Deimos Project.
         )
 

--- a/spec/module.dd
+++ b/spec/module.dd
@@ -133,7 +133,7 @@ lower case package and module names will avoid or minimize problems when moving 
 between dissimilar file systems.)
 
 $(P If the file name of a module is an invalid module name (e.g.
-`foo-bar.d`), you may use a module declaration to set a valid module name:)
+`foo-bar.d`), use a module declaration to set a valid module name:)
 
 ---------
 module foo_bar;

--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -379,7 +379,7 @@ $(OL
     }
     ---
 
-        $(P Alternatively, you can declare a single templated $(D opEquals)
+        $(P Alternatively, declare a single templated $(D opEquals)
         function with an $(DDSUBLINK spec/template, auto-ref-parameters, auto ref)
         parameter:)
     ---
@@ -469,7 +469,7 @@ $(H2 $(LEGACY_LNAME2 FunctionCall, function-call, Function Call Operator Overloa
 
         $(P Note that merely declaring $(D opCall) automatically disables
         $(DDSUBLINK spec/struct, StructLiteral, struct literal) syntax.
-        To avoid the limitation, you need to also declare a
+        To avoid the limitation, declare a
         $(DDSUBLINK spec/struct, Struct-Constructor, constructor)
         so that it takes priority over $(D opCall) in $(D Type(...)) syntax.
         )

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -391,9 +391,9 @@ immutable(S)
 )
 
     $(P This is especially useful when used with inheritance. For example,
-        you might want to implement a final base method which returns a derived
-        class type. Typically you would return a base type, but this won't allow
-        you to call or access derived properties of the type:)
+        consider the implementation of a final base method which returns a derived
+        class type. Typically this would return a base type, but that would prohibit
+        calling or accessing derived properties of the type:)
 
         ---
         interface Addable(T)


### PR DESCRIPTION
I'm sure you will agree that if you remove you from the text, you will find that the text almost always is shorter and you can see it reads better without it.