### PR TITLE
spec/version.dd: Document the D_PIE predefined version

### DIFF
--- a/spec/version.dd
+++ b/spec/version.dd
@@ -338,6 +338,8 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
         $(TROW $(ARGS $(D D_SoftFloat)) , $(ARGS The target hardware does not have a floating point unit))
         $(TROW $(ARGS $(D D_PIC)) , $(ARGS Position Independent Code
                 (command line switch $(DDSUBLINK dmd-linux, switch-fPIC, $(TT -fPIC))) is being generated))
+        $(TROW $(ARGS $(D D_PIE)) , $(ARGS Position Independent Executable
+                (command line switch $(DDSUBLINK dmd-linux, switch-fPIE, $(TT -fPIE))) is being generated))
         $(TROW $(ARGS $(D D_SIMD)) , $(ARGS $(DDLINK spec/simd, simd, Vector extensions) (via $(D __simd)) are supported))
         $(TROW $(ARGS $(D D_AVX)) , $(ARGS AVX Vector instructions are supported))
         $(TROW $(ARGS $(D D_AVX2)) , $(ARGS AVX2 Vector instructions are supported))


### PR DESCRIPTION
This is added by the compiler when `-fPIE` is seen on the command-line.