### PR TITLE
Use an Oxford comma in the allMembers spec

### DIFF
--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -1453,7 +1453,7 @@ $(H2 $(GNAME getVirtualIndex))
 $(H2 $(GNAME allMembers))
 
         $(P Takes a single argument, which must evaluate to either
-        a module, a struct, a union, a class, an interface or a
+        a module, a struct, a union, a class, an interface, or a
         template instantiation.
 
         A tuple of string literals is returned, each of which


### PR DESCRIPTION
For future reference the Oxford comma is the desired form - this commit message left here so there's something to search for.