### PR TITLE
Disambiguate 'Mixins' everywhere

### DIFF
--- a/articles/index.dd
+++ b/articles/index.dd
@@ -104,7 +104,7 @@ $(D_S Articles,
                     in D.)
             )
             $(DIVC item,
-                $(H4 $(LINK2 $(ROOT_DIR)articles/mixin.html, Mixins))
+                $(H4 $(LINK2 $(ROOT_DIR)articles/mixin.html, String Mixins))
                 $(P A short article about D's $(D mixin) statement which allows
                     to insert arbitrary code from a string, and how it compares
                     to the C preprocessor.)

--- a/articles/mixin.dd
+++ b/articles/mixin.dd
@@ -91,5 +91,5 @@ END
 )
 
 Macros:
-        TITLE=Mixins
+        TITLE=String Mixins
         SUBNAV=$(SUBNAV_ARTICLES)

--- a/articles/mixin.dd
+++ b/articles/mixin.dd
@@ -1,8 +1,8 @@
 Ddoc
 
-$(D_S Mixins,
+$(D_S String Mixins,
 
-        $(P Mixins (not to be confused with
+        $(P String Mixins (not to be confused with
         $(DDLINK spec/template-mixin, Template Mixins, template mixins))
         enable string constants to be compiled as regular D code
         and inserted into the program.

--- a/articles/template-comparison.dd
+++ b/articles/template-comparison.dd
@@ -700,7 +700,7 @@ void foo(int t) { }
         $(TR
             $(TD Templates can be evaluated in scope
             of instantiation rather than definition)
-            $(TD Yes, $(LINK2 mixin.html, Mixins))
+            $(TD Yes, $(DDLINK spec/template-mixin, Template Mixins, Template Mixins))
             $(TD No, but can be faked using macros)
         )
 

--- a/comparison.dd
+++ b/comparison.dd
@@ -64,7 +64,7 @@ $(ITEMIZE
                 Template Template Parameters,
                 $(A articles/variadic-function-templates.html, Variadic Template Parameters),
                 $(A concepts.html, Template Constraints),
-                $(A spec/template-mixin.html, Mixins),
+                $(A spec/template-mixin.html, Template Mixins),
                 $(A spec/version.html#staticif, static if),
                 $(A spec/expression.html#IsExpression, expressions),
                 $(A spec/type.html#Typeof, typeof),

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -477,7 +477,7 @@ $(SUBNAV_TEMPLATE
         $(ROOT_DIR)articles/intro-to-datetime.html, Introduction to std.datetime,
         $(ROOT_DIR)articles/lazy-evaluation.html, Lazy Evaluation,
         $(ROOT_DIR)articles/migrate-to-shared.html, Migrating to Shared,
-        $(ROOT_DIR)articles/mixin.html, Mixins,
+        $(ROOT_DIR)articles/mixin.html, String Mixins,
         $(ROOT_DIR)articles/regular-expression.html, Regular Expressions,
         $(ROOT_DIR)articles/safed.html, SafeD,
         $(ROOT_DIR)articles/templates-revisited.html, Templates Revisited,


### PR DESCRIPTION
The term *mixin* should always be qualified, e.g. with *template* or *string*.
Fix `template-comparison.dd` link to *Template Mixins*, not string mixins.