### PR TITLE
spec: abi: add function-local parent symbols to the mangling grammar

### DIFF
--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -379,6 +379,7 @@ $(GNAME Namechars):
 $(GRAMMAR
 $(GNAME LName):
     $(GLINK Number) $(GLINK Name)
+    $(GLINK Number) $(B __S) $(GLINK Number)    $(GREEN // function-local parent symbols)
 
 $(GNAME Number):
     $(GLINK Digit)


### PR DESCRIPTION
Related to the issue #20565.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---
This is needed in order for the LLVM demangler be in sync with the compiler's implementation. See https://reviews.llvm.org/D111415 .

CC @Geod24 