### PR TITLE
Updated D/C++ template comparisons up to C++20.

### DIFF
--- a/articles/template-comparison.dd
+++ b/articles/template-comparison.dd
@@ -2,8 +2,8 @@ Ddoc
 
 $(COMMUNITY Template Comparison,
 
-$(P C++ pioneered templates and template metaprogramming, and continues
-to improve on it with C++0x.
+$(P C++ pioneered templates and template metaprogramming and has continued
+to improve on it.
 The D programming language is the first to comprehensively reengineer
 templates based on the C++ experience.
 )
@@ -13,33 +13,31 @@ templates based on the C++ experience.
 
         <thead>
         $(TR
-        $(TH Feature)
-        $(TH D)
-        $(TH C++98)
-        $(TH C++0x)
+            $(TH Feature)
+            $(TH D)
+            $(TH C++)
         )
         </thead>
 
         <tbody>
 
         $(TR
-        $(TD Argument list delineation)
-        $(TD Uses !( ), as in Foo!(int). $(BR)Can omit parens when the argument is a single lexical token: Foo!int)
-        $(TD Uses &lt; &gt; as in Foo&lt;int&gt;)
-        $(TD No change)
+            $(TD Argument list delineation)
+            $(TD Uses !( ), as in Foo!(int). $(BR)Can omit parens when the argument is a single lexical token: Foo!int)
+            $(TD Uses &lt; &gt; as in Foo&lt;int&gt;)
         )
 
         $(TR
-        $(TD Class Templates)
-        $(TD Yes:
+            $(TD Class Templates)
+            $(TD Yes:
 ---
 class Foo(T)
 {
     T x;
 }
 ---
-)
-        $(TD Yes:
+            )
+            $(TD Yes:
 $(CPPCODE2
 template&lt;class T&gt;
 class Foo
@@ -47,21 +45,20 @@ class Foo
     T x;
 };
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Function Templates)
-        $(TD Yes:
+            $(TD Function Templates)
+            $(TD Yes:
 ---
 T foo(T)(T i)
 {
     ...
 }
 ---
-)
-        $(TD Yes:
+            )
+            $(TD Yes:
 $(CPPCODE2
 template&lt;class T&gt;
 T foo(T i)
@@ -69,44 +66,49 @@ T foo(T i)
     ...
 }
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Member Templates)
-        $(TD Yes)
-        $(TD Yes)
-        $(TD No change)
+            $(TD Member Templates)
+            $(TD Yes)
+            $(TD Yes)
         )
 
         $(TR
-        $(TD Constructor Templates)
-        $(TD No)
-        $(TD Yes)
-        $(TD No change)
+            $(TD Constructor Templates)
+            $(TD No)
+            $(TD Yes)
         )
 
         $(TR
-        $(TD Parameterize any Declaration)
-        $(TD Yes, classes, functions, typedefs,
-        variables, enums, etc. can be parameterized,
-        such as this variable:
+            $(TD Parameterize any Declaration)
+            $(TD Yes, classes, functions, typedefs,
+            variables, enums, etc. can be parameterized,
+            such as this variable:
 ---
 template Foo(T)
 {
     static T* p;
 }
 ---
+            )
+            $(TD
+                $(B$(U C++98))$(BR)
+                No, only classes and functions
+                $(BR)$(B$(U C++11))$(BR)
+                Yes:
+$(CPPCODE2
+template&lt;class T&gt;
+constexpr T pi = T(3.1415926535897932385L);
 )
-        $(TD No, only classes and functions)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Template Typedefs: Create an alias that binds to some but not all
-        of the template parameters)
-        $(TD Yes:
+            $(TD Template Typedefs: Create an alias that binds to some but not all
+            of the template parameters)
+            $(TD Yes:
 ---
 class Foo(T, U) { }
 template MyFoo(T)
@@ -115,42 +117,54 @@ template MyFoo(T)
 }
 MyFoo!(uint) f;
 ---
-)
-        $(TD No)
-        $(TD Yes:
+            )
+            $(TD
+                $(B$(U C++98))$(BR)
+                No
+                $(BR)$(B$(U C++11))$(BR)
+                Yes:
 $(CPPCODE2
 template&lt;class T, class U&gt; class Foo { };
 template&lt;class T&gt; using MyFoo = Foo&lt;T, int&gt;;
 MyFoo&lt;unsigned&gt; f;
 )
-)
+            )
         )
 
-
         $(TR
-        $(TD Sequence Constructors)
-        $(TD No)
-        $(TD No)
-        $(TD Yes:
+            $(TD Sequence Constructors)
+            $(TD No)
+            $(TD
+                $(B$(U C++98))$(BR)
+                No
+                $(BR)$(B$(U C++11))$(BR)
+                Yes:
 $(CPPCODE2
-Foo&lt;double&gt; f = { 1.2, 3, 6.8 };
+template &lt;class T&gt;
+class Foo {
+    Foo(std::initializer_list<T>);
+};
+
+Foo&lt;double&gt; f = { 1.2, 3.0, 6.8 };
 )
-)
+            )
         )
 
         $(TR
-        $(TD Concepts)
+            $(TD Concepts)
 
-        $(TD Yes: $(DDSUBLINK spec/template, template_constraints, Constraints))
-
-        $(TD No)
-        $(TD Yes: $(LINK2 http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1849.pdf, Concepts for C++0x N1849))
+            $(TD Yes: $(DDSUBLINK spec/template, template_constraints, Constraints))
+            $(TD
+                $(B$(U C++98))$(BR)
+                No
+                $(BR)$(B$(U C++20))$(BR)
+                Yes: $(LINK2 https://en.cppreference.com/w/cpp/language/constraints, Constraints and Concepts)
+            )
         )
 
-
         $(TR
-        $(TD Recursive Templates)
-        $(TD Yes:
+            $(TD Recursive Templates)
+            $(TD Yes:
 ---
 template factorial(int n)
 {
@@ -161,8 +175,8 @@ template factorial(int n : 1)
     const factorial = 1;
 }
 ---
-)
-        $(TD Yes:
+            )
+            $(TD Yes:
 $(CPPCODE2
 template&lt;int n&gt; class factorial
 {
@@ -175,58 +189,89 @@ template&lt;&gt; class factorial&lt;1&gt;
     enum { result = 1 };
 };
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Conditional Compilation based on
-        Template Arguments)
-        $(TD Yes:
+            $(TD Conditional Compilation
+            based on Template Arguments)
+            $(TD Yes:
 ---
-template factorial(int n)
+template void foo(T)(T i)
 {
-  static if (n == 1)
-    const factorial = 1;
+  static if (can_fast_foo!(T))
+    FastFoo f = fast_foo(i);
   else
-    const factorial = n * factorial!(n-1);
+    SlowFoo f = slow_foo(i);
+  use_foo(f);
+}
+
+class HashTable(T, int maxLength)
+{
+    static if (maxLength < 0xFFFE)
+        alias CellIdx = ushort;
+    else
+        alias CellIdx = uint;
+    CellIdx index;
 }
 ---
-)
-        $(TD No:
+            )
+            $(TD
+            $(B$(U C++98))$(BR)
+            No, but workarounds exist:
 $(CPPCODE2
-template&lt;int n&gt; class factorial
+template&lt;class T&gt; void foo(T i)
 {
-  public:
-    enum
-    {
-#if (n == 1) // $(ERROR)
-      result = 1;
-#else
-      result = n * factorial&lt;n-1&gt;::result
-#endif
-    };
+  // Differentiate using a
+  // Helper<bool> specialization
+  Helper<can_fast_foo<T>>::use_foo(i);
+};
+
+template&lt;class T, int maxLength&gt; class HashTable {
+    typedef typename std::conditional<
+            maxLength < 0xFFFE, uint16_t, uint32_t>
+        ::type CellIdx;
+    CellIdx index;
 };
 )
+            $(BR)$(B$(U C++17))$(BR)
+            Yes, but is limited to block scope:
+$(CPPCODE2
+template&lt;class T&gt; void foo(T i)
+{
+  if constexpr (can_fast_foo<T>)
+    FastFoo foo = fast_foo(i);
+  else
+    SlowFoo foo = slow_foo(i);
+  use_foo(foo); // $(ERROR foo is undeclared)
+}
+
+template&lt;class T, int maxLength&gt; class HashTable {
+    // $(ERROR cannot use 'if' outside of a function)
+    if constexpr (maxLength < 0xFFFE)
+        alias CellIdx = ushort;
+    else
+        alias CellIdx = uint;
+    CellIdx index;
+};
 )
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Template Declarations (with no definition))
-        $(TD No)
-        $(TD Yes:
+            $(TD Template Declarations (with no definition))
+            $(TD No)
+            $(TD Yes:
 $(CPPCODE2
 template&lt;class T&gt;
 class Foo;
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Grouping templates with the same parameters together)
-        $(TD Yes:
+            $(TD Grouping templates with the same parameters together)
+            $(TD Yes:
 ---
 template Foo(T, U)
 {
@@ -236,20 +281,18 @@ template Foo(T, U)
 Foo!(int,long).Bar b;
 return Foo!(char,int).foo('c',3);
 ---
-)
-        $(TD No, each must be separate:
+            )
+            $(TD $(I Sort of), using a class' members:
 $(CPPCODE2
 template&lt;class T, class U&gt;
-class Foo_Bar { ... };
-
-template&lt;class T, class U&gt;
-T Foo_foo(T t, U u) { ... };
-
-Foo_Bar&lt;int,long&gt; b;
-return Foo_foo&lt;char,int&gt;('c',3);
+class Foo {
+    class Bar { ... };
+    static T foo(T t, U u) { ... }
+};
+Foo<int, long>::bar b;
+return Foo<char, int>::foo('c', 3);
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
@@ -266,21 +309,24 @@ int factorial(int i)
 static f = factorial(6);
 ---
         )
-        $(TD No)
-        $(TD Named constant expressions with parameters:
-           $(LINK2 http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1972.pdf, Generalized Constant Expressions N1972))
+        $(TD
+            $(B$(U C++98))$(BR)
+            No
+            $(BR)$(B$(U C++11))$(BR)
+            Yes, but only for $(LINK2 https://en.cppreference.com/w/cpp/language/constexpr, constexpr) functions.$(BR)
+            constexpr was highly restricted in C++11, but each subsequent standard has eased these restrictions.
+        )
         )
 
         $(TR
-        $(TH Parameters)
-        $(TH D)
-        $(TH C++98)
-        $(TH C++0x)
+            $(TH Parameters)
+            $(TH D)
+            $(TH C++)
         )
 
         $(TR
-        $(TD Type Parameters)
-        $(TD Yes:
+            $(TD Type Parameters)
+            $(TD Yes:
 ---
 class Foo(T)
 {
@@ -289,7 +335,7 @@ class Foo(T)
 Foo!(int) f;
 ---
 )
-        $(TD Yes:
+            $(TD Yes:
 $(CPPCODE2
 template&lt;class T&gt;
 class Foo
@@ -298,21 +344,20 @@ class Foo
 };
 Foo&lt;int&gt; f;
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Integral Parameters)
-        $(TD Yes:
+            $(TD Integral Parameters)
+            $(TD Yes:
 ---
 void foo(int i)()
 {
     int v = i;
 }
 ---
-)
-        $(TD Yes:
+            )
+            $(TD Yes:
 $(CPPCODE2
 template&lt;int i&gt;
 void foo()
@@ -320,21 +365,19 @@ void foo()
     int v = i;
 }
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Pointer Parameters)
-        $(TD Yes, a pointer to object or function)
-        $(TD Yes, a pointer to object or function)
-        $(TD No change)
+            $(TD Pointer Parameters)
+            $(TD Yes, a pointer to object or function)
+            $(TD Yes, a pointer to object or function)
         )
 
         $(TR
-        $(TD Reference Parameters)
-        $(TD No, D does not have a general reference type)
-        $(TD Yes:
+            $(TD Reference Parameters)
+            $(TD No, D does not have a general reference type)
+            $(TD Yes:
 $(CPPCODE2
 template&lt;double& D&gt;
 void foo()
@@ -342,30 +385,28 @@ void foo()
     double y = D;
 }
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Pointer to Member Parameters)
-        $(TD No, D does not have pointers to members, it has
-          $(DDSUBLINK spec/type, delegates, delegates),
-          which can be used as parameters)
-        $(TD Yes)
-        $(TD No change)
+            $(TD Pointer to Member Parameters)
+            $(TD No, D does not have pointers to members. It does
+            have $(DDSUBLINK spec/type, delegates, delegates) however,
+            which can be used as parameters)
+            $(TD Yes)
         )
 
         $(TR
-        $(TD Template Template Parameters)
-        $(TD Yes:
+            $(TD Template Template Parameters)
+            $(TD Yes:
 ---
 class Foo(T, alias C)
 {
     C!(T) x;
 }
 ---
-)
-        $(TD Yes:
+            )
+            $(TD Yes:
 $(CPPCODE2
 template&lt;class T,
          template&lt;class U&gt; class C&gt;
@@ -374,13 +415,12 @@ class Foo
     C&lt;T&gt; x;
 };
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Alias Parameters)
-        $(TD Yes, any symbol can be passed to a template as an alias:
+            $(TD Alias Parameters)
+            $(TD Yes, any symbol can be passed to a template as an alias:
 ---
 void bar(int);
 void bar(double);
@@ -391,14 +431,13 @@ void foo(T, alias S)(T t)
 // calls bar(double)
 foo!(double, bar)(1);
 ---
-)
-        $(TD No)
-        $(TD No change)
+            )
+            $(TD No)
         )
 
         $(TR
-        $(TD Floating Point Parameters)
-        $(TD Yes:
+            $(TD Floating Point Parameters)
+            $(TD Yes:
 ---
 class Foo(double D)
 {
@@ -407,14 +446,25 @@ class Foo(double D)
 ...
 Foo!(1.6) F;
 ---
+            )
+            $(TD
+                $(B$(U C++98))$(BR)
+                No
+                $(BR)$(B$(U C++11))$(BR)
+                Yes:
+$(CPPCODE2
+template&lt;float f&gt;
+void foo()
+{
+    int v = f;
+}
 )
-        $(TD No)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD String Parameters)
-        $(TD Yes:
+            $(TD String Parameters)
+            $(TD Yes:
 ---
 void foo(char[] format)(int i)
 {
@@ -423,36 +473,51 @@ void foo(char[] format)(int i)
 ...
 foo!("i = %s")(3);
 ---
+            )
+            $(TD
+                $(B$(U C++98))$(BR)
+                No
+                $(BR)$(B$(U C++17))$(BR)
+                Only indirectly:
+$(CPPCODE2
+template &lt;const char*&gt;
+struct S {};
+
+S&lt;"Foo"&gt; foo1; $(ERROR A string literal argument is still illegal)
+const char foo_str[] = "foo";
+S&lt;foo_str&gt; foo2; // Literal types are allowed, including arrays.
 )
-        $(TD No)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Local Class Parameters)
-        $(TD Yes)
-        $(TD No)
-        $(TD Issue N1945)
+            $(TD Local Class Parameters)
+            $(TD Yes)
+            $(TD
+                $(B$(U C++98))$(BR)
+                No
+                $(BR)$(B$(U C++17))$(BR)
+                Yes
+            )
         )
 
         $(TR
-        $(TD Local Variable Parameters)
-        $(TD Yes)
-        $(TD No)
-        $(TD No change)
+            $(TD Local Variable Parameters)
+            $(TD Yes)
+            $(TD No)
         )
 
         $(TR
-        $(TD Parameter Default Values)
-        $(TD Yes:
+            $(TD Parameter Default Values)
+            $(TD Yes:
 ---
 class Foo(T = int)
 {
     T x;
 }
 ---
-)
-        $(TD Yes:
+            )
+            $(TD Yes:
 $(CPPCODE2
 template&lt;class T = int&gt;
 class Foo
@@ -460,13 +525,12 @@ class Foo
     T x;
 };
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Variadic Parameters)
-        $(TD Yes, $(LINK2 variadic-function-templates.html, Variadic Templates):
+            $(TD Variadic Parameters)
+            $(TD Yes, $(LINK2 variadic-function-templates.html, Variadic Templates):
 ---
 void print(A...)(A a)
 {
@@ -474,29 +538,54 @@ void print(A...)(A a)
         writeln(t);
 }
 ---
+            )
+            $(TD
+                $(B$(U C++98))$(BR)
+                No
+                $(BR)$(B$(U C++11))$(BR)
+                Yes:
+$(CPPCODE2
+// Need a zero- or one-argument version
+// to handle the final argument.
+void print() {};
+
+template &lt;class Arg, class... Args&gt;
+void print(const Arg& arg, Args&&... args)
+{
+    writeln(arg);
+    print(std::forward&lt;Args&gt;(args)...);
+}
 )
-        $(TD No)
-        $(TD $(LINK2 http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n2080.pdf, Variadic Templates N2080))
+                Note that the example above was
+                improved somewhat in C++17 using
+                $(LINK2 https://en.cppreference.com/w/cpp/language/fold, Fold Expressions):
+$(CPPCODE2
+template &lt;class Args...&gt;
+void print(Args...&& args)
+{
+    (writeln(std::forward&lt;Args.&gt(args)), ...);
+}
+)
+            )
         )
 
         $(TR
-        $(TH Specializations)
-        $(TH D)
-        $(TH C++98)
-        $(TH C++0x)
+            $(TH Specializations)
+            $(TH D)
+            $(TH C++)
         )
 
         $(TR
-        $(TD Explicit Specialization)
-        $(TD Yes:
+            $(TD Explicit Specialization)
+            $(TD Yes:
 ---
 class Foo(T : int)
 {
     T x;
 }
 ---
-)
-        $(TD Yes:
+            )
+            $(TD Yes:
 $(CPPCODE2
 template&lt;&gt;
 class Foo&lt;int&gt;
@@ -504,21 +593,20 @@ class Foo&lt;int&gt;
     int x;
 };
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Partial Specialization)
-        $(TD Yes:
+            $(TD Partial Specialization)
+            $(TD Yes:
 ---
 class Foo(T : T*, U)
 {
     T x;
 }
 ---
-)
-        $(TD Yes:
+            )
+            $(TD Yes:
 $(CPPCODE2
 template&lt;class T, class U&gt;
 class Foo&lt;T*, U&gt;
@@ -526,21 +614,20 @@ class Foo&lt;T*, U&gt;
     T x;
 };
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Partial specialization derived from multiple parameters)
-        $(TD Yes:
+            $(TD Partial specialization derived from multiple parameters)
+            $(TD Yes:
 ---
 class Foo(T : Bar!(T, U), U)
 {
     ...
 }
 ---
-)
-        $(TD Yes:
+            )
+            $(TD Yes:
 $(CPPCODE2
 template&lt;class T, class U&gt;
 class Foo&lt; Bar&lt;T,U&gt; &gt;
@@ -548,84 +635,79 @@ class Foo&lt; Bar&lt;T,U&gt; &gt;
     ...
 };
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Can specializations exist without a primary template?)
-        $(TD Yes)
-        $(TD No)
-        $(TD No change)
+            $(TD Can specializations exist without a primary template?)
+            $(TD Yes)
+            $(TD No)
         )
 
         $(TR
         $(TH Other)
-        $(TH D)
-        $(TH C++98)
-        $(TH C++0x)
+            $(TH D)
+            $(TH C++)
         )
 
         $(TR
-        $(TD Exported Templates)
-        $(TD Yes, it falls out as a natural consequence of modules)
-        $(TD Yes, though only in compilers based on EDG's front end)
-        $(TD No change)
+            $(TD Exported Templates)
+            $(TD Yes, it falls out as a natural consequence of modules)
+            $(TD
+                $(B$(U C++98))$(BR)
+                Yes, but was only support in compilers based on EDG's front end.
+                $(BR)$(B$(U C++11))$(BR)
+                Was removed from the language due to a lack of support.
+            )
         )
 
         $(TR
-        $(TD $(SFINAE))
-        $(TD No)
-        $(TD Yes)
-        $(TD No change)
+            $(TD $(SFINAE))
+            $(TD No)
+            $(TD Yes)
         )
 
         $(TR
-        $(TD Parse Template Definition Bodies before Instantiation)
-        $(TD Yes)
-        $(TD Not required by Standard, but some implementations do)
-        $(TD No change)
+            $(TD Parse Template Definition Bodies before Instantiation)
+            $(TD Yes)
+            $(TD Not required by the Standard, but some implementations do)
         )
 
         $(TR
-        $(TD Overloading Function Templates with Functions)
-        $(TD No, but the equivalent can be done with explicitly specialized
-        templates:
+            $(TD Overloading Function Templates with Functions)
+            $(TD No, but the equivalent can be done with explicitly specialized
+            templates:
 ---
 void foo(T)(T t) { }
 void foo(T:int)(int t) { }
 ---
-)
-        $(TD Yes:
+            )
+            $(TD Yes:
 $(CPPCODE2
 template&lt;class T&gt;
 void foo(T i) { }
-
 void foo(int t) { }
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Implicit Function Template Instantiation)
-        $(TD Yes)
-        $(TD Yes)
-        $(TD No change)
+            $(TD Implicit Function Template Instantiation)
+            $(TD Yes)
+            $(TD Yes)
         )
 
         $(TR
-        $(TD Templates can be evaluated in scope
-          of instantiation rather than definition)
-        $(TD Yes, $(LINK2 mixin.html, Mixins))
-        $(TD No, but can be faked using macros)
-        $(TD No change)
+            $(TD Templates can be evaluated in scope
+            of instantiation rather than definition)
+            $(TD Yes, $(LINK2 mixin.html, Mixins))
+            $(TD No, but can be faked using macros)
         )
 
         $(TR
-        $(TD Can extract arguments of
-        template instance)
-        $(TD Yes:
+            $(TD Can extract arguments of
+            template instance)
+            $(TD Yes:
 ---
 class Foo(T)
 {
@@ -639,24 +721,19 @@ struct Bar(T1, T2) { }
 alias BarInst = Bar!(int, float);
 Foo!(BarInst) f;
 ---
-    See $(DDSUBLINK spec/expression, IsExpression, is expressions).
-    )
-        $(TD No)
-        $(TD No change)
+            See $(DDSUBLINK spec/expression, IsExpression, is expressions).)
+            $(TD No)
         )
 
         $(TR
-        $(TH Parsing Idiosyncracies)
-        $(TH D)
-        $(TH C++98)
-        $(TH C++0x)
+            $(TH Parsing Idiosyncracies)
+            $(TH D)
+            $(TH C++)
         )
 
-
-
         $(TR
-        $(TD Context-Free Grammar)
-        $(TD Yes:
+            $(TD Context-Free Grammar)
+            $(TD Yes:
 ---
 class Foo(int i)
 {
@@ -664,8 +741,8 @@ class Foo(int i)
 }
 Foo!(3 $(B >) 4) f;
 ---
-)
-        $(TD No:
+            )
+            $(TD No:
 $(CPPCODE2
 template&lt;int i&gt; class Foo
 {
@@ -673,14 +750,12 @@ template&lt;int i&gt; class Foo
 };
 Foo&lt;3 $(B &gt;) 4&gt; f; // $(ERROR)
 )
-)
-        $(TD No change)
+            )
         )
 
-
         $(TR
-        $(TD Distinguish template arguments from other operators)
-        $(TD Yes:
+            $(TD Distinguish template arguments from other operators)
+            $(TD Yes:
 ---
 class Foo(T)
 {
@@ -692,8 +767,10 @@ class Bar(int i)
 }
 Foo!(Bar!(1)) x1;
 ---
-)
-        $(TD No:
+            )
+            $(TD
+                $(B$(U C++98))$(BR)
+                No:
 $(CPPCODE2
 template&lt;class T&gt; class Foo
 {
@@ -706,17 +783,15 @@ template&lt;int i&gt; class Bar
 Foo&lt;Bar&lt;1&gt;&gt; x1; // $(ERROR)
 Foo&lt;Bar&lt;1&gt; &gt; x2;
 )
-)
-        $(TD Partially fixed by
-        $(LINK2 http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2005/n1757.html, Right Angle Brackets N1757)
-        )
-
+                $(BR)$(B$(U C++11))$(BR)
+                Partially fixed by $(LINK2 http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2005/n1757.html, Right Angle Brackets N1757)
+            )
         )
 
 
         $(TR
         $(TD Redeclaration of Template Parameter)
-        $(TD Yes:
+            $(TD Yes:
 ---
 class Foo(T)
 {
@@ -727,8 +802,8 @@ class Foo(T)
     }
 }
 ---
-)
-        $(TD No:
+            )
+            $(TD No:
 $(CPPCODE2
 template&lt;class T&gt;
 class Foo
@@ -740,13 +815,12 @@ class Foo
     }
 };
 )
-)
-        $(TD No change)
+            )
         )
 
         $(TR
-        $(TD Dependent Base Class Lookup)
-        $(TD Yes:
+            $(TD Dependent Base Class Lookup)
+            $(TD Yes:
 ---
 class Foo(T)
 {
@@ -757,8 +831,8 @@ class Bar(T) : Foo(T)
     $(B A) x;
 }
 ---
-)
-        $(TD No:
+            )
+            $(TD No:
 $(CPPCODE2
 template&lt;class T&gt;
 class Foo
@@ -773,16 +847,12 @@ class Bar : Foo&lt;T&gt;
     $(B A) x; // $(ERROR)
 };
 )
-)
-        $(TD No change)
+            )
         )
 
-
-
-
         $(TR
-        $(TD Forward Referencing)
-        $(TD Yes:
+            $(TD Forward Referencing)
+            $(TD Yes:
 ---
 int $(B g)(void *);
 
@@ -796,8 +866,8 @@ class Foo(T)
 
 int $(B g)(int i);
 ---
-)
-        $(TD No:
+            )
+            $(TD No:
 $(CPPCODE2
 int $(B g)(void *);
 
@@ -812,14 +882,12 @@ class Foo
 
 int $(B g)(int i);
 )
-)
-        $(TD No change)
+            )
         )
 
-
         $(TR
-        $(TD Member templates parseable without hints)
-        $(TD Yes:
+            $(TD Member templates parseable without hints)
+            $(TD Yes:
 ---
 class Foo
 {
@@ -830,8 +898,8 @@ void abd(T)(T f)
     T f1 = f.bar!(3)();
 }
 ---
-)
-        $(TD No:
+            )
+            $(TD No:
 $(CPPCODE2
 class Foo
 {
@@ -844,22 +912,20 @@ template&lt;class T&gt; void abc(T *f)
     T *f2 = f-&gt;$(B template) bar&lt;3&gt;();
 }
 )
-)
-        $(TD No change)
+            )
         )
 
-
         $(TR
-        $(TD Dependent type members parseable without hints)
-        $(TD Yes:
+            $(TD Dependent type members parseable without hints)
+            $(TD Yes:
 ---
 class Foo(T)
 {
     T.A* a1;
 }
 ---
-)
-        $(TD No:
+            )
+            $(TD No:
 $(CPPCODE2
 template$(LT)class T$(GT) class Foo
 {
@@ -868,13 +934,11 @@ template$(LT)class T$(GT) class Foo
     $(B typename) T::A *a2;
 };
 )
-)
-        $(TD No change)
+            )
         )
 
         </tbody>
         </table>
-
 )
 
 Macros:
@@ -888,4 +952,4 @@ Macros:
 META_KEYWORDS=D Programming Language, template metaprogramming,
 variadic templates, type deduction, dependent base class
 META_DESCRIPTION=Comparison of templates between the
-D programming language, C++, and C++0x
+D programming language, C++98, C++11, and C++20


### PR DESCRIPTION
The comparisons were pre-C++11, and since C++ has developed greatly since then this was due for an update.

To avoid having a crowded table listing every standard or only listing the latest-and-greatest, I opted to just have a single C++ column that calls out differences when present.

I also made the indentation consistent since I was having trouble figuring out where sections began/ended.