### PR TITLE
assert_writeln_magic: Report filename on error (instead of `magic.d`)

### DIFF
--- a/ddoc/source/preprocessor.d
+++ b/ddoc/source/preprocessor.d
@@ -66,7 +66,7 @@ All unknown options are passed to the compiler.
 
     // Phobos index.d should have been named index.dd
     if (inputFile.endsWith(".d") && !inputFile.endsWith("index.d"))
-        text = assertWritelnModule(text);
+        text = assertWritelnModule(inputFile, text);
 
     string[string] macros;
     macros["SRC_FILENAME"] = "%s\n".format(inputFile.buildNormalizedPath);

--- a/ddoc/source/preprocessor.d
+++ b/ddoc/source/preprocessor.d
@@ -114,10 +114,13 @@ auto compile(R)(R buffer, string[] arguments, string inputFile, string[string] m
     auto ret = execute(args);
     if (ret.status != 0)
     {
-        stderr.writeln("File content:");
-        stderr.writeln(buffer);
-        stderr.writeln("----------------------------------------");
-        stderr.writeln(ret.output);
+        stderr.writeln(
+            "\n------------- File content -------------\n",
+            buffer,
+            "\n------------ Compiler output -----------\n",
+            ret.output,
+            "\n----------------------------------------\n",
+        );
     }
     return ret.status;
 }

--- a/dpl-docs/source/ddox_main.d
+++ b/dpl-docs/source/ddox_main.d
@@ -129,7 +129,7 @@ int cmdFilterDocs(string[] args)
 						writefln("Warning: Cannot add documented unit test %s to %s, which is not documented.", name, last_decl["name"].opt!string);
 					} else {
 					    import assert_writeln_magic;
-                        auto rewrittenSource = assertWritelnBlock(source);
+                        auto rewrittenSource = assertWritelnBlock(mod["file"].get!string(), source);
                         last_decl["comment"] ~= format("Example:\n%s$(DDOX_UNITTEST_HEADER %s)\n---\n%s\n---\n$(DDOX_UNITTEST_FOOTER %s)\n", comment.strip, name, rewrittenSource, name);
 					}
 				} catch (Exception e) {


### PR DESCRIPTION
Pass the current file path to libdparse s.t. error messages point to the
actual file instead of `magic.d`.