### PR TITLE
[spec/statement.dd] Improve foreach loop invariant docs

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1014,7 +1014,7 @@ foreach (int v; a)
 
     // reassigning is unspecified!
     a = null;
-    a = [5,6];
+    a = [5, 6];
 }
 a ~= 4;   // OK
 a = null; // OK

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1026,7 +1026,7 @@ foreach (v; aa)
 {
     aa[3] = 3; // unspecified resize
     aa.rehash; // unspecified reallocation
-    aa = [4:4]; // unspecified reassign
+    aa = [4: 4]; // unspecified reassign
 }
 aa[3] = 3; // OK
 aa = null; // OK

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1000,14 +1000,18 @@ $(H3 $(LNAME2 foreach_restrictions, Foreach Restrictions))
 
 --------------
 int[] a = [1,2,3];
+auto fun = {a ~= 4;};
 
 foreach (int v; a)
 {
     // resizing is unspecified!
+    fun();
     a ~= 4;
     a.length += 10;
+
     // reallocating is unspecified!
     a.reserve(10);
+
     // reassigning is unspecified!
     a = null;
     a = [5,6];

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -999,7 +999,7 @@ $(H3 $(LNAME2 foreach_restrictions, Foreach Restrictions))
         )
 
 --------------
-int[] a = [1,2,3];
+int[] a = [1, 2, 3];
 auto fun = {a ~= 4;};
 
 foreach (int v; a)

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -496,8 +496,8 @@ $(P
         will have $(D scope) semantics.
 )
 $(P
-        The aggregate must be loop invariant, meaning that
-        elements to the aggregate cannot be added or removed from it
+        The loop must be $(RELATIVE_LINK2 foreach_restrictions, invariant), meaning that
+        elements cannot be added or removed from the aggregate
         in the *NoScopeNonEmptyStatement*.
 )
 
@@ -995,20 +995,42 @@ $(H3 $(LNAME2 foreach_restrictions, Foreach Restrictions))
 
         $(P The aggregate itself must not be resized, reallocated, free'd,
         reassigned or destructed
-        while the foreach is iterating over the elements.
+        while `foreach` is iterating over the elements.
         )
 
 --------------
-int[] a;
-int[] b;
-foreach (int i; a)
+int[] a = [1,2,3];
+
+foreach (int v; a)
 {
-    a = null;       // error
-    a.length += 10; // error
-    a = b;          // error
+    // resizing is unspecified!
+    a ~= 4;
+    a.length += 10;
+    // reallocating is unspecified!
+    a.reserve(10);
+    // reassigning is unspecified!
+    a = null;
+    a = [5,6];
 }
-a = null;         // ok
+a ~= 4;   // OK
+a = null; // OK
 --------------
+---
+auto aa = [1:1,2:2];
+
+foreach (v; aa)
+{
+    aa[3] = 3; // unspecified resize
+    aa.rehash; // unspecified reallocation
+    aa = [4:4]; // unspecified reassign
+}
+aa[3] = 3; // OK
+aa = null; // OK
+---
+
+        $(NOTE Resizing or reassigning a dynamic or associative array during
+        `foreach` is still `@safe`.
+        )
 
 $(H3 $(LEGACY_LNAME2 ForeachRangeStatement, foreach-range-statement, Foreach Range Statement))
 

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1000,7 +1000,7 @@ $(H3 $(LNAME2 foreach_restrictions, Foreach Restrictions))
 
 --------------
 int[] a = [1, 2, 3];
-auto fun = {a ~= 4;};
+auto fun = { a ~= 4; };
 
 foreach (int v; a)
 {

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -496,8 +496,8 @@ $(P
         will have $(D scope) semantics.
 )
 $(P
-        The loop must be $(RELATIVE_LINK2 foreach_restrictions, invariant), meaning that
-        elements cannot be added or removed from the aggregate
+        The aggregate must be $(RELATIVE_LINK2 foreach_restrictions, loop invariant),
+        meaning that elements cannot be added or removed from it
         in the *NoScopeNonEmptyStatement*.
 )
 

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1020,7 +1020,7 @@ a ~= 4;   // OK
 a = null; // OK
 --------------
 ---
-auto aa = [1:1,2:2];
+auto aa = [1: 1, 2: 2];
 
 foreach (v; aa)
 {


### PR DESCRIPTION
The *loop* must be invariant, not the aggregate.
Improve array example - use 'unspecified' rather than 'error' as it doesn't throw.
Add AA example.
Document resizing or reassigning dynamic/associative arrays is `@safe`.
