### PR TITLE
statement.dd: Fix typo, use writefln properly

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1689,7 +1689,7 @@ int main()
     }
     catch (Exception e)
     {
-        writeln("catch %s", e.msg);
+        writefln("catch %s", e.msg);
     }
     writeln("done");
     return 0;


### PR DESCRIPTION
Fix a minor typo in the spec.

The code did compile and worked,
but produced the wrong output before.