### PR TITLE
Fixed wrong info about `long` C++ mangling

### DIFF
--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -770,12 +770,12 @@ $(H2 $(LNAME2 data-type-compatibility, Data Type Compatibility))
 
     $(TROW
     $(ARGS $(B long)),
-    $(ARGS $(B long long))
+    $(ARGS $(B long) if it is 64 bit wide, otherwise $(B long long))
     )
 
     $(TROW
     $(ARGS $(B ulong)),
-    $(ARGS $(B unsigned long long))
+    $(ARGS $(B unsigned long) if it is 64 bit wide, otherwise $(B unsigned long long))
     )
 
     $(TROW

--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -770,12 +770,12 @@ $(H2 $(LNAME2 data-type-compatibility, Data Type Compatibility))
 
     $(TROW
     $(ARGS $(B long)),
-    $(ARGS $(B long) if it is 64 bit wide, otherwise $(B long long))
+    $(ARGS $(B long) if it is 64 bits wide, otherwise $(B long long))
     )
 
     $(TROW
     $(ARGS $(B ulong)),
-    $(ARGS $(B unsigned long) if it is 64 bit wide, otherwise $(B unsigned long long))
+    $(ARGS $(B unsigned long) if it is 64 bits wide, otherwise $(B unsigned long long))
     )
 
     $(TROW


### PR DESCRIPTION
Real mangling of `long` does not currently match the spec. According to a comment at https://github.com/dlang/druntime/pull/3400 , it's the spec that should change.