### PR TITLE
Make .identifier searchable

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1387,7 +1387,7 @@ $(GNAME PrimaryExpression):
 
 $(H3 $(LNAME2 identifier, .Identifier))
 
-    $(P $(IDENTIFIER) is looked up at module scope, rather than the current
+    $(P $(IDENTIFIER) (with a dot before identifier) is looked up at module scope, rather than the current
         lexically nested scope.
     )
 


### PR DESCRIPTION
People have been asking about .identifier and have trouble searching for it or even know what to search for

They see stuff like this in code
.myVar

And have no idea what it is.

I've just added "dot before identifier" to increase the probability of finding it