### PR TITLE
Add notes in the spec that complex and imaginary types are deprecated

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -18,7 +18,7 @@ $(SPEC_S Deprecated Features,
         $(TROW $(DEPLINK Using the result of a comma expression),                 2.072,  2.072,  2.079, &nbsp;)
         $(TROW $(DEPLINK delete),                                                 &nbsp;, 2.079, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK scope as a type constraint),                             &nbsp;, 2.087, &nbsp;, &nbsp;)
-        $(TROW $(DEPLINK Imaginary and complex types),                            future, &nbsp;, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK Imaginary and complex types),                            future, 2.097, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Implicit catch statement),                               2.072, 2.072,  2.081, &nbsp; )
         $(TROW $(DEPLINK .sort and .reverse properties for arrays),               ?,     2.072,  &nbsp;, 2.075)
         $(TROW $(DEPLINK C-style array pointers),                                 ?,     2.072,  2.082, &nbsp;)

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1857,7 +1857,6 @@ $(H3 $(LNAME2 uniform_construction_syntax, Uniform construction syntax for built
         ---
         auto a = ushort();  // same as: ushort.init
         auto b = wchar();   // same as: wchar.init
-        auto c = creal();   // same as: creal.init
         ---
 
 

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -877,19 +877,12 @@ $(GNAME LeadingDecimal):
         and those followed by $(B L) are of type `real`.
         )
 
-        $(P If a floating literal is followed by $(B i), then it is an
-        $(I ireal) (imaginary) type.
-        )
-
         $(P Examples:)
 
 ---------
 0x1.FFFFFFFFFFFFFp1023 // double.max
 0x1p-52                // double.epsilon
 1.175494351e-38F       // float.min
-6.3i                   // idouble 6.3
-6.3fi                  // ifloat 6.3
-6.3Li                  // ireal 6.3
 ---------
 
         $(P The literal may not exceed the range of the type.
@@ -904,6 +897,9 @@ $(GNAME LeadingDecimal):
         1.f; // error
         1.;  // OK, double
         ---
+
+        $(P NOTE: Floating literals followed by $(B i) to denote imaginary
+        floating point values have been deprecated.)
 
 
 $(H2 $(LNAME2 keywords, Keywords))

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -130,8 +130,6 @@ import core.simd : float4;
 enum E : float { a, b }
 
 static assert(__traits(isFloating, float));
-static assert(__traits(isFloating, idouble));
-static assert(__traits(isFloating, creal));
 static assert(__traits(isFloating, E));
 static assert(__traits(isFloating, float4));
 

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -128,6 +128,9 @@ $(H2 $(LEGACY_LNAME2 Basic Data Types, basic-data-types, Basic Data Types))
     type supported by the x86 FPU.
     )
 
+    $(P NOTE: Complex and imaginary types `ifloat`, `idouble`, `ireal`, `cfloat`, `cdouble`,
+    and `creal` have been deprecated in favor of `std.complex.Complex`.)
+
 $(H2 $(LEGACY_LNAME2 Derived Data Types, derived-data-types, Derived Data Types))
 
     $(UL


### PR DESCRIPTION
Spec part of dlang/dmd#12390.