### PR TITLE
spec/iasm.dd: Add definition for Opcode

### DIFF
--- a/spec/iasm.dd
+++ b/spec/iasm.dd
@@ -79,8 +79,11 @@ $(GNAME AsmInstruction):
     $(D dl) $(GLINK_LEX StringLiteral)
     $(D dw) $(GLINK_LEX StringLiteral)
     $(D dq) $(GLINK_LEX StringLiteral)
-    $(I Opcode)
-    $(I Opcode) $(GLINK Operands)
+    $(GLINK Opcode)
+    $(GLINK Opcode) $(GLINK Operands)
+
+$(GNAME Opcode):
+    $(GLINK_LEX Identifier)
 
 $(GNAME Operands):
     $(GLINK Operand)


### PR DESCRIPTION
The full set of supported opcodes is probably an implementation detail, so we should at least include definitions for the syntax used to lex them.