### PR TITLE
Fix portability of the book builder

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -383,10 +383,13 @@ docs-prerelease: dmd-prerelease druntime-prerelease phobos-prerelease apidocs-pr
 
 docs : docs-latest docs-prerelease
 
-html : $(ALL_FILES) makebook
+html : html_files makebook
 
-makebook:
-	(cd book && rdmd build.d 6)
+html_files : $(ALL_FILES)
+
+makebook : book/build.d | $(STABLE_DMD)
+	cd book && PATH="$(STABLE_DMD_BIN_ROOT):$$PATH" rdmd build.d 6
+
 html-verbatim: $(addprefix $W/, $(addsuffix .verbatim,$(PAGES_ROOT)))
 
 verbatim : html-verbatim phobos-prerelease-verbatim


### PR DESCRIPTION
The addition of the book builder introduced the dependency on a `dmd` / `rdmd` found on the path. This broke multiple CI's:

1. DMD nightlies are built with ldc and hence have no `dmd` installed by default
2. Installer CI has no system-wide rdmd installation

---

```
Use STABLE_DMD building/running book/build.d

Relying on the `STABLE_DMD` release ensures that the book can be built
even if there is no `rdmd` / `dmd` found on the path.
```