### PR TITLE
spec: Remove mentions of custom allocators and deallocators

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -12,7 +12,7 @@ $(SPEC_S Deprecated Features,
         $(THEAD Feature,                                                          Spec,  Dep,    Error,  Gone)
         $(TROW $(DEPLINK body keyword),                                           2.075, &nbsp;, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Hexstring literals),                                     2.079, 2.079, 2.086, &nbsp;)
-        $(TROW $(DEPLINK Class allocators and deallocators),                      &nbsp;, 2.080, 2.087, &nbsp;)
+        $(TROW $(DEPLINK Class allocators and deallocators),                      &nbsp;, 2.080, 2.087, 2.100 )
         $(TROW $(DEPLINK Implicit comparison of different enums),                 2.075,  2.075, 2.081, &nbsp;)
         $(TROW $(DEPLINK Implicit string concatenation),                          2.072,  2.072, 2.081, &nbsp;)
         $(TROW $(DEPLINK Using the result of a comma expression),                 2.072,  2.072,  2.079, &nbsp;)

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -68,7 +68,6 @@ $(UL
             $(LI $(GLINK SharedStaticDestructor)s)
             $(LI $(RELATIVE_LINK2 invariants, Class Invariants))
             $(LI $(DDSUBLINK spec/unittest, unittest, Unit Tests))
-            $(LI $(RELATIVE_LINK2 allocators, Class Allocators))
             $(LI $(RELATIVE_LINK2 alias-this, Alias This))
         )
         )
@@ -1006,74 +1005,6 @@ $(GNAME Invariant):
     )
 
 
-$(H2 $(LNAME2 allocators, Class Allocators))
-$(B Note): Class allocators are deprecated in D2.
-$(GRAMMAR
-$(GNAME Allocator):
-    $(D new) $(GLINK2 function, Parameters) $(GLINK2 function, FunctionBody)
-)
-
-$(P A class member function of the form:)
-
-------
-new(size_t size)
-{
-    ...
-}
-------
-
-        is called a class allocator.
-        The class allocator can have any number of parameters, provided
-        the first one is of type `size_t`.
-        Any number can be defined for a class, the correct one is
-        determined by the usual function overloading rules.
-        When a new expression:
-
-------
-new Foo;
-------
-
-        is executed, and Foo is a class that has
-        an allocator, the allocator is called with the first argument
-        set to the size in bytes of the memory to be allocated for the
-        instance.
-        The allocator must allocate the memory and return it as a
-        $(D void*).
-        If the allocator fails, it must not return a $(D null), but
-        must throw an exception.
-        If there is more than one parameter to the allocator, the
-        additional arguments are specified within parentheses after
-        the $(D new) in the $(I NewExpression):
-
-------
-class Foo
-{
-    this(string a) { ... }
-
-    new(size_t size, int x, int y)
-    {
-        ...
-    }
-}
-
-...
-
-new(1,2) Foo(a);        // calls new(Foo.sizeof,1,2)
-------
-
-        $(P Derived classes inherit any allocator from their base class,
-        if one is not specified.
-        )
-
-        $(P The class allocator is not called if the instance is created
-        on the stack.
-        )
-
-        $(P See also
-        $(LINK2 https://wiki.dlang.org/Memory_Management#Explicit_Class_Instance_Allocation,
-        Explicit Class Instance Allocation).
-        )
-
 $(H2 $(LEGACY_LNAME2 AliasThis, alias-this, Alias This))
 
 $(GRAMMAR
@@ -1479,7 +1410,7 @@ $(H3 $(LNAME2 anonymous, Anonymous Nested Classes))
 
 $(GRAMMAR
 $(GNAME NewAnonClassExpression):
-    $(D new) $(GLINK2 expression, AllocatorArguments)$(OPT) $(D class) $(GLINK ConstructorArgs)$(OPT) $(GLINK SuperClassOrInterface)$(OPT) $(GLINK Interfaces)$(OPT) $(GLINK2 struct, AggregateBody)
+    $(D new) $(D class) $(GLINK ConstructorArgs)$(OPT) $(GLINK SuperClassOrInterface)$(OPT) $(GLINK Interfaces)$(OPT) $(GLINK2 struct, AggregateBody)
 
 $(GNAME ConstructorArgs):
     $(D $(LPAREN)) $(GLINK2 expression, ArgumentList)$(OPT) $(D $(RPAREN))
@@ -1490,7 +1421,7 @@ which is equivalent to:
 $(GRAMMAR_INFORMATIVE
 $(D class) $(GLINK_LEX Identifier) $(D :) $(I SuperClassOrInterface) $(I Interfaces) $(I AggregateBody)
 // ...
-$(D new) $(I AllocatorArguments) $(I Identifier) $(I ConstructorArgs)
+$(D new) $(I Identifier) $(I ConstructorArgs)
 )
 
 where $(I Identifier) is the name generated for the anonymous nested class.

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -973,13 +973,10 @@ $(H3 $(LNAME2 new_expressions, New Expressions))
 
 $(GRAMMAR
 $(GNAME NewExpression):
-    $(D new) $(GLINK AllocatorArguments)$(OPT) $(GLINK2 type, Type)
-    $(D new) $(GLINK AllocatorArguments)$(OPT) $(GLINK2 type, Type) $(D [) $(GLINK AssignExpression) $(D ])
-    $(D new) $(GLINK AllocatorArguments)$(OPT) $(GLINK2 type, Type) $(D $(LPAREN)) $(GLINK ArgumentList)$(OPT) $(D $(RPAREN))
+    $(D new) $(GLINK2 type, Type)
+    $(D new) $(GLINK2 type, Type) $(D [) $(GLINK AssignExpression) $(D ])
+    $(D new) $(GLINK2 type, Type) $(D $(LPAREN)) $(GLINK ArgumentList)$(OPT) $(D $(RPAREN))
     $(GLINK2 class, NewAnonClassExpression)
-
-$(GNAME AllocatorArguments):
-    $(D $(LPAREN)) $(GLINK ArgumentList)$(OPT) $(D $(RPAREN))
 
 $(GNAME ArgumentList):
     $(GLINK AssignExpression)
@@ -988,19 +985,12 @@ $(GNAME ArgumentList):
 )
 
     $(P $(I NewExpression)s are used to allocate memory on the garbage
-        collected heap (default) or using a class or struct specific allocator.
-    )
-
-    $(DDOC_DEPRECATED If $(I AllocatorArguments) is provided, then
-        the $(I ArgumentList) is passed to the class or struct specific
-        $(DDSUBLINK spec/class, allocators, allocator function) after the size argument.
+        collected heap.
     )
 
     $(P If a $(I NewExpression) is used as an initializer for
         a function local variable with $(D scope) storage class,
-        and the $(I ArgumentList) to $(D new) is empty, then
-        the instance is allocated on the stack rather than the heap
-        or using the class specific allocator.
+        then the instance is allocated on the stack.
     )
 
 $(H3 $(LNAME2 new_multidimensional, Multidimensional Arrays))
@@ -1079,8 +1069,7 @@ $(GNAME DeleteExpression):
 
     $(P If $(I UnaryExpression) is a variable allocated
         on the stack, the class destructor (if any) is called for that
-        instance. Neither the garbage collector nor any class deallocator
-        is called.
+        instance. The garbage collector is not called.
     )
 
     $(UNDEFINED_BEHAVIOR

--- a/spec/module.dd
+++ b/spec/module.dd
@@ -20,8 +20,6 @@ $(GNAME DeclDef):
     $(GLINK2 class, Constructor)
     $(GLINK2 class, Destructor)
     $(GLINK2 struct, Postblit)
-    $(GLINK2 class, Allocator)
-    $(GLINK2 class, Deallocator)
     $(GLINK2 class, Invariant)
     $(GLINK2 unittest, UnitTest)
     $(GLINK2 class, AliasThis)


### PR DESCRIPTION
However... this is only half the story, as class allocators still live on in the form of `@disable new();` only.  This is not mentioned anywhere in the spec and should be added as well.