### PR TITLE
Deprecate complex number keywords

### DIFF
--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -992,14 +992,14 @@ $(MULTICOLS 4,
     $(LINK2 statement.html#SwitchStatement, $(D case))
     $(LINK2 expression.html#CastExpression, $(D cast))
     $(LINK2 statement.html#TryStatement, $(D catch))
-    $(LINK2 type.html, $(D cdouble))
+    $(GDEPRECATED $(LINK2 type.html, $(D cdouble)))
     $(LINK2 type.html, $(D cent))
-    $(LINK2 type.html, $(D cfloat))
+    $(GDEPRECATED $(LINK2 type.html, $(D cfloat)))
     $(LINK2 type.html, $(D char))
     $(LINK2 class.html, $(D class))
     $(LINK2 attribute.html#const, $(D const))
     $(LINK2 statement.html#ContinueStatement, $(D continue))
-    $(LINK2 type.html, $(D creal))
+    $(GDEPRECATED $(LINK2 type.html, $(D creal)))
 
     $(LINK2 type.html, $(D dchar))
     $(LINK2 version.html#debug, $(D debug))
@@ -1026,9 +1026,9 @@ $(MULTICOLS 4,
 
     $(LINK2 statement.html#GotoStatement, $(D goto))
 
-    $(LINK2 type.html, $(D idouble))
+    $(GDEPRECATED $(LINK2 type.html, $(D idouble)))
     $(LINK2 statement.html#IfStatement, $(D if))
-    $(LINK2 type.html, $(D ifloat))
+    $(GDEPRECATED $(LINK2 type.html, $(D ifloat)))
     $(LINK2 attribute.html#immutable, $(D immutable))
     $(LINK2 expression.html#ImportExpression, $(D import))
     $(LINK2 expression.html#InExpression, $(D in))
@@ -1036,7 +1036,7 @@ $(MULTICOLS 4,
     $(LINK2 type.html, $(D int))
     $(LINK2 interface.html, $(D interface))
     $(LINK2 contracts.html, $(D invariant))
-    $(LINK2 type.html, $(D ireal))
+    $(GDEPRECATED $(LINK2 type.html, $(D ireal)))
     $(LINK2 expression.html#IsExpression, $(D is))
 
     $(LINK2 function.html#overload-sets, $(D lazy))


### PR DESCRIPTION
Since built-in complex numbers are deprecated now.