### PR TITLE
[spec/declaration.dd] Grammar tweaks

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -4,6 +4,8 @@ $(SPEC_S Declarations,
 
 $(HEADERNAV_TOC)
 
+$(H2 $(LNAME2 grammar, Grammar))
+
 $(GRAMMAR
 $(GNAME Declaration):
     $(GLINK2 function, FuncDeclaration)
@@ -18,6 +20,11 @@ $(GNAME Declaration):
     $(GLINK2 version, StaticAssert)
 )
 
+$(P See also $(GLINK2 module, DeclDef).
+)
+
+$(H3 $(LNAME2 aggregates, Aggregates))
+
 $(GRAMMAR
 $(GNAME AggregateDeclaration):
     $(GLINK2 class, ClassDeclaration)
@@ -25,6 +32,8 @@ $(GNAME AggregateDeclaration):
     $(GLINK2 struct, StructDeclaration)
     $(GLINK2 struct, UnionDeclaration)
 )
+
+$(H3 $(LNAME2 variable-declarations, Variable Declarations))
 
 $(GRAMMAR
 $(GNAME VarDeclarations):
@@ -43,10 +52,7 @@ $(GNAME DeclaratorIdentifierList):
     $(GLINK DeclaratorIdentifier)
     $(GLINK DeclaratorIdentifier) $(D ,) $(GSELF DeclaratorIdentifierList)
 
-$(GNAME DeclaratorIdentifier):
-    $(GLINK VarDeclaratorIdentifier)
-
-$(GNAME VarDeclaratorIdentifier):
+$(GNAME DeclaratorIdentifier):$(LEGACY_LNAME2 VarDeclaratorIdentifier)
     $(GLINK_LEX Identifier)
     $(GLINK_LEX Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK Initializer)
 
@@ -56,6 +62,8 @@ $(GNAME Declarator):
 $(GNAME VarDeclarator):
     $(GLINK2 type, TypeSuffixes)$(OPT) $(GLINK_LEX Identifier)
 )
+
+$(H3 $(LNAME2 storage-classes, Storage Classes))
 
 $(GRAMMAR
 $(GNAME StorageClasses):
@@ -87,18 +95,17 @@ $(MULTICOLS 5,     $(GLINK2 attribute, LinkageAttribute)
     $(D ref))
 )
 
+$(H3 $(LNAME2 initializers, Initializers))
+
 $(GRAMMAR
 $(GNAME Initializer):
     $(GLINK VoidInitializer)
     $(GLINK NonVoidInitializer)
 
 $(GNAME NonVoidInitializer):
-    $(GLINK ExpInitializer)
+    $(GLINK2 expression, AssignExpression)$(LEGACY_LNAME2 ExpInitializer)
     $(GLINK ArrayInitializer)
     $(GLINK StructInitializer)
-
-$(GNAME ExpInitializer):
-    $(GLINK2 expression, AssignExpression)
 
 $(GNAME ArrayInitializer):
     $(D [) $(GLINK ArrayMemberInitializations)$(OPT) $(D ])


### PR DESCRIPTION
Add *Grammar* heading & subheadings. This helps break up a big block of grammar text for easier navigation.
Add link to *DeclDef* under *Declaration*.

Inline *VarDeclaratorIdentifier* and *ExpInitializer* as they are singletons and not referenced anywhere else. They don't appear in grammar.dd.