### PR TITLE
Update nightlies link to refer to the GitHub releases

### DIFF
--- a/changelog/pending.ddoc
+++ b/changelog/pending.ddoc
@@ -1,7 +1,7 @@
 VERSION=
 $(DIVC version,
 $(P
-$(B $(LARGE $(LINK2 http://nightlies.dlang.org, Download D nightlies)))$(BR)
+$(B $(LARGE $(LINK2 https://github.com/dlang/dmd/releases/tag/nightly, Download D nightlies)))$(BR)
 $(SMALL $1)
 
 )


### PR DESCRIPTION
The original nightlies are no longer maintaned and the current nightlies
are uploaded to GitHub.

---

Unless someone is willing / able to come up with a way to mirror these builds to the website.