### PR TITLE
spec: DDoc syntax fixes

### DIFF
--- a/spec/errors.dd
+++ b/spec/errors.dd
@@ -92,7 +92,7 @@ $(UL
 )
 
 $(P The solution is to use exception handling to report errors. All
-errors are objects derived from abstract $(LINK2 https://dlang.org/phobos/object.html#.Error, $(D class $Error)). $(D Error)
+errors are objects derived from the abstract class $(LINK2 https://dlang.org/phobos/object.html#.Error, $(D Error)). $(D Error)
 has a pure virtual function called toString() which produces a $(D string)
 with a human readable description of the error.)
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2105,7 +2105,7 @@ void test()
 }
 ------
 
-        $(D _arguments) gives the number of arguments and the `typeid`
+        $(P $(D _arguments) gives the number of arguments and the `typeid`
         of each, enabling type safety to be checked at run time.)
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
@@ -3095,7 +3095,7 @@ static assert(countTen(12) == 12);  // invalid, modifies y.
     $(NOTE `__ctfe` can be used to provide
         an alternative execution path to avoid operations which are forbidden
         in CTFE. Every usage of $(D __ctfe) is statically evaluated
-        and has no run-time cost.)
+        and has no run-time cost.
     )
 
     $(P Non-recoverable errors (such as $(D_KEYWORD assert) failures) are illegal.
@@ -3250,7 +3250,7 @@ $(H3 $(LNAME2 safe-functions, Safe Functions))
         )
 
         $(P When indexing or slicing an array, an out of bounds access
-            will cause a runtime error.)
+            will cause a runtime error.
         )
 
         $(P Functions nested inside safe functions default to being
@@ -3646,7 +3646,7 @@ $(H2 $(LNAME2 pseudo-member, Uniform Function Call Syntax (UFCS)))
         $(P is the equivalent of:)
 
         ---
-        copy(sort(array(map!(a => a.idup)(byLine(stdin, KeepTerminator.yes))), lockingTextWriter(stdout));
+        copy(sort(array(map!(a => a.idup)(byLine(stdin, KeepTerminator.yes)))), lockingTextWriter(stdout));
         ---
 
         $(P UFCS works with $(D @property) functions:)

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -547,7 +547,7 @@ $(H2 $(LNAME2 escape_sequences, Escape Sequences))
         $(D \U0001F603) represents the Unicode character U+1F603 (SMILING FACE
         WITH OPEN MOUTH).)
     $(TROW $(D \)$(I name), Named character entity from the HTML5
-        specification. These names begin with $(CODE_AMP) and end with $(D ;), e.g., $(CODE_AMP)$D(euro;).
+        specification. These names begin with $(CODE_AMP) and end with $(D ;), e.g.$(COMMA) $(D $(AMP)euro;).
         See $(GLINK2 entity, NamedCharacterEntity).)
     )
 

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1663,7 +1663,7 @@ $(GNAME FinallyStatement):
         the capture of the entire chain.
         )
 
-        $(P Thrown objects derived from $(LINK2 https://dlang.org/phobos/object.html#.Error, $(D class $Error)) are treated differently. They
+        $(P Thrown objects derived from the $(LINK2 https://dlang.org/phobos/object.html#.Error, $(D Error)) class are treated differently. They
         bypass the normal chaining mechanism, such that the chain can only be
         caught by catching the first $(D Error). In addition to the list of
         subsequent exceptions, $(D Error) also contains a pointer that points


### PR DESCRIPTION
I wrote a DDoc parser (to extract the grammar) and it choked on the invalid DDoc constructs fixed in this commit.