### PR TITLE
OpenBSD: the dub package is just named dub now

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -175,11 +175,10 @@ sudo snap install --classic dub
 sudo snap install --classic ldc2))
 
 $(DOWNLOAD_OTHER $(OPENBSD), $(LINK2 https://openports.se/lang/dmd, OpenBSD), $(CONSOLE # install DMD compiler
-
 doas pkg_add dmd
 
 \# install DUB package/build manager (and DMD if not already installed)
-doas pkg_add dub-dmd
+doas pkg_add dub
 
 \# install D tools
 doas pkg_add dtools))


### PR DESCRIPTION
As it says on the tin, OpenBSD users just need to type `pkg_add dub` to get dub these days.