### PR TITLE
spec/declaration.dd: Add AtAttribute to StorageClass

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -90,6 +90,7 @@ $(GNAME StorageClasses):
 $(GNAME StorageClass):
 $(MULTICOLS 5,     $(GLINK2 attribute, LinkageAttribute)
     $(GLINK2 attribute, AlignAttribute)
+    $(GLINK2 attribute, AtAttribute)
     $(D deprecated)
     $(D enum)
     $(D static)


### PR DESCRIPTION
According to DMD, @-attributes may occur wherever storage classes are parsed (see `Parser.parseStorageClasses`).