### PR TITLE
[spec/template.dd] Improve docs

### DIFF
--- a/spec/template.dd
+++ b/spec/template.dd
@@ -934,7 +934,8 @@ $(H2 $(LNAME2 implicit_template_properties, Eponymous Templates))
         }
         ------
 
-        $(P Using functions and more types than the template:)
+        $(P The following example has more than one eponymous member and uses
+        $(RELATIVE_LINK2 ifti, Implicit Function Template Instantiation):)
 
         ------
         template foo(S, T)
@@ -948,24 +949,6 @@ $(H2 $(LNAME2 implicit_template_properties, Eponymous Templates))
         {
             foo(1, 2, "test"); // foo!(int, int).foo(1, 2, "test")
             foo(1, 2); // foo!(int, int).foo(1, 2)
-        }
-        ------
-
-        $(P When the template parameters must be deduced, the eponymous members
-        can't rely on a $(LINK2 version.html#StaticIfCondition, `static if`)
-        condition since the deduction relies on how the in members are used:)
-
-        ------
-        template foo(T)
-        {
-            static if (is(T)) // T is not yet known...
-                void foo(T t) {} // T is deduced from the member usage
-        }
-
-        void main()
-        {
-            foo(0); // Error: cannot deduce function from argument types
-            foo!int(0); // Ok since no deduction necessary
         }
         ------
 
@@ -1084,6 +1067,8 @@ $(H3 $(LNAME2 ifti, Implicit Function Template Instantiation (IFTI)))
         from the function arguments.
     )
 
+$(H4 $(LNAME2 ifti-restrictions, Restrictions))
+
     $(P Function template type parameters that are to be implicitly
         deduced may not have specializations:)
 
@@ -1093,6 +1078,25 @@ $(H3 $(LNAME2 ifti, Implicit Function Template Instantiation (IFTI)))
         int x,y;
         foo!(int*)(x);   // ok, T is not deduced from function argument
         foo(&y);         // error, T has specialization
+        ------
+
+        $(P When the template parameters must be deduced, the
+        $(RELATIVE_LINK2 implicit_template_properties, eponymous members)
+        can't rely on a $(LINK2 version.html#StaticIfCondition, `static if`)
+        condition since the deduction relies on how the members are used:)
+
+        ------
+        template foo(T)
+        {
+            static if (is(T)) // T is not yet known...
+                void foo(T t) {} // T is deduced from the member usage
+        }
+
+        void main()
+        {
+            foo(0); // Error: cannot deduce function from argument types
+            foo!int(0); // Ok since no deduction necessary
+        }
         ------
 
 $(H4 $(LNAME2 ifti-conversions, Type Conversions))

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -53,6 +53,11 @@ $(GNAME TemplateParameter):
         $(I TemplateParameter) in case one is not supplied.
     )
 
+    $(NOTE `template` keyword declarations are less common in idiomatic D code.
+    Usually an aggregate, function, alias, enum or variable template
+    would be declared with
+    $(RELATIVE_LINK2 aggregate_templates, short syntax) instead.)
+
 $(H2 $(LNAME2 explicit_tmp_instantiation, Template Instantiation))
 
 $(H3 $(LNAME2 explicit_tmp_instantiation, Explicit Template Instantiation))

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -157,7 +157,7 @@ $(H3 $(LNAME2 common_instantiation, Common Instantiation))
 
     $(P Even if template arguments are implicitly converted to the same
         template parameter type, they still refer to the same instance.
-        This example uses a
+        This example uses a $(GLINK TemplateValueParameter) and a
         $(RELATIVE_LINK2 aggregate_templates, `struct` template):)
 
         -----
@@ -952,7 +952,7 @@ $(H2 $(LNAME2 implicit_template_properties, Eponymous Templates))
         }
         ------
 
-$(H2 $(LNAME2 aggregate_templates, Aggregate Templates))
+$(H2 $(LNAME2 aggregate_templates, Aggregate Type Templates))
 
 $(GRAMMAR
 $(GNAME ClassTemplateDeclaration):

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -195,15 +195,14 @@ $(H2 $(LNAME2 instantiation_scope, Instantiation Scope))
         the $(I TemplateDeclaration) is declared, with the addition of the
         template parameters being declared as aliases for their deduced types.
     )
-    $(P For example:)
+    $(P $(B Example:))
 
-        $(BR)$(BR)
-        $(U module a)
+        $(U module a:)
         ------
         template TFoo(T) { void bar() { func(); } }
         ------
 
-        $(U module b)
+        $(U module b:)
         ------
         import a;
 
@@ -211,16 +210,15 @@ $(H2 $(LNAME2 instantiation_scope, Instantiation Scope))
         alias f = TFoo!(int); // error: func not defined in module a
         ------
 
-    and:
+    $(P $(B Example:))
 
-        $(BR)$(BR)
-        $(U module a)
+        $(U module a:)
         ------
         template TFoo(T) { void bar() { func(1); } }
         void func(double d) { }
         ------
 
-        $(U module b)
+        $(U module b:)
         ------
         import a;
 

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -37,12 +37,20 @@ $(GNAME TemplateParameter):
         functions, and other templates.
     )
 
-    $(P Template parameters can be types, values, symbols, or sequences.
-        Type parameters can be any type.
-        Value parameters can have any type which can be statically
+    $(P Template parameters can take types, values, symbols, or sequences.
+        Type parameters can take any type.)
+
+    ---
+    template t(T) // declare type parameter T
+    {
+        T v; // declare a member variable of type T within template t
+    }
+    ---
+
+    $(P Value parameters can take any type which can be statically
         initialized at compile time.
-        Symbols can be any non-local symbol.
-        Sequences can contain zero or more types, values or symbols.
+        Alias parameters can take any non-local symbol.
+        Sequence parameters can take zero or more types, values or symbols.
     )
 
     $(P Template parameter specializations

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -239,7 +239,7 @@ $(H3 $(LNAME2 instantiation_scope, Instantiation Scope))
         values are evaluated in the scope of the $(I TemplateDeclaration).
     )
 
-$(H3 $(LNAME2 argument_deduction, Parameter Type Deduction))
+$(H2 $(LNAME2 argument_deduction, Argument Deduction))
 
     $(P The types of template parameters are deduced for a particular
         template instantiation by comparing the template argument with

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -1017,17 +1017,6 @@ $(GNAME UnionTemplateDeclaration):
         can be transformed into templates by supplying a template parameter list.
     )
 
-$(H2 $(LNAME2 template_ctors, Template Constructors))
-
-$(GRAMMAR
-$(GNAME ConstructorTemplate):
-    $(D this) $(GLINK TemplateParameters) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(D :)
-    $(D this) $(GLINK TemplateParameters) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(GLINK2 function, FunctionBody)
-)
-
-    $(P Templates can be used to form constructors for classes and structs.
-    )
-
 $(H2 $(LNAME2 function-templates, Function Templates))
 
     $(P If a template declares exactly one member, and that member is a function
@@ -1200,6 +1189,17 @@ $(H3 $(LNAME2 function-default, Default Arguments))
         assert(fun!int(1, "filename") == 1);  // no IFTI
         ---
         )
+
+$(H2 $(LNAME2 template_ctors, Template Constructors))
+
+$(GRAMMAR
+$(GNAME ConstructorTemplate):
+    $(D this) $(GLINK TemplateParameters) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(D :)
+    $(D this) $(GLINK TemplateParameters) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(GLINK2 function, FunctionBody)
+)
+
+    $(P Templates can be used to form constructors for classes and structs.
+    )
 
 $(H2 $(LNAME2 variable-template, Enum & Variable Templates))
 

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -47,8 +47,8 @@ $(GNAME TemplateParameter):
     }
     ---
 
-    $(P Value parameters can take any type which can be statically
-        initialized at compile time.
+    $(P Value parameters can take any expression which can be statically
+        evaluated at compile time.
         Alias parameters can take almost any symbol.
         Sequence parameters can take zero or more types, values or symbols.
     )
@@ -478,8 +478,8 @@ $(GNAME TemplateValueParameterDefault):
     $(D =) $(GLINK2 expression, SpecialKeyword)
 )
 
-    $(P Template value parameter types can be any type which can
-        be statically initialized at compile time.
+    $(P A template value parameter can take an argument of any expression which can
+        be statically evaluated at compile time.
         Template value arguments can be integer values, floating point values,
         nulls, string values, array literals of template value arguments,
         associative array literals of template value arguments,
@@ -496,6 +496,9 @@ $(GNAME TemplateValueParameterDefault):
             writefln("%s", foo!("hello").bar()); // prints: hello betty
         }
         -----
+
+    $(P Any specialization or default expression provided must be evaluatable
+        at compile-time.)
 
     $(P This example of template foo has a value parameter that
         is specialized for 10:)

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -74,9 +74,7 @@ $(GNAME TemplateParameter):
         template declarations instead.)
 
 
-$(H2 $(LNAME2 explicit_tmp_instantiation, Template Instantiation))
-
-$(H3 $(LNAME2 explicit_tmp_instantiation, Explicit Template Instantiation))
+$(H2 $(LNAME2 explicit_tmp_instantiation, Explicit Template Instantiation))
 
     $(P Templates are explicitly instantiated with:
     )
@@ -147,8 +145,6 @@ $(GNAME TemplateSingleArgument):
         foo.Ptr x;        // declare x to be of type int*
         ------
 
-$(H3 $(LNAME2 common_instantiation, Common Instantiation))
-
     $(P Multiple instantiations of a $(I TemplateDeclaration) with the same
         $(I TemplateArgumentList) will all refer to the same instantiation.
         For example:)
@@ -168,7 +164,7 @@ $(H3 $(LNAME2 common_instantiation, Common Instantiation))
 
     $(P Even if template arguments are implicitly converted to the same
         template parameter type, they still refer to the same instance.
-        This example uses a $(GLINK TemplateValueParameter) and a
+        This example uses a
         $(RELATIVE_LINK2 aggregate_templates, `struct` template):)
 
         -----
@@ -207,20 +203,21 @@ $(H3 $(LNAME2 common_instantiation, Common Instantiation))
         ------
     $(P See also $(RELATIVE_LINK2 function-templates, function templates).)
 
-$(H3 $(LNAME2 instantiation_scope, Instantiation Scope))
+$(H2 $(LNAME2 instantiation_scope, Instantiation Scope))
 
     $(P $(I TemplateInstance)s are always instantiated in the scope of where
         the $(I TemplateDeclaration) is declared, with the addition of the
         template parameters being declared as aliases for their deduced types.
     )
-    $(P $(B Example:))
+    $(P For example:)
 
-        $(U module a:)
+        $(BR)$(BR)
+        $(U module a)
         ------
         template TFoo(T) { void bar() { func(); } }
         ------
 
-        $(U module b:)
+        $(U module b)
         ------
         import a;
 
@@ -228,15 +225,16 @@ $(H3 $(LNAME2 instantiation_scope, Instantiation Scope))
         alias f = TFoo!(int); // error: func not defined in module a
         ------
 
-    $(P $(B Example:))
+    and:
 
-        $(U module a:)
+        $(BR)$(BR)
+        $(U module a)
         ------
         template TFoo(T) { void bar() { func(1); } }
         void func(double d) { }
         ------
 
-        $(U module b:)
+        $(U module b)
         ------
         import a;
 

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -53,6 +53,11 @@ $(GNAME TemplateParameter):
         $(I TemplateParameter) in case one is not supplied.
     )
 
+    $(P If multiple templates with the same $(I Identifier) are
+        declared, they are distinct if they have different parameters
+        or are differently specialized.
+    )
+
     $(NOTE `template` declarations with only one member are usually
     written as specific $(RELATIVE_LINK2 aggregate_templates, short syntax)
     template declarations instead.)
@@ -130,11 +135,6 @@ $(GNAME TemplateSingleArgument):
         alias foo = TFoo!(int);
         foo.Ptr x;        // declare x to be of type int*
         ------
-
-    $(P If multiple templates with the same $(I Identifier) are
-        declared, they are distinct if they have a different number of
-        arguments or are differently specialized.
-    )
 
 $(H3 $(LNAME2 common_instantiation, Common Instantiation))
 

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -53,10 +53,10 @@ $(GNAME TemplateParameter):
         $(I TemplateParameter) in case one is not supplied.
     )
 
-    $(NOTE `template` keyword declarations are less common in idiomatic D code.
-    Usually an aggregate, function, alias, enum or variable template
-    would be declared with
-    $(RELATIVE_LINK2 aggregate_templates, short syntax) instead.)
+    $(NOTE `template` declarations with only one member are usually
+    written as specific $(RELATIVE_LINK2 aggregate_templates, short syntax)
+    template declarations instead.)
+
 
 $(H2 $(LNAME2 explicit_tmp_instantiation, Template Instantiation))
 

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -7,7 +7,7 @@ $(HEADERNAV_TOC)
 $(H2 $(LNAME2 declarations, Template Declarations))
 
     $(P Templates are D's approach to generic programming.
-        Templates are defined with a $(I TemplateDeclaration):
+        Templates can be defined with a $(I TemplateDeclaration):
     )
 
 $(GRAMMAR
@@ -30,11 +30,11 @@ $(GNAME TemplateParameter):
     $(GLINK TemplateThisParameter)
 )
 
-    $(P The body of the $(I TemplateDeclaration) must be syntactically correct
+    $(P The *DeclDefs* body of the template must be syntactically correct
         even if never instantiated. Semantic analysis is not done until
-        instantiated. A template forms its own scope, and the template
-        body can contain classes, structs, types, enums, variables,
-        functions, and other templates.
+        instantiation. A template forms its own scope, and the template
+        body can contain declarations such as classes, structs, types,
+        enums, variables, functions, and other templates.
     )
 
     $(P Template parameters can take types, values, symbols, or sequences.
@@ -66,9 +66,12 @@ $(GNAME TemplateParameter):
         or are differently specialized.
     )
 
-    $(NOTE `template` declarations with only one member are usually
-    written as specific $(RELATIVE_LINK2 aggregate_templates, short syntax)
-    template declarations instead.)
+    $(P If a template has a member which has the same identifier as the
+        template, the template is an
+        $(RELATIVE_LINK2 implicit_template_properties, Eponymous Template).
+        `template` declarations with one eponymous member are usually
+        written as specific $(RELATIVE_LINK2 aggregate_templates, short syntax)
+        template declarations instead.)
 
 
 $(H2 $(LNAME2 explicit_tmp_instantiation, Template Instantiation))

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -49,7 +49,7 @@ $(GNAME TemplateParameter):
 
     $(P Value parameters can take any type which can be statically
         initialized at compile time.
-        Alias parameters can take any non-local symbol.
+        Alias parameters can take almost any symbol.
         Sequence parameters can take zero or more types, values or symbols.
     )
 

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -4,6 +4,8 @@ $(SPEC_S Templates,
 
 $(HEADERNAV_TOC)
 
+$(H2 $(LNAME2 declarations, Template Declarations))
+
     $(P Templates are D's approach to generic programming.
         Templates are defined with a $(I TemplateDeclaration):
     )
@@ -36,11 +38,9 @@ $(GNAME TemplateParameter):
     )
 
     $(P Template parameters can be types, values, symbols, or sequences.
-        Types can be any type.
-        Value parameters must be of an integral type, floating point
-        type, or string type and
-        specializations for them must resolve to an integral constant,
-        floating point constant, null, or a string literal.
+        Type parameters can be any type.
+        Value parameters can have any type which can be statically
+        initialized at compile time.
         Symbols can be any non-local symbol.
         Sequences can contain zero or more types, values or symbols.
     )
@@ -124,6 +124,13 @@ $(GNAME TemplateSingleArgument):
         foo.Ptr x;        // declare x to be of type int*
         ------
 
+    $(P If multiple templates with the same $(I Identifier) are
+        declared, they are distinct if they have a different number of
+        arguments or are differently specialized.
+    )
+
+$(H3 $(LNAME2 common_instantiation, Common Instantiation))
+
     $(P Multiple instantiations of a $(I TemplateDeclaration) with the same
         $(I TemplateArgumentList) will all refer to the same instantiation.
         For example:)
@@ -158,11 +165,6 @@ $(GNAME TemplateSingleArgument):
         // and refers to exactly the same instance as TFoo!(3)
         static assert(is(TFoo!(3) == TFoo!(3u)));
         -----
-
-    $(P If multiple templates with the same $(I Identifier) are
-        declared, they are distinct if they have a different number of
-        arguments or are differently specialized.
-    )
 
     $(H3 $(LNAME2 copy_example, Practical Example))
 
@@ -232,7 +234,7 @@ $(H2 $(LNAME2 instantiation_scope, Instantiation Scope))
         values are evaluated in the scope of the $(I TemplateDeclaration).
     )
 
-$(H2 $(LNAME2 argument_deduction, Argument Deduction))
+$(H2 $(LNAME2 argument_deduction, Template Argument Deduction))
 
     $(P The types of template parameters are deduced for a particular
         template instantiation by comparing the template argument with
@@ -812,6 +814,8 @@ $(GNAME TemplateSequenceParameter):
         to dynamically change, add, or remove elements either at compile-time or run-time.
     )
 
+$(H3 $(LNAME2 typeseq_deduction, Type Sequence Deduction))
+
     $(P Type sequences can be deduced from the trailing parameters
         of an implicitly instantiated function template:)
 
@@ -960,17 +964,6 @@ $(H2 $(LNAME2 implicit_template_properties, Eponymous Templates))
         }
         ------
 
-$(H2 $(LNAME2 template_ctors, Template Constructors))
-
-$(GRAMMAR
-$(GNAME ConstructorTemplate):
-    $(D this) $(GLINK TemplateParameters) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(D :)
-    $(D this) $(GLINK TemplateParameters) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(GLINK2 function, FunctionBody)
-)
-
-    $(P Templates can be used to form constructors for classes  and structs.
-    )
-
 $(H2 $(LNAME2 aggregate_templates, Aggregate Templates))
 
 $(GRAMMAR
@@ -1022,6 +1015,17 @@ $(GNAME UnionTemplateDeclaration):
 
     $(P Analogously to class templates, struct, union and interfaces
         can be transformed into templates by supplying a template parameter list.
+    )
+
+$(H2 $(LNAME2 template_ctors, Template Constructors))
+
+$(GRAMMAR
+$(GNAME ConstructorTemplate):
+    $(D this) $(GLINK TemplateParameters) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(D :)
+    $(D this) $(GLINK TemplateParameters) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(GLINK2 function, FunctionBody)
+)
+
+    $(P Templates can be used to form constructors for classes and structs.
     )
 
 $(H2 $(LNAME2 function-templates, Function Templates))

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -53,7 +53,9 @@ $(GNAME TemplateParameter):
         $(I TemplateParameter) in case one is not supplied.
     )
 
-$(H2 $(LNAME2 explicit_tmp_instantiation, Explicit Template Instantiation))
+$(H2 $(LNAME2 explicit_tmp_instantiation, Template Instantiation))
+
+$(H3 $(LNAME2 explicit_tmp_instantiation, Explicit Template Instantiation))
 
     $(P Templates are explicitly instantiated with:
     )
@@ -189,7 +191,7 @@ $(H3 $(LNAME2 common_instantiation, Common Instantiation))
         ------
     $(P See also $(RELATIVE_LINK2 function-templates, function templates).)
 
-$(H2 $(LNAME2 instantiation_scope, Instantiation Scope))
+$(H3 $(LNAME2 instantiation_scope, Instantiation Scope))
 
     $(P $(I TemplateInstance)s are always instantiated in the scope of where
         the $(I TemplateDeclaration) is declared, with the addition of the
@@ -232,7 +234,7 @@ $(H2 $(LNAME2 instantiation_scope, Instantiation Scope))
         values are evaluated in the scope of the $(I TemplateDeclaration).
     )
 
-$(H2 $(LNAME2 argument_deduction, Template Argument Deduction))
+$(H3 $(LNAME2 argument_deduction, Parameter Type Deduction))
 
     $(P The types of template parameters are deduced for a particular
         template instantiation by comparing the template argument with


### PR DESCRIPTION
Add *Template Declarations* heading:
Add example for template type parameter.
Fix: Value parameters are not limited to int, float, string.
Fix: Alias parameters can take local symbols.
Move paragraph about overloaded templates from *Explicit Template Instantiation* to *Template Declarations*.
Mention eponymous templates & often using short syntax templates instead.

Move sentence about value specialization to *Value Parameters*.
Add *Type Sequence Deduction* subheading of *Sequence Parameters*.

Tweak *Eponymous Templates* wording.
Rename *Aggregate Templates* to *Aggregate Type Templates*.

Move 'IFTI vs static if' section from *Eponymous Templates* to *IFTI* & add *Restrictions* subheading.
Move *Template Constructors* below *Function Templates* section.