### PR TITLE
posix.mak: Explicitly call stable rdmd using absolute path

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -388,7 +388,7 @@ html : html_files makebook
 html_files : $(ALL_FILES)
 
 makebook : book/build.d | $(STABLE_DMD)
-	cd book && PATH="$(STABLE_DMD_BIN_ROOT):$$PATH" rdmd build.d 6
+	cd book && $(abspath $(STABLE_DMD_BIN_ROOT))/rdmd build.d 6
 
 html-verbatim: $(addprefix $W/, $(addsuffix .verbatim,$(PAGES_ROOT)))
 


### PR DESCRIPTION
Avoids issues when `GENERATED` resolves to a relative path, e.g. the default.
This adresses the remaining issue outlined in https://github.com/dlang/installer/pull/489#issuecomment-980709464

CC @maxhaton @lionello 