### PR TITLE
Fix issue 22234 - __traits(getLinkage) returns wrong value for extern(System) functions

### DIFF
--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -971,7 +971,10 @@ $(H2 $(GNAME getLinkage))
         $(LI $(D "C++"))
         $(LI $(D "Windows"))
         $(LI $(D "Objective-C"))
-        $(LI $(D "System"))
+        )
+
+        $(P A type with `extern(System)` linkage will not result in a string $(D "System")), but the
+        actual linkage it resolves to: $(D "Windows")) or $(D "C")) depending on the target platform.
         )
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE


### PR DESCRIPTION
Looking at the test cases that came with the implementation (https://github.com/dlang/dmd/pull/6822), it looks like intentional behavior that `__traits(getLinkage)` gives the actual linkage of `extern(System)` instead of "System". It also sounds more useful to me this way and avoids code breakage, hence the spec PR instead of dmd PR.