### PR TITLE
[spec] Make more examples runnable

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -731,7 +731,7 @@ $(GNAME Destructor):
         )
 
         $(P Objects referenced from the data segment never get collected
-        by the GC.
+        by the gc.
         )
 
 $(H2 $(LNAME2 static-constructor, Static Constructors))

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -181,11 +181,13 @@ $(H2 $(LNAME2 class_properties, Class Properties))
         `.tupleof` is not available for `extern(Objective-C)` classes due to
         their fields having a dynamic offset.
         )
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 ---
 class Foo { int x; long y; }
 
-void test(Foo foo)
+void main()
 {
+    auto foo = new Foo;
     import std.stdio;
     static assert(typeof(foo.tupleof).stringof == `(int, long)`);
 
@@ -195,6 +197,7 @@ void test(Foo foo)
         write(x);       // prints 12
 }
 ---
+)
 
         $(P The properties $(D .__vptr) and $(D .__monitor) give access
         to the class object's vtbl[] and monitor, respectively, but
@@ -219,11 +222,12 @@ $(H2 $(LNAME2 member-functions, Member Functions (a.k.a. Methods)))
         $(D const), $(D immutable), $(D shared), or $(D inout).
         These attributes apply to the hidden $(I this) parameter.
         )
+$(SPEC_RUNNABLE_EXAMPLE_FAIL
 ---
 class C
 {
     int a;
-    const void foo()
+    void foo() const
     {
         a = 3; // error, 'this' is const
     }
@@ -233,6 +237,7 @@ class C
     }
 }
 ---
+)
 
 $(H3 $(LNAME2 objc-member-functions, Objective-C linkage))
 
@@ -726,7 +731,7 @@ $(GNAME Destructor):
         )
 
         $(P Objects referenced from the data segment never get collected
-        by the gc.
+        by the GC.
         )
 
 $(H2 $(LNAME2 static-constructor, Static Constructors))

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -434,6 +434,7 @@ b = 4;         // sets `S.j` to `4`
         $(P Aliases can be used to call a function with different default
         arguments, change an argument from required to default or vice versa:)
 
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 -----------
 import std.stdio : writefln;
 
@@ -464,6 +465,7 @@ void barbar(int a, int b = 6, int c = 7) {
     writefln("a: %d, b: %d, c: %d", a, b, c);
 }
 -----------
+)
 
 $(H2 $(LNAME2 AliasAssign, Alias Assign))
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2377,6 +2377,7 @@ $(H4 $(LNAME2 lazy_variadic_functions, Lazy Variadic Functions))
         would evaluate every array element.
         With the latter, only the element being accessed would be evaluated.)
 
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
         ---
         import std.stdio;
 
@@ -2399,10 +2400,11 @@ $(H4 $(LNAME2 lazy_variadic_functions, Lazy Variadic Functions))
         // variadic delegate array
         void flash(scope int delegate()[] arr ...)
         {
-            writeln(arr[0]); // 1
-            writeln(arr[1]); // 2
+            writeln(arr[0]()); // 1
+            writeln(arr[1]()); // 2
         }
         ---
+        )
 
         $(BEST_PRACTICE Use `scope` when declaring the array of delegates
         parameter. This will prevent a closure being generated for the delegate,
@@ -3020,20 +3022,22 @@ $(H2 $(LNAME2 interpretation, Compile Time Function Execution (CTFE)))
     $(LI $(DDLINK spec/traits, Traits, `__traits` argument))
     )
 
-$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 ---
-enum eval(Args...) = Args[0];
+enum eval(alias arg) = arg;
 
 int square(int i)
 {
     return i * i;
 }
 
-void foo()
+void main()
 {
+    import std.stdio;
+
     static j = square(3);      // CTFE
     writeln(j);
-    assert(square(4));         // run time
+    assert(square(4) == 16);       // run time
     static assert(square(3) == 9); // CTFE
     writeln(eval!(square(5))); // CTFE
 }

--- a/spec/garbage.dd
+++ b/spec/garbage.dd
@@ -288,7 +288,7 @@ struct Foo
 
         $(LI Do not use byte-by-byte memory copies to copy pointer values.
         This may result in intermediate conditions where there is
-        not a valid pointer, and if the GC pauses the thread in such a
+        not a valid pointer, and if the gc pauses the thread in such a
         condition, it can corrupt memory.
         Most implementations of $(D memcpy()) will work since the
         internal implementation of it does the copy in aligned chunks
@@ -401,7 +401,7 @@ $(H2 $(LNAME2 gc_config, Configuring the Garbage Collector))
         $(UL
         $(LI disable:0|1    - start disabled)
         $(LI profile:0|1    - enable profiling with summary when terminating program)
-        $(LI gc:conservative|precise|manual - select GC implementation (default = conservative))
+        $(LI gc:conservative|precise|manual - select gc implementation (default = conservative))
         $(LI initReserve:N  - initial memory to reserve in MB)
         $(LI minPoolSize:N  - initial and minimum pool size in MB)
         $(LI maxPoolSize:N  - maximum pool size in MB)

--- a/spec/garbage.dd
+++ b/spec/garbage.dd
@@ -288,7 +288,7 @@ struct Foo
 
         $(LI Do not use byte-by-byte memory copies to copy pointer values.
         This may result in intermediate conditions where there is
-        not a valid pointer, and if the gc pauses the thread in such a
+        not a valid pointer, and if the GC pauses the thread in such a
         condition, it can corrupt memory.
         Most implementations of $(D memcpy()) will work since the
         internal implementation of it does the copy in aligned chunks
@@ -401,7 +401,7 @@ $(H2 $(LNAME2 gc_config, Configuring the Garbage Collector))
         $(UL
         $(LI disable:0|1    - start disabled)
         $(LI profile:0|1    - enable profiling with summary when terminating program)
-        $(LI gc:conservative|precise|manual - select gc implementation (default = conservative))
+        $(LI gc:conservative|precise|manual - select GC implementation (default = conservative))
         $(LI initReserve:N  - initial memory to reserve in MB)
         $(LI minPoolSize:N  - initial and minimum pool size in MB)
         $(LI maxPoolSize:N  - maximum pool size in MB)

--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -1057,6 +1057,7 @@ $(H2 $(LEGACY_LNAME2 Dispatch, dispatch, Forwarding))
         to a template function named $(CODE opDispatch) for resolution.
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 ---
 import std.stdio;
 
@@ -1098,6 +1099,7 @@ void main()
     assert(d.foo == 8);
 }
 ---
+)
 
 $(H2 $(LEGACY_LNAME2 Old-Style, old-style, D1 style operator overloading))
 

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -362,8 +362,6 @@ $(GNAME TemplateThisParameter):
 
         $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ---
-        import std.stdio;
-
         struct S
         {
             void foo(this T)(int i) const

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -796,10 +796,8 @@ $(GNAME TemplateSequenceParameter):
             }
         }
 
-        template write(Args...)
+        template write(Args...) // Args is a TypeSeq
         {
-            pragma(msg, Args); // Args is a TypeSeq
-
             void f(Args args) // args is a ValueSeq
             {
                 writeln("args are ", args);
@@ -823,8 +821,6 @@ $(GNAME TemplateSequenceParameter):
     $(P $(I AliasSeq)-s are static compile-time entities, there is no way
         to dynamically change, add, or remove elements either at compile-time or run-time.
     )
-
-$(H3 $(LNAME2 typeseq_deduction, Type Sequence Deduction))
 
     $(P Type sequences can be deduced from the trailing parameters
         of an $(RELATIVE_LINK2 ifti, implicitly instantiated) function template:)

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -360,14 +360,15 @@ $(GNAME TemplateThisParameter):
         infer the mutability of the `this` reference. For example, if
         `this` is `const`, then the function is marked `const`.)
 
+        $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ---
         import std.stdio;
 
         struct S
         {
-            const void foo(this T)(int i)
+            void foo(this T)(int i) const
             {
-                writeln(typeid(T));
+                pragma(msg, T);
             }
         }
 
@@ -381,6 +382,7 @@ $(GNAME TemplateThisParameter):
             s3.foo(3);
         }
         ---
+        )
 
     Prints:
 
@@ -470,6 +472,7 @@ $(GNAME TemplateValueParameterDefault):
         associative array literals of template value arguments,
         or struct literals of template value arguments.)
 
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
         -----
         template foo(string s)
         {
@@ -478,9 +481,11 @@ $(GNAME TemplateValueParameterDefault):
 
         void main()
         {
-            writefln("%s", foo!("hello").bar()); // prints: hello betty
+            import std.stdio;
+            writeln(foo!("hello").bar()); // prints: hello betty
         }
         -----
+        )
 
     $(P This example of template foo has a value parameter that
         is specialized for 10:)
@@ -655,6 +660,7 @@ $(GNAME TemplateAliasParameterDefault):
 
         $(LI Literals
 
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
         ------
         template Foo(alias x, alias y)
         {
@@ -664,11 +670,12 @@ $(GNAME TemplateAliasParameterDefault):
 
         void main()
         {
+            import std.stdio;
             alias foo = Foo!(3, "bar");
             writeln(foo.i, foo.s);  // prints 3bar
         }
         ------
-        )
+        ))
 
         $(LI Compile-time values
         $(SPEC_RUNNABLE_EXAMPLE_RUN
@@ -777,10 +784,13 @@ $(GNAME TemplateSequenceParameter):
     $(P An $(I AliasSeq) can be used as an argument list to instantiate
         another template, or as the list of parameters for a function.)
 
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
         ---
+        import std.stdio;
+
         template print(args...)
         {
-            void print()
+            void f()
             {
                 writeln("args are ", args); // args is a ValueSeq
             }
@@ -788,8 +798,9 @@ $(GNAME TemplateSequenceParameter):
 
         template write(Args...)
         {
-            void write(Args args) // Args is a TypeSeq
-                                  // args is a ValueSeq
+            pragma(msg, Args); // Args is a TypeSeq
+
+            void f(Args args) // args is a ValueSeq
             {
                 writeln("args are ", args);
             }
@@ -797,10 +808,11 @@ $(GNAME TemplateSequenceParameter):
 
         void main()
         {
-            print!(1,'a',6.8).print();                    // prints: args are 1a6.8
-            write!(int, char, double).write(1, 'a', 6.8); // prints: args are 1a6.8
+            print!(1,'a',6.8).f();                    // prints: args are 1a6.8
+            write!(int, char, double).f(1, 'a', 6.8); // prints: args are 1a6.8
         }
         ---
+        )
 
     $(P The number of elements in an $(I AliasSeq) can be retrieved with
         the $(D .length) property. The $(I n)th element can be retrieved
@@ -812,10 +824,15 @@ $(GNAME TemplateSequenceParameter):
         to dynamically change, add, or remove elements either at compile-time or run-time.
     )
 
-    $(P Type sequences can be deduced from the trailing parameters
-        of an implicitly instantiated function template:)
+$(H3 $(LNAME2 typeseq_deduction, Type Sequence Deduction))
 
+    $(P Type sequences can be deduced from the trailing parameters
+        of an $(RELATIVE_LINK2 ifti, implicitly instantiated) function template:)
+
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
         ---
+        import std.stdio;
+
         template print(T, Args...)
         {
             void print(T first, Args args)
@@ -831,6 +848,7 @@ $(GNAME TemplateSequenceParameter):
             print(1, 'a', 6.8);
         }
         ---
+        )
 
     prints:
 
@@ -843,6 +861,7 @@ a
     $(P Type sequences can also be deduced from the type of a delegate
         or function parameter list passed as a function argument:)
 
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
         ----
         import std.stdio;
 
@@ -864,10 +883,12 @@ a
                 return x + y + z;
             }
 
+            import std.stdio;
             auto plus_two = partial(&plus, 2);
-            writefln("%d", plus_two(6, 8)); // prints 16
+            writeln(plus_two(6, 8)); // prints 16
         }
         ----
+        )
         See also: $(REF partial, std,functional)
 
 $(H3 $(LNAME2 variadic_template_specialization, Specialization))
@@ -1067,6 +1088,7 @@ $(H3 $(LNAME2 ifti, Implicit Function Template Instantiation (IFTI)))
         $(I TemplateArgumentList) is deducible from the types of the
         function arguments:)
 
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
         ----
         T square(T)(T t)
         {
@@ -1075,6 +1097,7 @@ $(H3 $(LNAME2 ifti, Implicit Function Template Instantiation (IFTI)))
 
         writefln("The square of %s is %s", 3, square(3));  // T is deduced to be int
         ----
+        )
 
     $(P Type parameter deduction is not influenced by the order of function
         arguments.


### PR DESCRIPTION
Also tweak those examples:
Move const attribute after parameters.
Fix calling array delegate elements.
Rename 2 eponymous template member functions so they can be called explicitly (this is before the IFTI section). Needed to compile.
Replace some trivial writefln calls with writeln.