### PR TITLE
spec/function.dd: Make VariadicArgumentsAttributes optional in ParameterList

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -33,7 +33,7 @@ $(GNAME Parameters):
 $(GNAME ParameterList):
     $(GLINK Parameter)
     $(GLINK Parameter) $(D ,) $(GSELF ParameterList)
-    $(GLINK VariadicArgumentsAttributes) $(D ...)
+    $(GLINK VariadicArgumentsAttributes)$(OPT) $(D ...)
 
 $(GNAME Parameter):
     $(GLINK ParameterAttributes)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator)


### PR DESCRIPTION
const / shared / etc. are allowed before "...", but not required.