### PR TITLE
Fix Issue 21906 - obscure sentence in the introduction to phases of c…

### DIFF
--- a/spec/intro.dd
+++ b/spec/intro.dd
@@ -15,8 +15,7 @@ $(H2 Phases of Compilation)
 $(P The process of compiling is divided into multiple phases. Each phase is
 independent of subsequent phases. For example, the scanner is not affected by
 the semantic analyzer. This separation of passes makes language tools like
-syntax-directed editors relatively easy to create. It is also possible to
-compress D source by storing it in $(SINGLEQUOTE tokenized) form.)
+syntax-directed editors relatively easy to create.
 
 $(OL
         $(LI $(B source character set)$(BR)

--- a/spec/intro.dd
+++ b/spec/intro.dd
@@ -15,7 +15,7 @@ $(H2 Phases of Compilation)
 $(P The process of compiling is divided into multiple phases. Each phase is
 independent of subsequent phases. For example, the scanner is not affected by
 the semantic analyzer. This separation of passes makes language tools like
-syntax-directed editors relatively easy to create.
+syntax-directed editors relatively easy to create.)
 
 $(OL
         $(LI $(B source character set)$(BR)


### PR DESCRIPTION
…ompilation

Removed sentence due to lack of relevance to specification as an abstract statement of behaviour and lack of historical significance. 