### PR TITLE
spec: Remove definitions redundant with MissingFunctionBody

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -315,7 +315,6 @@ $(H2 $(LNAME2 constructors, Constructors))
 
 $(GRAMMAR
 $(GNAME Constructor):
-    $(D this) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(D ;)
     $(D this) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
     $(GLINK2 template, ConstructorTemplate)
 )
@@ -678,7 +677,6 @@ $(H2 $(LNAME2 destructors, Destructors))
 
 $(GRAMMAR
 $(GNAME Destructor):
-    $(D ~ this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(D ;)
     $(D ~ this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
 )
 
@@ -1009,7 +1007,6 @@ $(H2 $(LNAME2 allocators, Class Allocators))
 $(B Note): Class allocators are deprecated in D2.
 $(GRAMMAR
 $(GNAME Allocator):
-    $(D new) $(GLINK2 function, Parameters) $(D ;)
     $(D new) $(GLINK2 function, Parameters) $(GLINK2 function, FunctionBody)
 )
 
@@ -1089,7 +1086,6 @@ assert(foo.x == int.init);  // object is still accessible
 
 $(GRAMMAR
 $(GNAME Deallocator):
-    $(D delete) $(GLINK2 function, Parameters) $(D ;)
     $(D delete) $(GLINK2 function, Parameters) $(GLINK2 function, FunctionBody)
 )
 


### PR DESCRIPTION
`$(D ;)` is already a possible `FunctionBody` (as `MissingFunctionBody`).