### PR TITLE
[expression.dd] (re)move 2 sections to lex.dd

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1369,12 +1369,12 @@ $(GNAME PrimaryExpression):
     $(RELATIVE_LINK2 this, $(D this))
     $(RELATIVE_LINK2 super, $(D super))
     $(RELATIVE_LINK2 null, $(D null))
-    $(D true)
-    $(D false)
-    $(D $)
+    $(LEGACY_LNAME2 true_false)$(DDSUBLINK spec/type, bool, `true`)
+    $(DDSUBLINK spec/type, bool, `false`)
+    $(RELATIVE_LINK2 IndexExpression, `$`)
     $(GLINK_LEX IntegerLiteral)
     $(GLINK_LEX FloatLiteral)
-    $(GLINK_LEX CharacterLiteral)
+    $(LEGACY_LNAME2 CharacterLiteral)$(LEGACY_LNAME2 character-literal)$(GLINK_LEX CharacterLiteral)
     $(GLINK StringLiterals)
     $(GLINK ArrayLiteral)
     $(GLINK AssocArrayLiteral)
@@ -1461,23 +1461,6 @@ $(H3 $(LNAME2 null, null))
         functions, delegates, etc.
         After it is cast to a type, such conversions are implicit,
         but no longer exact.
-    )
-
-$(H3 $(LNAME2 true_false, true, false))
-
-    $(P These are of type $(D bool) and when cast to another integral
-        type become the values 1 and 0,
-        respectively.
-    )
-
-$(H3 $(LEGACY_LNAME2 CharacterLiteral, character-literal, Character Literals))
-
-    $(P Character literals are single characters and resolve to one
-        of type $(D char), $(D wchar), or $(D dchar).
-        If the literal is a $(D \u) escape sequence, it resolves to type $(D wchar).
-        If the literal is a $(D \U) escape sequence, it resolves to type $(D dchar).
-        Otherwise, it resolves to the type with the smallest size it
-        will fit into.
     )
 
 $(H3 $(LNAME2 string_literals, String Literals))

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -638,6 +638,17 @@ single quotes.)
     '\\'  // the backslash character
     ---
 
+$(P A character literal resolves to one
+    of type $(D char), $(D wchar), or $(D dchar)
+    (see $(DDSUBLINK spec/type, basic-data-types, Basic Data Types)).)
+
+$(UL
+    $(LI If the literal is a $(D \u) escape sequence, it resolves to type $(D wchar).)
+    $(LI If the literal is a $(D \U) escape sequence, it resolves to type $(D dchar).)
+)
+$(P Otherwise, it resolves to the type with the smallest size it
+    will fit into.)
+
 $(H2 $(LNAME2 integerliteral, Integer Literals))
 
 $(GRAMMAR_LEX


### PR DESCRIPTION
Remove section for bool literals, this info (and more) is already in lex.dd - add links to there.
Move *CharacterLiteral* paragraph to lex.dd so the key info is all in one place. (In general, expression.dd can provide more technical info than a specific page, but the type of a literal seems pretty important to leave out of lex.dd).
Keep old link anchors.
Add link for `$`.