### PR TITLE
Update IRC channel (from Freenode to Libera.Chat)

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -261,7 +261,7 @@ $(SUBMENU_MANUAL
     $(SUBMENU_LINK https://twitter.com/search?q=%23dlang, Twitter)
     $(SUBMENU_LINK $(ROOT_DIR)calendar.html, Calendar)
     $(SUBMENU_LINK_DIVIDER https://forum.dlang.org, Forums)
-    $(SUBMENU_LINK irc://irc.freenode.net/d, IRC)
+    $(SUBMENU_LINK irc://irc.libera.chat/d, IRC)
     $(SUBMENU_LINK https://discord.gg/bMZk9Q4, Community Discord)
     $(SUBMENU_LINK https://wiki.dlang.org, Wiki)
     $(SUBMENU_LINK_DIVIDER https://github.com/dlang, GitHub)

--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -83,7 +83,7 @@ html(lang='en-US')
                   li.menu-divider
                     a(href="https://forum.dlang.org") Forums
                   li
-                    a(href="irc://irc.freenode.net/d") IRC
+                    a(href="irc://irc.libera.chat/d") IRC
                   li
                     a(href="https://wiki.dlang.org") Wiki
                   li.menu-divider

--- a/index.dd
+++ b/index.dd
@@ -404,7 +404,7 @@ $(DIVC boxes,
     $(DIVC row,
         $(TOUR comments, Community,
             $(P Discuss D on the $(LINK2 https://forum.dlang.org/, forums), join
-                the $(LINK2 irc://irc.freenode.net/d, IRC channel), read our
+                the $(LINK2 irc://irc.libera.chat/d, IRC channel), read our
                 $(LINK2 https://dlang.org/blog, official Blog), or follow us
                 on $(LINK2 https://twitter.com/D_Programming, Twitter).
                 Browse the $(LINK2 https://wiki.dlang.org/, wiki), where among


### PR DESCRIPTION
Following most open-source projects, we are moving our official IRC presence from Freenode to Libera.Chat.

Some users have chosen to move to OFTC instead. It is not mentioned here but I updated https://wiki.dlang.org/ to mention OFTC as well.