### PR TITLE
spec/iasm.dd: Improve definition of Opcode

### DIFF
--- a/spec/iasm.dd
+++ b/spec/iasm.dd
@@ -84,6 +84,9 @@ $(GNAME AsmInstruction):
 
 $(GNAME Opcode):
     $(GLINK_LEX Identifier)
+    $(D int)
+    $(D in)
+    $(D out)
 
 $(GNAME Operands):
     $(GLINK Operand)


### PR DESCRIPTION
After adding [the GDC inline assembler grammar](https://github.com/dlang/dlang.org/pull/3062) to [tree-sitter-d](https://github.com/CyberShadow/tree-sitter-d), I noticed an unexpected regression in [parsing the top community D projects](https://github.com/CyberShadow/tree-sitter-d/issues/3): [the following code](https://github.com/dlang-community/dfmt/blob/f6490b31c969e7ec07f57958c2104a2479060b75/tests/issue0251.d#L3-L3), which previously parsed successfully under the grammar with just the DMD inline assembler syntax, now failed to parse.

My first thought was that it must be a bug in tree-sitter. How could adding an additional alternative definition for a rule result in the old definition not working any more? That made no sense. However, DustMite-ing the tree-sitter-d grammar revealed that tree-sitter was actually working correctly. What happened was:

- We defined `Opcode` to be an `Identifier`
- An identifier cannot be a keyword. Though we don't have a way to express this within our formal grammar, tree-sitter knows this, because we configure [keyword extraction](http://tree-sitter.github.io/tree-sitter/creating-parsers#keyword-extraction) for `Identifier`.
- `int` is a keyword.
- Therefore, `int` cannot be an `Opcode`.

The token pair `asm` `{` is a valid beginning for both `AsmStatement` and `GccAsmStatement`, so the next token can disambiguate the two. In the GDC syntax, one rule that can appear here is a `AssignExpression`. And, e.g. `int` `.` `min` is an `AssignExpression`.

But, why did it work before? This is because keywords in tree-sitter are context-sensitive, so, if either a keyword or the word token can occur in some context, and both are matched, tree-sitter chooses the keyword. Since no keyword could have appeared alongside `Identifier` before, there was no conflict.

What do we do about it? 

1. One option was considered in #3055, simply to list all possible opcodes (which would also have the benefit of validating them at tree-sitter parsing time). However, that might not be practical if the list of opcodes changes frequently, or if different compilers support different sets of opcodes. 

2. Another is to do [what DMD itself does](https://github.com/dlang/dmd/blob/b25ef77c92afddefcf70b928b950a2f0729af52f/src/dmd/iasmdmd.d#L153-L163), and simply list those keywords which also match assembler instructions as explicit options alongside `Identifier`, which is what is proposed in this patch.