### PR TITLE
ddoc_preprocessor: Don't execute dmd twice

### DIFF
--- a/ddoc/source/preprocessor.d
+++ b/ddoc/source/preprocessor.d
@@ -85,7 +85,7 @@ auto compile(R)(R buffer, string[] arguments, string inputFile, string[string] m
 {
     import core.time : usecs;
     import core.thread : Thread;
-    import std.process : pipeProcess, Redirect, wait;
+    import std.process : execute;
     auto args = [config.dmdBinPath] ~ arguments;
 
     // Note: ideally we could pass in files directly on stdin.
@@ -110,8 +110,7 @@ auto compile(R)(R buffer, string[] arguments, string inputFile, string[string] m
         if (!args.canFind(arg))
             args ~= arg;
     }
-    auto pipes = pipeProcess(args, Redirect.stdin);
-    import std.process : execute;
+
     auto ret = execute(args);
     if (ret.status != 0)
     {


### PR DESCRIPTION
The first process was started by `pipeProcess` but never interacted with,not even calling `wait` before starting the next instance - with the exact same arguments!

Seems like this line wasn't deleted in dlang/dlang.org#2069 which introduced `execute` and removed the other code interacting with the piped process.