### PR TITLE
spec/function.dd: Document optional contracts for ShortenedFunctionBody

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -118,6 +118,7 @@ $(GNAME MissingFunctionBody):
 
 $(GNAME ShortenedFunctionBody):
     $(D =>) $(GLINK2 expression, AssignExpression) $(D ;)
+    $(GLINK FunctionContracts)$(OPT) $(GLINK InOutContractExpression) $(D =>) $(GLINK2 expression, AssignExpression) $(D ;)
 )
 
         $(P Examples:)


### PR DESCRIPTION
See e.g. https://github.com/dlang/dmd/blob/21c3c5ab24ef2bf42822e7a41ab152df3f0434a4/test/compilable/shortened_methods.d#L9

Block contracts are allowed, as long as the last contract is using the expression syntax.

I think I should have submitted this as part of the previous batch, but for some reason it fell through.