### PR TITLE
Remove unsupported mechanism for keeping pointers alive

### DIFF
--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -108,9 +108,6 @@ $(H2 $(LNAME2 storage_allocation, Storage Allocation))
         $(LI Making a copy of the data using core.stdc.stdlib.malloc() and passing
         the copy instead.)
 
-        $(LI Leaving a pointer to it on the stack (as a parameter or
-        automatic variable), as the garbage collector will scan the stack.)
-
         $(LI Leaving a pointer to it in the static data segment, as the
         garbage collector will scan the static data segment.)
 


### PR DESCRIPTION
As noted by @WalterBright on the D forums, only `GC.addRoot` is a supported mechanism for keeping a pointer to GC data alive, you may not rely on stack references.

See https://forum.dlang.org/post/siol11$2hic$1@digitalmars.com