### PR TITLE
spec/statement.dd: Remove PSSEMI from LabeledStatement

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -142,7 +142,6 @@ $(P     Statements can be labeled. A label is an identifier that
 $(GRAMMAR
 $(GNAME LabeledStatement):
     $(GLINK_LEX Identifier) $(D :)
-    $(GLINK_LEX Identifier) $(D :) $(PSSEMI)
     $(GLINK_LEX Identifier) $(D :) $(PSSEMI_PSCURLYSCOPE)
 )
 


### PR DESCRIPTION
A `{ }` block after a label does always introduce a scope.

They are also syntactically identical, and therefore indistinguishable.