### PR TITLE
Added link to github.com/dukc/oldDDerivations

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -149,7 +149,9 @@ $(DOWNLOAD_OTHER $(GENTOO), $(LINK2 https://wiki.gentoo.org/wiki/Dlang, Gentoo),
 
 $(DOWNLOAD_OTHER $(HOMEBREW), $(LINK2 https://formulae.brew.sh/formula/dmd, Homebrew), $(CONSOLE brew install dmd))
 
-$(DOWNLOAD_OTHER $(NIX), $(LINK2 https://search.nixos.org/packages?show=dmd&query=dmd, Nix/NixOS), $(CONSOLE nix-env -iA nixpkgs.dmd))
+$(DOWNLOAD_OTHER $(NIX), $(LINK2 https://search.nixos.org/packages?show=dmd&query=dmd, Nix/NixOS), $(CONSOLE nix-env -iA nixpkgs.dmd)
+$(LINK2 https://github.com/dukc/oldDDerivations, derivations for building various versions yourself)
+)
 
 $(DOWNLOAD_OTHER $(UBUNTU) $(DEBIAN), Ubuntu/Debian, $(LINK2 http://d-apt.sourceforge.net/, APT repository)
 $(CONSOLE sudo wget https://netcologne.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list


### PR DESCRIPTION
Links to my repo that might be useful for a Nix user who wants to use a different version of DMD compared to what happens to be on NixPkgs repository.

Same as #3133 but this time based on newest master