### PR TITLE
spec/lex.dd: Describe the source file layout within the grammar

### DIFF
--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -13,6 +13,24 @@ phase of translation.)
 
 $(H2 $(LNAME2 source_text, Source Text))
 
+$(GRAMMAR
+$(GNAME SourceFile):
+    $(GLINK ByteOrderMark) $(GLINK2 module, Module)$(OPT)
+    $(GLINK Shebang) $(GLINK2 module, Module)$(OPT)
+    $(GLINK2 module, Module)$(OPT)
+)
+$(GRAMMAR_LEX
+$(GNAME ByteOrderMark):
+    $(B \uFEFF)
+
+$(GNAME Shebang):
+    $(B #!) $(GLINK Characters)$(OPT) $(GLINK EndOfShebang)
+
+$(GNAME EndOfShebang):
+    $(B \u000A)
+    $(GLINK EndOfFile)
+)
+
 $(P Source text can be encoded as any one of the following:)
 
         $(LIST


### PR DESCRIPTION
- The optional BOM is mentioned in prose, but not specified.

- Describe the shebang line, which was hitherto undocumented.

  The described syntax is what the current DMD implementation does.

- Define that empty source files are valid.