### PR TITLE
[spec/struct.dd] Improve struct initialization docs

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -120,7 +120,7 @@ $(GNAME Initializer):
 $(GNAME NonVoidInitializer):
     $(GLINK ExpInitializer)
     $(GLINK ArrayInitializer)
-    $(GLINK StructInitializer)
+    $(GLINK2 struct, StructInitializer)$(LEGACY_LNAME2 StructInitializer)
 
 $(GNAME ExpInitializer):
     $(GLINK2 expression, AssignExpression)
@@ -136,19 +136,6 @@ $(GNAME ArrayMemberInitializations):
 $(GNAME ArrayMemberInitialization):
     $(GLINK NonVoidInitializer)
     $(GLINK2 expression, AssignExpression) $(D :) $(GLINK NonVoidInitializer)
-
-$(GNAME StructInitializer):
-    $(D {) $(GLINK StructMemberInitializers)$(OPT) $(D })
-
-$(GNAME StructMemberInitializers):
-    $(GLINK StructMemberInitializer)
-    $(GLINK StructMemberInitializer) $(D ,)
-    $(GLINK StructMemberInitializer) $(D ,) $(GSELF StructMemberInitializers)
-
-$(GNAME StructMemberInitializer):
-    $(GLINK NonVoidInitializer)
-    $(GLINK_LEX Identifier) $(D :) $(GLINK NonVoidInitializer)
-)
 
 $(H2 $(LNAME2 declaration_syntax, Declaration Syntax))
 

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -136,6 +136,7 @@ $(GNAME ArrayMemberInitializations):
 $(GNAME ArrayMemberInitialization):
     $(GLINK NonVoidInitializer)
     $(GLINK2 expression, AssignExpression) $(D :) $(GLINK NonVoidInitializer)
+)
 
 $(H2 $(LNAME2 declaration_syntax, Declaration Syntax))
 

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -140,7 +140,9 @@ S* p;     // ok, knowledge of members is not necessary
         $(LINK2 https://en.wikipedia.org/wiki/Opaque_pointer, PIMPL idiom).)
 
 
-$(H2 $(LNAME2 default_struct_init, Default Initialization of Structs))
+$(H2 $(LNAME2 initialization, Initialization))
+
+$(H3 $(LNAME2 default_struct_init, Default Initialization of Structs))
 
         $(P Struct fields are by default initialized to whatever the
         $(GLINK2 declaration, Initializer) for the field is, and if none is supplied, to
@@ -158,10 +160,24 @@ $(H2 $(LNAME2 default_struct_init, Default Initialization of Structs))
 
         $(P The default initializers may not contain references to mutable data.)
 
-$(H2 $(LNAME2 static_struct_init, Static Initialization of Structs))
+$(H3 $(LNAME2 static_struct_init, Static Initialization of Structs))
 
-        $(P If a $(GLINK2 declaration, StructInitializer) is supplied, the
-        fields are initialized by the $(GLINK2 declaration, StructMemberInitializer) syntax.
+$(GRAMMAR
+$(GNAME StructInitializer):
+    $(D {) $(I StructMemberInitializers)$(OPT) $(D })
+
+$(GNAME StructMemberInitializers):
+    $(I StructMemberInitializer)
+    $(I StructMemberInitializer) $(D ,)
+    $(I StructMemberInitializer) $(D ,) $(GSELF StructMemberInitializers)
+
+$(GNAME StructMemberInitializer):
+    $(GLINK2 declaration, NonVoidInitializer)
+    $(GLINK_LEX Identifier) $(D :) $(GLINK2 declaration, NonVoidInitializer)
+)
+
+        $(P If a $(I StructInitializer) is supplied, the
+        fields are initialized by the $(I StructMemberInitializer) syntax.
         $(I StructMemberInitializers) with the $(I Identifier : NonVoidInitializer) syntax
         may be appear in any order, where $(I Identifier) is the field identifier.
         $(I StructMemberInitializer)s with the $(GLINK2 declaration, NonVoidInitializer) syntax
@@ -190,14 +206,12 @@ $(H2 $(LNAME2 static_struct_init, Static Initialization of Structs))
         ---
         )
 
-$(H2 $(LNAME2 default_union_init, Default Initialization of Unions))
+$(H3 $(LNAME2 default_union_init, Default Initialization of Unions))
 
         $(P Unions are by default initialized to whatever the
         $(GLINK2 declaration, Initializer) for the first field is, and if none is supplied, to
         the default initializer for the first field's type.
-        )
-
-        $(P If the union is larger than the first field, the remaining bits
+        If the union is larger than the first field, the remaining bits
         are set to 0.)
 
         $(SPEC_RUNNABLE_EXAMPLE_COMPILE
@@ -206,6 +220,8 @@ $(H2 $(LNAME2 default_union_init, Default Initialization of Unions))
         U x; // x.a is set to 4, x.b to an implementation-defined value
         ---
         )
+
+        $(P It is an error to supply initializers for members other than the first one.)
 
         $(SPEC_RUNNABLE_EXAMPLE_FAIL
         ---
@@ -219,10 +235,10 @@ $(H2 $(LNAME2 default_union_init, Default Initialization of Unions))
         $(IMPLEMENTATION_DEFINED The values the fields other than the
         default initialized field are set to.)
 
-$(H2 $(LNAME2 static_union_init, Static Initialization of Unions))
+$(H3 $(LNAME2 static_union_init, Static Initialization of Unions))
 
         $(P Unions are initialized similarly to structs, except that only
-        one initializer is allowed.)
+        one member initializer is allowed.)
 
         $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ---
@@ -244,7 +260,7 @@ $(H2 $(LNAME2 static_union_init, Static Initialization of Unions))
         $(IMPLEMENTATION_DEFINED The values the fields other than the
         initialized field are set to.)
 
-$(H2 $(LNAME2 dynamic_struct_init, Dynamic Initialization of Structs))
+$(H3 $(LNAME2 dynamic_struct_init, Dynamic Initialization of Structs))
 
         $(P The $(RELATIVE_LINK2 static_struct_init, static initializer syntax)
         can also be used to initialize non-static variables.
@@ -273,7 +289,7 @@ S s = t;  // s.a is set to 3
 ----
 )
 
-        $(P If the struct has a $(LINK2 #struct-constructor, constructor), and
+        $(P If the struct has a $(RELATIVE_LINK2 struct-constructor, constructor), and
         the struct is initialized with a value that is of a different type,
         then the constructor is called:)
 
@@ -293,7 +309,8 @@ S s = 3; // sets s.a to 3 using S's constructor
 ----
 )
 
-        $(P If the struct does not have a constructor but $(D opCall) is
+        $(P If the struct does not have a constructor but
+        $(DDSUBLINK spec/operatoroverloading, FunctionCall, `opCall`) is
         overridden for the struct, and the struct is initialized with a value
         that is of a different type, then the $(D opCall) operator is called:)
 


### PR DESCRIPTION
Move `StructInitializer` grammar to struct.dd from declaration.dd. It's not a declaration and the docs for it are in struct.dd.
Add *Initialization* heading and reparent 5 headings.
Minor tweaks.