### PR TITLE
spec/function.dd: Remove "ref" from "return ref"

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -56,7 +56,7 @@ $(GNAME InOut):
     $(D lazy)
     $(D out)
     $(D ref)
-    $(RELATIVE_LINK2 return-ref-parameters, $(D return ref))
+    $(RELATIVE_LINK2 return-ref-parameters, $(D return))
     $(D scope)
 
 $(GNAME VariadicArgumentsAttributes):

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -56,7 +56,7 @@ $(GNAME InOut):
     $(D lazy)
     $(D out)
     $(D ref)
-    $(RELATIVE_LINK2 return-ref-parameters, $(D return))
+    $(D return)
     $(D scope)
 
 $(GNAME VariadicArgumentsAttributes):


### PR DESCRIPTION
Return-ref parameters don't need to specifically be declared with the exact token sequence `return ref`. For example, `ref return` also works, as does e.g. `return scope int* a`.