### PR TITLE
changelog/next_version.sh: Zero-pad three-digit version properly

### DIFF
--- a/changelog/next_version.sh
+++ b/changelog/next_version.sh
@@ -12,7 +12,7 @@ VERSION=${VERSION:1:7}
 # 2.076.1 -> (2 076 1)
 PARTS=(${VERSION//./ })
 # use 10#076 prefix to read octal as base10 int
-PARTS[1]=0$((10#${PARTS[1]} + 1))
+PARTS[1]=$(printf %03d $((10#${PARTS[1]} + 1)))
 PARTS[2]=0
 # 2 077 0 -> 2.077.0
 echo "${PARTS[0]}.${PARTS[1]}.${PARTS[2]}"


### PR DESCRIPTION
Fix the next version being calculated as "2.0100.0".