### PR TITLE
Update arrays.dd

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -229,7 +229,7 @@ writeln(b[7]);      // 10
 
 $(H2 $(LNAME2 array-copying, Array Copying))
 
-        $(P When the slice operator appears as the left-hand side of an
+        $(P When the slice appears as the left-hand side of an
         assignment expression, it means that the contents of the array are the
         target of the assignment rather than a reference to the array.
         Array copying happens when the left-hand side is a slice, and the
@@ -284,7 +284,7 @@ assert(s == [2, 3, 3, 4]);
 
 $(H2 $(LNAME2 array-setting, Array Setting))
 
-        $(P If a slice operator appears as the left-hand side of an assignment
+        $(P If a slice appears as the left-hand side of an assignment
         expression, and the type of the right-hand side is the same as the
         element type of the left-hand side, then the array contents of the
         left-hand side are set to the right-hand side.


### PR DESCRIPTION
Referring to a "slice operator" is confusing since there isn't really a special, separate "slice operator". You change values in the underlying array by assignment to the entire slice:

int[] a;
// snip...
int[] b;
b = a[1..4];
b = 0; // Sets a[1] = 0, a[2] = 0 and a[3] = 0. 

and you can also use the array index operator when assigning to a slice

int[] a;
// snip...
int[] b;
b = a[1..4];
b[0..2] = 0; // Sets a[1] = 0, a[2] = 0 

The operator used in the first example is the array- and slice-assignment operator. The second example also uses the array- and slice-index. Neither example uses a separate, special "slice operator". 
