### PR TITLE
spec: Add EmptyDeclaration and EmptyStatement

### DIFF
--- a/spec/module.dd
+++ b/spec/module.dd
@@ -37,6 +37,9 @@ $(GNAME DeclDef):
     $(GLINK2 template-mixin, TemplateMixinDeclaration)
     $(GLINK2 template-mixin, TemplateMixin)
     $(GLINK MixinDeclaration)
+    $(GLINK EmptyDeclaration)
+
+$(GNAME EmptyDeclaration):
     $(D ;)
 )
 

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -12,16 +12,19 @@ $(HEADERNAV_TOC)
 
 $(GRAMMAR
 $(GNAME Statement):
-    $(D ;)
+    $(GLINK EmptyStatement)
     $(GLINK NonEmptyStatement)
     $(GLINK ScopeBlockStatement)
+
+$(GNAME EmptyStatement):
+    $(D ;)
 
 $(GNAME NoScopeNonEmptyStatement):
     $(GLINK NonEmptyStatement)
     $(GLINK BlockStatement)
 
 $(GNAME NoScopeStatement):
-    $(D ;)
+    $(GLINK EmptyStatement)
     $(GLINK NonEmptyStatement)
     $(GLINK BlockStatement)
 
@@ -1096,7 +1099,7 @@ $(GNAME StatementListNoCaseNoDefault):
     $(GLINK StatementNoCaseNoDefault) $(GSELF StatementListNoCaseNoDefault)
 
 $(GNAME StatementNoCaseNoDefault):
-    $(D ;)
+    $(GLINK EmptyStatement)
     $(GLINK NonEmptyStatementNoCaseNoDefault)
     $(GLINK ScopeBlockStatement)
 )


### PR DESCRIPTION
- Semantically indicate that the various occurrences of `$(D ;)` all mean the same thing
- Add explicit counterpart to e.g. `NonEmptyStatement`
- Avoiding mixing leaf and non-leaf nodes makes the grammar more structured in general.
