### PR TITLE
Follow-up to DMD PR#14892: document version(D_ProfileGC).

### DIFF
--- a/spec/version.dd
+++ b/spec/version.dd
@@ -347,6 +347,8 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
         $(TROW $(ARGS $(D D_NoBoundsChecks)) , $(ARGS Array bounds checks are disabled
                 (command line switch $(DDSUBLINK dmd, switch-boundscheck, $(TT -boundscheck=off)))))
         $(TROW $(ARGS $(D D_ObjectiveC)) , $(ARGS The target supports interfacing with Objective-C))
+        $(TROW $(ARGS $(D D_ProfileGC)) , $(ARGS GC allocations being profiled
+                (command line switch $(DDSUBLINK dmd, switch-profile, $(TT -profile=gc)))))
         $(TROW $(ARGS $(D Core)) , $(ARGS Defined when building the standard runtime))
         $(TROW $(ARGS $(D Std)) , $(ARGS Defined when building the standard library))
         $(TROW $(ARGS $(D unittest)) , $(ARGS $(DDLINK spec/unittest, Unit Tests, Unit tests) are enabled


### PR DESCRIPTION
Follow-up for https://github.com/dlang/dmd/pull/13545.