### PR TITLE
treewide: fix duplicate words and typos

### DIFF
--- a/articles/d-floating-point.dd
+++ b/articles/d-floating-point.dd
@@ -81,7 +81,7 @@ $(D nextDown(x)) gives the next representable number which is less than x.
 
 $(P Numerical analysts often describe errors in terms of "units in the last place"(ulp), a surprisingly subtle term which is often used rather carelessly. [footnote:
 The most formal definition is found in [J.-M. Muller, "On the definition of ulp(x)",INRIA Technical Report 5504 (2005).]: If $(D x) is a real number that lies between two finite consecutive floating-point numbers a and b of type F, without being equal to one of them, then ulp(x)=abs(b-a); otherwise ulp(x) = $(D x*F.epsilon). Moreover, ulp(NaN) is NaN, and ulp($(PLUSMN)F.infinity) = $(PLUSMN)$(D F.max*F.epsilon).]
-I prefer a far simpler definition: The difference in ulps between two numbers x and y is is the number of times which you need to call nextUp() or nextDown() to move from x to y. [Footnote: This will not be an integer if either x or y is a real number, rather than a floating point number.]
+I prefer a far simpler definition: The difference in ulps between two numbers x and y is the number of times which you need to call nextUp() or nextDown() to move from x to y. [Footnote: This will not be an integer if either x or y is a real number, rather than a floating point number.]
 The D library function $(D feqrel(x, y)) gives the number of bits which are equal between x and y; it is an easy way to check for loss-of-precision problems.
 )
 
@@ -176,7 +176,7 @@ $(TR $(TD max_10_exp) $(TD +38) $(TD +308) $(TD +4932) $(TD +4932) $(TD 385) $(T
 )
 
 $(P When writing code which should adapt to different CPUs at compile time, use $(D static if) with the $(D mant_dig) property. For example, $(D static if (real.mant_dig==64)) is true if 80-bit reals are available.
-For binary types, the $(D dig) property gives only the $(I minimum) number of valid decimal digits. To ensure that that every representable number has a unique decimal representation, two additional digits are required. Similarly, for decimal numbers, $(D mant_dig) is a lower bound on the number of valid binary digits.
+For binary types, the $(D dig) property gives only the $(I minimum) number of valid decimal digits. To ensure that every representable number has a unique decimal representation, two additional digits are required. Similarly, for decimal numbers, $(D mant_dig) is a lower bound on the number of valid binary digits.
 )
 
 $(H2 Useful relations for a floating point type $(D F), where $(D x) and $(D y) are of type $(D F))

--- a/articles/hijack.dd
+++ b/articles/hijack.dd
@@ -130,7 +130,7 @@ to add the rules:
 $(OL
 $(LI by default functions can only overload against other functions in the same
 module)
-$(LI if a name is found in more than one scope, in order to use it it must
+$(LI if a name is found in more than one scope, in order to use it, it must
 be fully qualified)
 $(LI in order to overload functions from multiple modules together, an alias
 statement is used to merge the overloads)

--- a/dstyle.dd
+++ b/dstyle.dd
@@ -70,9 +70,9 @@ struct FooAndBar;
 
     $(DD Templates which have the same name as a symbol within that template
          (and instantiations of that template are therefore replaced with that
-         symbol) should be capitalized in the same way that that inner symbol
-         would be capitalized if it weren't in a template - e.g. types should be
-         PascalCased and values should be camelCased.
+         symbol) should be capitalized in the same way that the inner symbol
+         would be capitalized if it weren't in a template - e.g. types should
+         be PascalCased and values should be camelCased.
 
 -------------------------
 template GetSomeType(T) { alias GetSomeType = T; }

--- a/foundation/donate.dd
+++ b/foundation/donate.dd
@@ -48,7 +48,7 @@ the art in the D programming language.)
 
 $(P If you want to support us and have no particular project you'd like your
 donation to be directed toward, then your money is best aimed at the General
-Fund where we'll use it as we need it. You may donate to to the General Fund via
+Fund where we'll use it as we need it. You may donate to the General Fund via
 $(HTTPS www.flipcause.com/secure/cause_pdetails/NDMzMzE=, our targeted Flipcause
 campaign) or via any of the other donation methods listed further down this page
 (the General Fund is the default with these methods when you leave no comments

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -604,7 +604,7 @@ $(GNAME VoidInitializer):
         $(BEST_PRACTICE
         $(OL
         $(LI Void initializers are useful when a static array is on the stack,
-        but may only be partially used, such as as a temporary buffer.
+        but may only be partially used, such as a temporary buffer.
         Void initializers will potentially speed up the code, but they introduce risk, since one must ensure
         that array elements are always set before read.)
         $(LI The same is true for structs.)

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1869,7 +1869,7 @@ $(GNAME FunctionLiteralBody2):
         ---
         )
 
-    $(NOTE The syntax `Identifier { statement; }` is not supported because because it is
+    $(NOTE The syntax `Identifier { statement; }` is not supported because it is
         easily confused with statements `x = Identifier; { statement; };`
         if the semicolons were accidentally omitted.
         )

--- a/spec/importc.dd
+++ b/spec/importc.dd
@@ -8,7 +8,7 @@ $(HEADERNAV_TOC)
 
     $(P ImportC is a C compiler embedded into the D implementation.
     Its purpose is to enable direct importation of C files, without
-    needing to manually prepare a D file corresponding to the the declarations
+    needing to manually prepare a D file corresponding to the declarations
     in the C file. It enables directly compiling C files into modules, and
     linking them in with D code to form an executable. It can be used
     as a C compiler to compile and link 100% C programs.

--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -98,9 +98,9 @@ $(H2 $(LNAME2 storage_allocation, Storage Allocation))
         )
 
         $(P If pointers to D garbage collector allocated memory are passed to
-        C functions, it's critical to ensure that that memory will not
-        be collected by the garbage collector before the C function is
-        done with it. This is accomplished by:
+        C functions, it's critical to ensure that the memory will not be
+        collected by the garbage collector before the C function is done with
+        it. This is accomplished by:
         )
 
         $(UL


### PR DESCRIPTION
With the help of '(\b.+) \1\b' regex, it was found some incorrect
wording on the spec such as duplicate words or typos such as missing
punctuation.