### PR TITLE
[spec/expression.dd] Improve InExpression

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -306,19 +306,17 @@ $(H2 $(LNAME2 array-concatenation, Array Concatenation))
         to concatenate arrays:
         )
 
-$(SPEC_RUNNABLE_EXAMPLE_COMPILE
----------
-int[] a;
-int[] b;
-int[] c;
-
-a = b ~ c; // Create an array from the concatenation
-           // of the b and c arrays
----------
+$(SPEC_RUNNABLE_EXAMPLE_RUN
+---
+int[] a = [1, 2];
+assert(a ~ 3 == [1, 2, 3]); // concatenate array with a single value
+int[] b = a ~ [3, 4];
+assert(b == [1, 2, 3, 4]); // concatenate two arrays
+---
 )
 
-        $(P Many languages overload the + operator to mean concatenation.
-        This confusingly leads to, does:
+        $(P Many languages overload the + operator for concatenation.
+        This confusingly leads to a dilemma - does:
         )
 
 ---------
@@ -333,20 +331,30 @@ a = b ~ c; // Create an array from the concatenation
         concatenation.
         )
 
+        $(P Concatenation always creates a copy of its operands, even
+        if one of the operands is a 0 length array, so:
+        )
+
+$(SPEC_RUNNABLE_EXAMPLE_RUN
+---------
+auto b = [7];
+auto a = b;      // a refers to b
+assert(a is b);
+a = b ~ []; // a refers to a copy of b
+assert(a !is b);
+assert(a == b);
+---------
+)
+
+        $(P See also: $(DDSUBLINK spec/expression, identity_expressions, `is` operator).)
+
+$(H2 $(LNAME2 array-appending, Array Appending))
+
         $(P Similarly, the ~= operator means append, as in:
         )
 
 ---------
 a ~= b; // a becomes the concatenation of a and b
----------
-
-        $(P Concatenation always creates a copy of its operands, even
-        if one of the operands is a 0 length array, so:
-        )
-
----------
-a = b;           // a refers to b
-a = b ~ c[0..0]; // a refers to a copy of b
 ---------
 
         $(P Appending does not always create a copy, see $(RELATIVE_LINK2 resize,

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -306,17 +306,19 @@ $(H2 $(LNAME2 array-concatenation, Array Concatenation))
         to concatenate arrays:
         )
 
-$(SPEC_RUNNABLE_EXAMPLE_RUN
----
-int[] a = [1, 2];
-assert(a ~ 3 == [1, 2, 3]); // concatenate array with a single value
-int[] b = a ~ [3, 4];
-assert(b == [1, 2, 3, 4]); // concatenate two arrays
----
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+---------
+int[] a;
+int[] b;
+int[] c;
+
+a = b ~ c; // Create an array from the concatenation
+           // of the b and c arrays
+---------
 )
 
-        $(P Many languages overload the + operator for concatenation.
-        This confusingly leads to a dilemma - does:
+        $(P Many languages overload the + operator to mean concatenation.
+        This confusingly leads to, does:
         )
 
 ---------
@@ -331,30 +333,20 @@ assert(b == [1, 2, 3, 4]); // concatenate two arrays
         concatenation.
         )
 
-        $(P Concatenation always creates a copy of its operands, even
-        if one of the operands is a 0 length array, so:
-        )
-
-$(SPEC_RUNNABLE_EXAMPLE_RUN
----------
-auto b = [7];
-auto a = b;      // a refers to b
-assert(a is b);
-a = b ~ []; // a refers to a copy of b
-assert(a !is b);
-assert(a == b);
----------
-)
-
-        $(P See also: $(DDSUBLINK spec/expression, identity_expressions, `is` operator).)
-
-$(H2 $(LNAME2 array-appending, Array Appending))
-
         $(P Similarly, the ~= operator means append, as in:
         )
 
 ---------
 a ~= b; // a becomes the concatenation of a and b
+---------
+
+        $(P Concatenation always creates a copy of its operands, even
+        if one of the operands is a 0 length array, so:
+        )
+
+---------
+a = b;           // a refers to b
+a = b ~ c[0..0]; // a refers to a copy of b
 ---------
 
         $(P Appending does not always create a copy, see $(RELATIVE_LINK2 resize,

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -691,7 +691,7 @@ $(H2 $(LNAME2 in_expressions, In Expressions))
 $(GRAMMAR
 $(GNAME InExpression):
     $(GLINK ShiftExpression) $(D in) $(GLINK ShiftExpression)
-    $(GLINK ShiftExpression) $(D !in) $(GLINK ShiftExpression)
+    $(GLINK ShiftExpression) $(D ! in) $(GLINK ShiftExpression)
 )
 
 $(P A container such as an associative array
@@ -700,14 +700,17 @@ $(P A container such as an associative array
         -------------
         int foo[string];
         ...
-        if ("hello" in foo) {
+        if ("hello" in foo)
+        {
             // the string was found
         }
         -------------
 
-    $(P The return value of the $(I InExpression) is typically `bool` or a pointer.
+    $(P The result of an $(I InExpression) is a pointer for associative
+        arrays.
         The pointer is $(D null) if the container has no matching key.
-        If there is a match, the return value is a pointer to a value associated with the key.
+        If there is a match, the pointer points to a value associated
+        with the key.
     )
 
     $(P The $(D !in) expression is the logical negation of the $(D in)
@@ -717,9 +720,11 @@ $(P A container such as an associative array
     $(P The $(D in) expression has the same precedence as the
         relational expressions $(D <), $(D <)$(D =), etc.)
 
-    $(NOTE When $(DDSUBLINK spec/operatoroverloading, binary, overloading) `in`, normally only `opBinaryRight` would be defined.)
-
-    $(BEST_PRACTICE Overloading `in` for a container should only be done when the operation is of sublinear time complexity.)
+    $(NOTE When $(DDSUBLINK spec/operatoroverloading, binary, overloading)
+        `in`, normally only $(TT opBinaryRight) would be defined. This is
+        because the operation is usually not defined by the key type but by
+        the container, which appears on the right hand side of the `in`
+        operator.)
 
 $(H2 $(LNAME2 shift_expressions, Shift Expressions))
 
@@ -812,7 +817,7 @@ $(GNAME CatExpression):
 )
 
     $(P A $(I CatExpression) concatenates a container's data with other data, producing
-        a new container of the same type as the result.
+        a new container.
         Typically the container is a dynamic array.)
 
     $(P For a dynamic array, the other operand must either be another array or a

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -816,13 +816,13 @@ $(GNAME CatExpression):
     $(GLINK AddExpression) $(D ~) $(GLINK MulExpression)
 )
 
-    $(P A $(I CatExpression) concatenates a container's data with other data, producing
-        a new container.
-        Typically the container is a dynamic array.)
-
-    $(P For a dynamic array, the other operand must either be another array or a
-        single value compatible with the element type of the array.
-        See $(DDSUBLINK spec/arrays, array-concatenation, Array Concatenation).)
+    $(P A $(I CatExpression) concatenates arrays, producing
+        a dynamic array with the result. The arrays must be
+        arrays of the same element type. If one operand is an array
+        and the other is of that array's element type, that element
+        is converted to an array of length 1 of that element,
+        and then the concatenation is performed.
+    )
 
 $(H2 $(LNAME2 mul_expressions, Mul Expressions))
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -695,7 +695,7 @@ $(GNAME InExpression):
 )
 
 $(P A container such as an associative array
-    $(DDSUBLINK spec/hash-map, testing_membership, can be tested) to see if contains a key:)
+    $(DDSUBLINK spec/hash-map, testing_membership, can be tested) to see if it contains a certain key:)
 
         -------------
         int foo[string];
@@ -707,7 +707,7 @@ $(P A container such as an associative array
 
     $(P The return value of the $(I InExpression) is typically `bool` or a pointer.
         The pointer is $(D null) if the container has no matching key.
-        If there is a match, the return value is a pointer to the associated element.
+        If there is a match, the return value is a pointer to a value associated with the key.
     )
 
     $(P The $(D !in) expression is the logical negation of the $(D in)
@@ -717,8 +717,9 @@ $(P A container such as an associative array
     $(P The $(D in) expression has the same precedence as the
         relational expressions $(D <), $(D <)$(D =), etc.)
 
-    $(BEST_PRACTICE $(DDSUBLINK spec/operatoroverloading, binary, Overloading `in`)
-    for a container should only be done when the operation is of sublinear time complexity.)
+    $(NOTE When $(DDSUBLINK spec/operatoroverloading, binary, overloading) `in`, normally only `opBinaryRight` would be defined.)
+
+    $(BEST_PRACTICE Overloading `in` for a container should only be done when the operation is of sublinear time complexity.)
 
 $(H2 $(LNAME2 shift_expressions, Shift Expressions))
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -691,29 +691,34 @@ $(H2 $(LNAME2 in_expressions, In Expressions))
 $(GRAMMAR
 $(GNAME InExpression):
     $(GLINK ShiftExpression) $(D in) $(GLINK ShiftExpression)
-    $(GLINK ShiftExpression) $(D ! in) $(GLINK ShiftExpression)
+    $(GLINK ShiftExpression) $(D !in) $(GLINK ShiftExpression)
 )
 
-$(P An associative array can be tested to see if an element is in the array:)
+$(P A container such as an associative array
+    $(DDSUBLINK spec/hash-map, testing_membership, can be tested) to see if contains a key:)
 
         -------------
         int foo[string];
         ...
-        if ("hello" in foo)
-            ...
+        if ("hello" in foo) {
+            // the string was found
+        }
         -------------
 
-    $(P The $(D in) expression has the same precedence as the
-        relational expressions $(D <), $(D <)$(D =),
-        etc.
-        The return value of the $(I InExpression) is $(D null)
-        if the element is not in the array;
-        if it is in the array it is a pointer to the element.
+    $(P The return value of the $(I InExpression) is typically `bool` or a pointer.
+        The pointer is $(D null) if the container has no matching key.
+        If there is a match, the return value is a pointer to the associated element.
     )
 
     $(P The $(D !in) expression is the logical negation of the $(D in)
         operation.
     )
+
+    $(P The $(D in) expression has the same precedence as the
+        relational expressions $(D <), $(D <)$(D =), etc.)
+
+    $(BEST_PRACTICE $(DDSUBLINK spec/operatoroverloading, binary, Overloading `in`)
+    for a container should only be done when the operation is of sublinear time complexity.)
 
 $(H2 $(LNAME2 shift_expressions, Shift Expressions))
 
@@ -805,13 +810,13 @@ $(GNAME CatExpression):
     $(GLINK AddExpression) $(D ~) $(GLINK MulExpression)
 )
 
-    $(P A $(I CatExpression) concatenates arrays, producing
-        a dynamic array with the result. The arrays must be
-        arrays of the same element type. If one operand is an array
-        and the other is of that array's element type, that element
-        is converted to an array of length 1 of that element,
-        and then the concatenation is performed.
-    )
+    $(P A $(I CatExpression) concatenates a container's data with other data, producing
+        a new container of the same type as the result.
+        Typically the container is a dynamic array.)
+
+    $(P For a dynamic array, the other operand must either be another array or a
+        single value compatible with the element type of the array.
+        See $(DDSUBLINK spec/arrays, array-concatenation, Array Concatenation).)
 
 $(H2 $(LNAME2 mul_expressions, Mul Expressions))
 

--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -247,7 +247,7 @@ $(H2 $(LEGACY_LNAME2 Binary, binary, Binary Operator Overloading))
 
         $(TABLE2 Overloadable Binary Operators,
         $(TROW $(D +), $(D -), $(D *), $(D /), $(CODE_PERCENT), $(D ^^), $(CODE_AMP))
-        $(TROW $(CODE_PIPE), $(D ^), $(D <)$(D <), $(D >)$(D >), $(D >)$(D >)$(D >), $(D ~), $(D in))
+        $(TROW $(CODE_PIPE), $(D ^), $(D <)$(D <), $(D >)$(D >), $(D >)$(D >)$(D >), $(D ~), $(DDSUBLINK spec/expression, InExpression, $(D in)))
         )
 
         $(P The expression:)


### PR DESCRIPTION
Make *InExpression* discuss a container, not just an associative array. Use key/value rather than *element*.
Mention result of `in` is a pointer *for AAs* (specifically).
Move sentence about precedence below result type description.
~~Add best practice note about overloading `in` only when there's sub-linear time complexity.~~
Add note about overloading `opBinaryRight`.