### PR TITLE
[spec] Improve *AliasDeclaration* docs

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -281,12 +281,14 @@ $(GNAME AliasAssignment):
     $(GLINK_LEX Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT)
 )
 
-    $(P $(I AliasDeclaration)s create a symbol that is an alias for another type,
-        and can be used anywhere that other type may appear.
+    $(P $(I AliasDeclaration)s create a symbol name that refers to another symbol.
+        That symbol name can be used anywhere that the aliased symbol may appear.
     )
 
+$(H3 $(LNAME2 alias-type, Type Aliases))
+
 --------------------
-alias myint = abc.Foo.bar;
+alias MyInt = abc.Foo;
 --------------------
 
         $(P
@@ -296,11 +298,28 @@ alias myint = abc.Foo.bar;
         )
 
 --------------------
-alias myint = int;
+alias MyInt = int;
 
 void foo(int x) { ... }
-void foo(myint m) { ... } // error, multiply defined function foo
+void foo(MyInt m) { ... } // error, multiply defined function foo
 --------------------
+
+        $(P
+        Type aliases can sometimes look indistinguishable from
+        other symbol aliases:
+        )
+
+--------------------
+alias abc = foo.bar; // is it a type or a symbol?
+--------------------
+
+        $(P
+        The distinction is made in the semantic analysis pass.
+        )
+
+        $(BEST_PRACTICE use Capitalized Identifiers for type aliases.)
+
+$(H3 $(LNAME2 alias-symbol, Symbol Aliases))
 
     $(P A symbol can be declared as an $(I alias) of another symbol.
         For example:
@@ -329,16 +348,7 @@ t1.t v1;  // v1 is type int
 t2 v2;    // v2 is type int
 t3 v3;    // v3 is type int
 t4 v4;    // v4 is type int
-
-alias Fun = int(string p);
-int fun(string){return 0;}
-static assert(is(typeof(fun) == Fun));
-
-alias MemberFun1 = int() const;
-alias MemberFun2 = const int();
-// leading attributes apply to the func, not the return type
-static assert(is(MemberFun1 == MemberFun2));
---------------------
+---
 
         $(P
         Aliased symbols are useful as a shorthand for a long qualified
@@ -366,57 +376,44 @@ version (linux)
 alias strlen = string.strlen;
 --------------------
 
+$(H3 $(LNAME2 alias-overload, Aliasing an Overload Set))
+
         $(P
         Aliases can also `import` a set of overloaded functions, that can
         be overloaded with functions in the current scope:
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 --------------------
-class A
+class B
 {
-    int foo(int a) { return 1; }
-}
-
-class B : A
-{
-    int foo( int a, uint b ) { return 2; }
+    int foo(int a, uint b) { return 2; }
 }
 
 class C : B
 {
-    int foo( int a ) { return 3; }
+    // declaring an overload hides any base class overloads
+    int foo(int a) { return 3; }
+    // redeclare hidden overload
     alias foo = B.foo;
 }
 
-class D : C
+void main()
 {
-}
+    import std.stdio;
 
-void test()
-{
-    D b = new D();
-    int i;
-
-    i = b.foo(1, 2u);   // calls B.foo
-    i = b.foo(1);       // calls C.foo
+    C c = new C();
+    c.foo(1, 2u).writeln;   // calls B.foo
+    c.foo(1).writeln;       // calls C.foo
 }
 --------------------
+)
 
-        $(P
-        $(B Note:) Type aliases can sometimes look indistinguishable from
-        alias declarations:
-        )
-
---------------------
-alias abc = foo.bar; // is it a type or a symbol?
---------------------
-
-        $(P
-        The distinction is made in the semantic analysis pass.
-        )
+$(H3 $(LNAME2 alias-variable, Aliasing Variables))
 
         $(P Aliases cannot be used for expressions:)
 
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 -----------
 struct S
 {
@@ -426,10 +423,27 @@ struct S
 
 alias a = S.i; // OK, `S.i` is a symbol
 alias b = S.j; // OK. `S.j` is also a symbol
-alias c = a + b; // illegal, `a + b` is an expression
+//alias c = a + b; // illegal, `a + b` is an expression
 a = 2;         // sets `S.i` to `2`
 b = 4;         // sets `S.j` to `4`
+assert(S.i == 2);
+assert(S.j == 4);
 -----------
+)
+
+$(H3 $(LNAME2 alias-function, Aliasing a Function Type))
+
+        $(P Function types can be aliased:)
+---
+alias Fun = int(string p);
+int fun(string){return 0;}
+static assert(is(typeof(fun) == Fun));
+
+alias MemberFun1 = int() const;
+alias MemberFun2 = const int();
+// leading attributes apply to the func, not the return type
+static assert(is(MemberFun1 == MemberFun2));
+--------------------
 
         $(P Aliases can be used to call a function with different default
         arguments, change an argument from required to default or vice versa:)
@@ -465,7 +479,7 @@ void barbar(int a, int b = 6, int c = 7) {
 }
 -----------
 
-$(H2 $(LNAME2 AliasAssign, Alias Assign))
+$(H3 $(LNAME2 AliasAssign, Alias Assign))
 
 $(GRAMMAR
 $(GNAME AliasAssign):
@@ -534,7 +548,7 @@ pragma(msg, TK); // prints tuple(3, (const(uint)), (int))
 ---
         )
 
-$(H2 $(LNAME2 alias-reassignment, Alias Reassignment))
+$(H3 $(LNAME2 alias-reassignment, Alias Reassignment))
 
 $(GRAMMAR
 $(GNAME AliasReassignment):

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -523,7 +523,7 @@ to another $(I AliasAssign) to the same lvalue other than in the right hand side
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
-template AliasSeq(T...) { alias AliasSeq = T; }
+import std.meta : AliasSeq;
 
 static if (0) // recursive method for comparison
 {
@@ -565,13 +565,13 @@ $(GNAME AliasReassignment):
 
         $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ---
-        alias AliasSeq(a...) = a;
+        import std.meta : AliasSeq;
 
-        template staticMap(alias F, args...)
+        template staticMap(alias F, Args...)
         {
             alias A = AliasSeq!();
-            static foreach (arg; args)
-                A = AliasSeq!(A, F!arg); // alias reassignment
+            static foreach (Arg; Args)
+                A = AliasSeq!(A, F!Arg); // alias reassignment
             alias staticMap = A;
         }
 

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -288,7 +288,7 @@ $(GNAME AliasAssignment):
 $(H3 $(LNAME2 alias-type, Type Aliases))
 
 --------------------
-alias MyInt = abc.Foo;
+alias myint = abc.Foo.bar;
 --------------------
 
         $(P
@@ -298,10 +298,10 @@ alias MyInt = abc.Foo;
         )
 
 --------------------
-alias MyInt = int;
+alias myint = int;
 
 void foo(int x) { ... }
-void foo(MyInt m) { ... } // error, multiply defined function foo
+void foo(myint m) { ... } // error, multiply defined function foo
 --------------------
 
         $(P
@@ -313,11 +313,8 @@ void foo(MyInt m) { ... } // error, multiply defined function foo
 alias abc = foo.bar; // is it a type or a symbol?
 --------------------
 
-        $(P
-        The distinction is made in the semantic analysis pass.
-        )
-
-        $(BEST_PRACTICE use Capitalized Identifiers for type aliases.)
+        $(BEST_PRACTICE Other than when aliasing simple basic type names,
+        type alias names should be Capitalized.)
 
 $(H3 $(LNAME2 alias-symbol, Symbol Aliases))
 

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -489,6 +489,7 @@ $(GNAME AliasAssign):
         $(P An $(GLINK AliasDeclaration) can have a new value assigned to it with an
         $(I AliasAssign):)
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 template Gorgon(T)
 {
@@ -498,6 +499,7 @@ template Gorgon(T)
 }
 pragma(msg, Gorgon!int); // prints int
 ---
+)
 
 $(UL
 $(LI The $(I AliasAssign) and its corresponding $(I AliasDeclaration) must both be
@@ -517,7 +519,9 @@ to another $(I AliasAssign) to the same lvalue other than in the right hand side
         $(I AliasAssign) is particularly useful when using an iterative
         computation rather than a recursive one, as it avoids creating
         the large number of intermediate templates that the recursive one
-        engenders.
+        engenders.)
+
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 template AliasSeq(T...) { alias AliasSeq = T; }
 
@@ -546,7 +550,7 @@ enum X = 3;
 alias TK = Reverse!(int, const uint, X);
 pragma(msg, TK); // prints tuple(3, (const(uint)), (int))
 ---
-        )
+)
 
 $(H3 $(LNAME2 alias-reassignment, Alias Reassignment))
 
@@ -559,15 +563,22 @@ $(GNAME AliasReassignment):
 
         $(P An alias declaration inside a template can be reassigned a new value.)
 
+        $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ---
-        template staticMap(alias F, T...)
+        alias AliasSeq(a...) = a;
+
+        template staticMap(alias F, args...)
         {
             alias A = AliasSeq!();
-            static foreach (t; T)
-                A = AliasSeq!(A, F!T); // alias reassignment
+            static foreach (arg; args)
+                A = AliasSeq!(A, F!arg); // alias reassignment
             alias staticMap = A;
         }
+
+        enum size(T) = T.sizeof;
+        static assert(staticMap!(size, char, wchar, dchar) == AliasSeq!(1, 2, 4));
         ---
+        )
 
         $(P The $(I Identifier) must resolve to a lexically preceding $(GLINK AliasDeclaration).
         Both must be members of the same $(GLINK2 template, TemplateDeclaration).


### PR DESCRIPTION
Define aliases in terms of another symbol, not just another type.
Add subheadings.
Add note about capitalizing non-basic type aliases.
Move paragraph about type aliases being indistinguishable (from other aliases) up to type aliases section.
Move function type aliases example down to function type aliases section.
Make 2 examples runnable.
Simplify aliasing an overload set example - classes A and D are not needed.
Make *AliasAssign* sections child headings of *AliasDeclaration*.
Make *AliasAssign* examples get compiled; add static assert with `staticMap` and `T.sizeof`.
