### PR TITLE
Ensure that book builder uses the stable dmd algongside rdmd

### DIFF
--- a/book/build.d
+++ b/book/build.d
@@ -27,7 +27,7 @@ void compileToPath(string compileThis, string outputPath, bool loud = false)
         macroOut.writefln!"%s = %s"(key, value);
     }
     macroOut.flush();
-    const compileString = format!"dmd -revert=markdown -D  contextMacros.ddoc macros.ddoc html.ddoc dlang.org.ddoc doc.ddoc aliBook.ddoc %s -Df%s "(compileThis, outputPath);
+    const compileString = format!"dmd -D  contextMacros.ddoc macros.ddoc html.ddoc dlang.org.ddoc doc.ddoc aliBook.ddoc %s -Df%s "(compileThis, outputPath);
     if(loud)
         writefln!"%s:%s |> %s"(compileThis, outputPath, compileString);
     const res = executeShell(compileString);

--- a/posix.mak
+++ b/posix.mak
@@ -388,7 +388,7 @@ html : html_files makebook
 html_files : $(ALL_FILES)
 
 makebook : book/build.d | $(STABLE_DMD)
-	cd book && $(abspath $(STABLE_DMD_BIN_ROOT))/rdmd build.d 6
+	cd book && PATH="$(abspath $(STABLE_DMD_BIN_ROOT)):$$PATH" rdmd build.d 6
 
 html-verbatim: $(addprefix $W/, $(addsuffix .verbatim,$(PAGES_ROOT)))
 


### PR DESCRIPTION
Also disable -revert=markdown for the older compiler.

---

Sorry for the PR spam. Apparently messed up with my test setup for these changes s.t. it still found another dmd...