### PR TITLE
Update broken examples

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -529,7 +529,7 @@ void main()
     // Code is executed in any case upon scope exit.
     scope(exit) { writeln("Exiting main."); }
     // File is closed deterministically at scope's end.
-    foreach (line; File("text.txt").byLine())
+    foreach (line; File("/etc/issue").byLine())
     {
         writeln(line);
     }
@@ -584,7 +584,7 @@ class Widget : Printable
 {
    void print(uint level)
    in{ }
-   body{ }
+   do{ }
 }
 
 // Single inheritance of state
@@ -592,7 +592,7 @@ class ExtendedWidget : Widget
 {
    override void print(uint level)
    in { /* weakening precondition is okay */  }
-   body
+   do
    {
        //... level may be 0 here ...
    }

--- a/index.dd
+++ b/index.dd
@@ -529,7 +529,7 @@ void main()
     // Code is executed in any case upon scope exit.
     scope(exit) { writeln("Exiting main."); }
     // File is closed deterministically at scope's end.
-    foreach (line; File("/etc/issue").byLine())
+    foreach (line; File(__FILE_FULL_PATH__).byLine())
     {
         writeln(line);
     }


### PR DESCRIPTION
body is deprecated and text.txt is not readable on run.dlang.io which is suboptimal