### PR TITLE
Correct hasMember trait example

### DIFF
--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -677,8 +677,6 @@ import std.stdio;
 struct S
 {
     int m;
-
-    import std.stdio; // imports write
 }
 
 void main()
@@ -688,7 +686,7 @@ void main()
     writeln(__traits(hasMember, S, "m")); // true
     writeln(__traits(hasMember, s, "m")); // true
     writeln(__traits(hasMember, S, "y")); // false
-    writeln(__traits(hasMember, S, "write")); // true
+    writeln(__traits(hasMember, S, "write")); // false
     writeln(__traits(hasMember, int, "sizeof")); // true
 }
 ---

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -686,7 +686,7 @@ void main()
     writeln(__traits(hasMember, S, "m")); // true
     writeln(__traits(hasMember, s, "m")); // true
     writeln(__traits(hasMember, S, "y")); // false
-    writeln(__traits(hasMember, S, "write")); // false
+    writeln(__traits(hasMember, S, "write")); // false, but callable like a member via UFCS
     writeln(__traits(hasMember, int, "sizeof")); // true
 }
 ---


### PR DESCRIPTION
The `hasMember` trait made an odd claim — that adding `import std.stdio;` inside a struct S makes `write` a member of that struct. If you run the example, you can see that `write` isn't a member after all.

I left the `import std.stdio;` at the top to show that UFCS doesn't mean any function is a member.