### PR TITLE
spec: abi: clarify calling convention for other architectures other t…

### DIFF
--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -697,11 +697,13 @@ $(GNAME TypeTuple):
 
 $(H2 $(LNAME2 function_calling_conventions, Function Calling Conventions))
 
-        $(P The $(D extern (C)) and $(D extern (D)) calling convention matches the C
-        calling convention
-        used by the supported C compiler on the host system.
-        Except that the extern (D) calling convention for Windows x86 is described here.
-        )
+        $(P Functions with $(D extern (C)) linkage matches the C calling
+        convention used by the supported C compiler on the host system.)
+
+        $(P Functions with $(D extern (D)) linkage matches the calling
+        convention used by $(D extern (C)) functions with the parameters
+        pushed in the reverse order, except for 32-bit x86 architecture, which
+        is described here.)
 
 $(H3 $(LNAME2 register_conventions, Register Conventions))
 


### PR DESCRIPTION
…han x86

Observing the assembly generated by the following source file in either DMD and
LDC:

```d
extern (C) void ccall( size_t a, size_t b, size_t c );
extern (D) void dcall( size_t a, size_t b, size_t c );

//...

ccall( a, b, c ); // RDI, RSI, RDX
dcall( a, b, c ); // RDX, RSI, RDI
```

The parameters are passed in the reverse order in functions with `extern(D)`
linkage. Furthermore, on x86 the calling convention seems to be what is
described by the current subsections, not only matching Windows x86, but also
appears to be the same behaviour on System V ABI.

Fixes #20204 .

Signed-off-by: Luís Ferreira <contact@lsferreira.net>