### PR TITLE
fix Issue 19136 - is expressions don't work as documented

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2246,10 +2246,10 @@ void foo()
 
         $(LI $(D is $(LPAREN)) $(I Type) $(I Identifier) $(D :) $(I TypeSpecialization) $(D $(RPAREN))$(BR)
 
-        The condition is satisfied if $(I Type) is the same as
-        $(I TypeSpecialization), or if $(I Type) is a class and
-        $(I TypeSpecialization) is a base class or base interface
-        of it.
+        The condition is satisfied if $(I Type) is semantically
+        correct and it is the same as
+        or can be implicitly converted to $(I TypeSpecialization).
+        $(I TypeSpecialization) is only allowed to be a $(I Type).
         The $(I Identifier) is declared to be either an alias of the
         $(I TypeSpecialization) or, if $(I TypeSpecialization) is
         dependent on $(I Identifier), the deduced type.


### PR DESCRIPTION
As per @adamdruppe 's [explanation](https://github.com/dlang/dmd/pull/13387#issuecomment-986288394), I edited the description for `is ( Type Identifier : TypeSpecialization )` in the spec to match `is ( Type : TypeSpecialization )`.