### PR TITLE
Example code references a deprecated vibe-d version

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -156,7 +156,7 @@ $(EXTRA_EXAMPLE Start a minimal web server,
 ----
 #!/usr/bin/env dub
 /+ dub.sdl:
-dependency "vibe-d" version="~>0.8.0"
+dependency "vibe-d" version="~>0.9.0"
 +/
 void main()
 {


### PR DESCRIPTION
Simple web server example references vibe-d 0.8 that fails because it uses std.exception.enforceEx (deprecated 2 years ago)