### PR TITLE
spec/function.dd: Allow trailing comma in ParameterList

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -32,6 +32,7 @@ $(GNAME Parameters):
 
 $(GNAME ParameterList):
     $(GLINK Parameter)
+    $(GLINK Parameter) $(D ,)
     $(GLINK Parameter) $(D ,) $(GSELF ParameterList)
     $(GLINK VariadicArgumentsAttributes) $(D ...)
 


### PR DESCRIPTION
Match `ArgumentList` and DMD behavior.