### PR TITLE
spec/lex.dd: Describe TokenString within the grammar

### DIFF
--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -168,6 +168,11 @@ $(GNAME Tokens):
     $(GLINK Token) $(GSELF Tokens)
 
 $(GNAME Token):
+    $(D {)
+    $(D })
+    $(GLINK TokenNoBraces)
+
+$(GNAME TokenNoBraces):
 $(MULTICOLS 4,     $(GLINK Identifier)
     $(GLINK StringLiteral)
     $(GLINK CharacterLiteral)
@@ -207,8 +212,6 @@ $(MULTICOLS 4,     $(GLINK Identifier)
     $(D $(RPAREN))
     $(D [)
     $(D ])
-    $(D {)
-    $(D })
     $(D ?)
     $(D ,)
     $(D ;)
@@ -344,7 +347,15 @@ $(GNAME DelimitedString):
 )
 $(GRAMMAR
 $(GNAME TokenString):
-    $(D q{) $(GLINK Tokens)$(OPT) $(D })
+    $(D q{) $(GLINK TokenStringTokens)$(OPT) $(D })
+
+$(GNAME TokenStringTokens):
+    $(GLINK TokenStringToken)
+    $(GLINK TokenStringToken) $(GSELF TokenStringTokens)
+
+$(GNAME TokenStringToken):
+    $(GLINK TokenNoBraces)
+    $(D {) $(GLINK TokenStringTokens)$(OPT) $(D })
 )
 
         $(P


### PR DESCRIPTION
Use the same approach as `NestingBlockComment`.

NB: `Tokens` and `Token` are not used anywhere in the grammar any more, and are therefore only illustrative.