### PR TITLE
Replace throw statement with throw expressions (DIP 1034)

### DIFF
--- a/articles/lazy-evaluation.dd
+++ b/articles/lazy-evaluation.dd
@@ -249,12 +249,7 @@ if (!p)
 p.bar();    // now use p
 ---
 
-$(P Because throw is a statement, not an expression, expressions that
-need to do this need to be broken up into multiple statements,
-and extra variables are introduced.
-(For a thorough treatment of this issue, see Andrei Alexandrescu and
-Petru Marginean's paper
-$(LINK2 https://erdani.org/publications/cuj-06-2003.php.html, Enforcements)).
+$(P
 With lazy evaluation, this can all be encapsulated into a single
 function:
 )
@@ -312,4 +307,3 @@ Macros:
     SUBNAV=$(SUBNAV_ARTICLES)
 
     NG_digitalmars_D = <a href="http://www.digitalmars.com/pnews/read.php?server=news.digitalmars.com$(AMP)group=digitalmars.D$(AMP)artnum=$0">D/$0</a>
-

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -939,6 +939,7 @@ $(GNAME UnaryExpression):
     $(GLINK ComplementExpression)
     $(GLINK DeleteExpression)
     $(GLINK CastExpression)
+    $(GLINK ThrowExpression)
     $(GLINK PowExpression)
 )
 
@@ -1299,6 +1300,43 @@ $(H4 $(LNAME2 cast_void, Casting to `void`))
             foo(cast(void)10);  // OK
         }
         ----
+
+$(H2 $(LNAME2 throw_expression, Throw Expression))
+
+$(GRAMMAR
+$(GNAME ThrowExpression):
+    $(D throw) $(GLINK AssignExpression) $(D ;)
+)
+
+$(P
+    $(I AssignExpression) is evaluated and must yield a reference to a `Throwable`
+    or a class derived from `Throwable`. The reference is thrown as an exception,
+    interrupting the current control flow to continue at a suitable $(D catch) clause
+    of a $(GLINK2 statement, try-statement). This process will execute any applicable
+    $(LINK2 statement.html#ScopeGuardStatement, `scope (exit)` / `scope (failure)`)
+    passed since entering the corresponding `try` block.
+)
+
+    ---
+    throw new Exception("message");
+    ---
+
+$(P
+    A $(I ThrowExpression) may be nested in another expression:
+)
+    ---
+    void foo(int function() f) {}
+
+    void main() {
+        foo(() => throw new Exception());
+    }
+    ---
+
+
+$(BEST_PRACTICE Use $(DDSUBLINK spec/expression, assert_expressions, Assert Expressions)
+rather than $(LINK2 $(ROOT_DIR)library/object#.Error, Error) to report program bugs
+and abort the program.
+)
 
 $(H2 $(LNAME2 pow_expressions, Pow Expressions))
 

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -57,7 +57,6 @@ $(GNAME NonEmptyStatementNoCaseNoDefault):
     $(GLINK SynchronizedStatement)
     $(GLINK TryStatement)
     $(GLINK ScopeGuardStatement)
-    $(GLINK ThrowStatement)
     $(GLINK AsmStatement)
     $(GLINK MixinStatement)
     $(GLINK ForeachRangeStatement)
@@ -1174,7 +1173,7 @@ $(H3 $(LNAME2 no-implicit-fallthrough, No Implicit Fall-Through))
 
         $(P A $(GLINK ScopeStatementList) must either be empty, or be ended with
         a $(GLINK ContinueStatement), $(GLINK BreakStatement),
-        $(GLINK ReturnStatement), $(GLINK GotoStatement), $(GLINK ThrowStatement)
+        $(GLINK ReturnStatement), $(GLINK GotoStatement), $(GLINK2 expression, ThrowExpression)
         or `assert(0)` expression unless this is the last case. This is to
         set apart with C's error-prone implicit fall-through behavior.)
 
@@ -1746,27 +1745,6 @@ done
         $(P A $(I FinallyStatement) may not contain any $(I Catches).
         This restriction may be relaxed in future versions.
         )
-
-$(H2 $(LEGACY_LNAME2 ThrowStatement, throw-statement, Throw Statement))
-
-$(P Throws an exception.)
-
-$(GRAMMAR
-$(GNAME ThrowStatement):
-    $(D throw) $(EXPRESSION) $(D ;)
-)
-
-$(P *Expression* is evaluated and must be  a `Throwable` reference. The
-`Throwable` reference is thrown as an exception.)
-
----
-throw new Exception("message");
----
-
-$(BEST_PRACTICE Use $(DDSUBLINK spec/expression, assert_expressions, Assert Expressions)
-rather than $(LINK2 $(ROOT_DIR)library/object#.Error, Error) to report program bugs
-and abort the program.
-)
 
 $(H2 $(LEGACY_LNAME2 ScopeGuardStatement, scope-guard-statement, Scope Guard Statement))
 


### PR DESCRIPTION
Updates the grammar rules and moves the documentation from `statement.dd` to `expression.dd`

Also added an example for nested throws and removed the outdated paragraph in the lazy evaluation article.

---

See dlang/dmd#13162