### PR TITLE
Fix broken DDSUBLINKs & code_coverage DDLINK

### DIFF
--- a/articles/ctarguments.dd
+++ b/articles/ctarguments.dd
@@ -146,7 +146,7 @@ string
 void()
 )
 
-        $(P $(B Note:) $(DDSUBLINK version, staticforeach, Static foreach)
+        $(P $(B Note:) $(DDSUBLINK spec/version, staticforeach, Static foreach)
         should be preferred in new code.)
 
 $(H2 $(LNAME2 auto-expansion, Auto-expansion))

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -81,7 +81,7 @@ assert(i == 4);
         )
 
         $(BEST_PRACTICE Most conventional uses for pointers can be replaced with
-        dynamic arrays, $(D ref) and $(D out) $(DDSUBLINK function, parameters, parameters),
+        dynamic arrays, $(D ref) and $(D out) $(DDSUBLINK spec/function, parameters, parameters),
         and reference types.
         )
 
@@ -162,7 +162,7 @@ int[2] = [1, 2];
 ---
     $(P `[]` is an empty array literal.)
 
-    $(P See $(DDSUBLINK expression, array_literals, Array Literals).)
+    $(P See $(DDSUBLINK spec/expression, array_literals, Array Literals).)
 
 $(LEGACY_LNAME2 usage)
 $(H2 $(LNAME2 assignment, Array Assignment))
@@ -735,7 +735,7 @@ assert(cap == array.capacity);
 
 $(H3 $(LNAME2 func-as-property, Functions as Array Properties))
 
-        $(P See $(DDSUBLINK function, pseudo-member, Uniform Function Call Syntax (UFCS)).)
+        $(P See $(DDSUBLINK spec/function, pseudo-member, Uniform Function Call Syntax (UFCS)).)
 
 $(H2 $(LNAME2 bounds, Array Bounds Checking))
 
@@ -798,7 +798,7 @@ int x = foo[3]; // error, out of bounds
             The runtime behavior is part of the language semantics.
         )
 
-        $(P See also $(DDSUBLINK function, safe-functions, Safe Functions).)
+        $(P See also $(DDSUBLINK spec/function, safe-functions, Safe Functions).)
 
 $(H3 $(LNAME2 disable-bounds-check, Disabling Array Bounds Checking))
 

--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -521,11 +521,11 @@ void main() { foo(); /* error, foo is disabled */ }
 
 $(H2 $(LNAME2 safe, $(D @safe), $(D @trusted), and $(D @system) Attribute))
 
-    $(P See $(DDSUBLINK function, function-safety, Function Safety).)
+    $(P See $(DDSUBLINK spec/function, function-safety, Function Safety).)
 
 $(H2 $(LNAME2 nogc, $(D @nogc) Attribute))
 
-    $(P See $(DDSUBLINK function, nogc-functions, No-GC Functions).)
+    $(P See $(DDSUBLINK spec/function, nogc-functions, No-GC Functions).)
 
 $(H2 $(LNAME2 property, $(D @property) Attribute))
 
@@ -606,7 +606,7 @@ auto i = 6.8;   // declare i as a double
 ---
 
     $(P For functions, the `auto` attribute means return type inference.
-        See $(DDSUBLINK function, auto-functions, Auto Functions).
+        See $(DDSUBLINK spec/function, auto-functions, Auto Functions).
     )
 
 $(H2 $(LNAME2 scope, $(D scope) Attribute))

--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -34,7 +34,7 @@ $(H2 $(LNAME2 pre_post_contracts, Pre and Post Contracts))
 
 $(H2 $(LNAME2 Invariants, Invariants))
 
-        $(P See $(DDSUBLINK struct, Invariant, Struct Invariants) and $(DDSUBLINK class, invariants, Class Invariants).)
+        $(P See $(DDSUBLINK spec/struct, Invariant, Struct Invariants) and $(DDSUBLINK spec/class, invariants, Class Invariants).)
 
 
 $(H2 $(LNAME2 references, References))

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -945,7 +945,7 @@ $(GNAME UnaryExpression):
 
 $(TABLE
     $(THEAD Operator, Description)
-    $(TROW `&`, Take memory address of an $(RELATIVE_LINK2 .define-lvalue, lvalue) - see $(DDSUBLINK arrays, pointers, pointers))
+    $(TROW `&`, Take memory address of an $(RELATIVE_LINK2 .define-lvalue, lvalue) - see $(DDSUBLINK spec/arrays, pointers, pointers))
     $(TROW `++`, Increment before use - see $(RELATIVE_LINK2 order-of-evaluation, order of evaluation))
     $(TROW `--`, Decrement before use)
     $(TROW `*`, Dereference/indirection - typically for pointers)

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -987,7 +987,7 @@ void test()
         $(UL
         $(LI Struct and union member functions)
         $(LI `final` member functions)
-        $(LI $(DDSUBLINK attribute, static, `static`) member functions)
+        $(LI $(DDSUBLINK spec/attribute, static, `static`) member functions)
         $(LI Member functions which are $(D private) or $(D package))
         $(LI Member template functions)
         )
@@ -3051,7 +3051,7 @@ void main()
     $(LI Expressions may not reference any global or local
         static variables.)
 
-    $(LI $(DDSUBLINK iasm, asmstatements, AsmStatements) are not permitted)
+    $(LI $(DDSUBLINK spec/iasm, asmstatements, AsmStatements) are not permitted)
 
     $(LI Non-portable casts (eg, from $(D int[]) to $(D float[])), including
         casts which depend on endianness, are not permitted.
@@ -3185,14 +3185,14 @@ $(H2 $(LNAME2 nogc-functions, No-GC Functions))
         )
 
         $(OL
-        $(LI $(DDSUBLINK expression, ArrayLiteral, constructing an array) on the heap)
+        $(LI $(DDSUBLINK spec/expression, ArrayLiteral, constructing an array) on the heap)
         $(LI resizing an array by writing to its $(D .length) property)
-        $(LI $(DDSUBLINK expression, CatExpression, array concatenation))
-        $(LI $(DDSUBLINK expression, simple_assignment_expressions, array appending))
-        $(LI $(DDSUBLINK expression, AssocArrayLiteral, constructing an associative array))
-        $(LI $(DDSUBLINK expression, IndexExpression, indexing) an associative array
+        $(LI $(DDSUBLINK spec/expression, CatExpression, array concatenation))
+        $(LI $(DDSUBLINK spec/expression, simple_assignment_expressions, array appending))
+        $(LI $(DDSUBLINK spec/expression, AssocArrayLiteral, constructing an associative array))
+        $(LI $(DDSUBLINK spec/expression, IndexExpression, indexing) an associative array
             $(NOTE because it may throw $(D RangeError) if the specified key is not present))
-        $(LI $(DDSUBLINK expression, NewExpression, allocating an object with `new`) on the heap)
+        $(LI $(DDSUBLINK spec/expression, NewExpression, allocating an object with `new`) on the heap)
         $(LI calling functions that are not `@nogc`, unless the call is
             in a $(GLINK2 version, ConditionalStatement)
             controlled by a $(GLINK2 version, DebugCondition))

--- a/spec/hash-map.dd
+++ b/spec/hash-map.dd
@@ -40,7 +40,7 @@ static assert(is(typeof(aa) == string[uint]));
 assert(aa[2] == "hi");
 ---
 )
-    $(P See $(DDSUBLINK expression, associative_array_literals, Associative Array Literals).)
+    $(P See $(DDSUBLINK spec/expression, associative_array_literals, Associative Array Literals).)
 
 $(H2 $(LNAME2 removing_keys, Removing Keys))
 

--- a/spec/simd.dd
+++ b/spec/simd.dd
@@ -11,7 +11,7 @@ $(HEADERNAV_TOC)
 
         $(P Specialized $(GLINK2 type, Vector) types provide access to them.)
 
-        $(P The $(GLINK2 type, VectorBaseType) must be a $(DDSUBLINK arrays, static-arrays, Static Array).
+        $(P The $(GLINK2 type, VectorBaseType) must be a $(DDSUBLINK spec/arrays, static-arrays, Static Array).
         The $(GNAME VectorElementType) is the unqualified element type of the
         static array.
         The dimension of the static array is the number

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -1218,7 +1218,7 @@ $(H3 $(LNAME2 return-deduction, Return Type Deduction))
     $(P Function templates can have their return types deduced based on the
         $(GLINK2 statement, ReturnStatement)s in the function, just as with
         normal functions.
-        See $(DDSUBLINK function, auto-functions, Auto Functions).
+        See $(DDSUBLINK spec/function, auto-functions, Auto Functions).
     )
 
     $(SPEC_RUNNABLE_EXAMPLE_COMPILE

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -1695,7 +1695,7 @@ void main()
 $(H2 $(GNAME toType))
 
         $(P Takes a single argument, which must evaluate to an expression of type `string`.
-        The contents of the string must correspond to the $(DDSUBLINK abi, name_mangling, mangled contents of a type)
+        The contents of the string must correspond to the $(DDSUBLINK spec/abi, name_mangling, mangled contents of a type)
         that has been seen by the implementation.)
 
         $(P Only D mangling is supported. Other manglings, such as C++ mangling, are not.)
@@ -1712,7 +1712,7 @@ $(H2 $(GNAME toType))
         __traits(toType, "i") x = 4; // x is also declared as type `int`
         ---
 
-        $(RATIONALE Provides the inverse operation of the $(DDSUBLINK property, mangleof, `.mangleof`) property.)
+        $(RATIONALE Provides the inverse operation of the $(DDSUBLINK spec/property, mangleof, `.mangleof`) property.)
 
 $(H2 $(GNAME initSymbol))
 

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -134,9 +134,9 @@ $(H2 $(LEGACY_LNAME2 Basic Data Types, basic-data-types, Basic Data Types))
 $(H2 $(LEGACY_LNAME2 Derived Data Types, derived-data-types, Derived Data Types))
 
     $(UL
-    $(LI $(DDSUBLINK arrays, pointers, Pointer))
-    $(LI $(DDSUBLINK arrays, static-arrays, Static Array))
-    $(LI $(DDSUBLINK arrays, dynamic-arrays, Dynamic Array))
+    $(LI $(DDSUBLINK spec/arrays, pointers, Pointer))
+    $(LI $(DDSUBLINK spec/arrays, static-arrays, Static Array))
+    $(LI $(DDSUBLINK spec/arrays, dynamic-arrays, Dynamic Array))
     $(LI $(DDLINK spec/hash-map, Associative Array, Associative Array))
     $(LI $(DDLINK spec/function, Functions, Functions))
     $(LI $(RELATIVE_LINK2 delegates, Delegates))

--- a/spec/version.dd
+++ b/spec/version.dd
@@ -325,7 +325,7 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
                 command line switch $(DDSUBLINK dmd, switch-betterC, $(TT -betterC))))
         $(TROW $(ARGS $(D D_TypeInfo)) , $(ARGS Runtime type information (a.k.a `TypeInfo`) is supported.  Evaluates to `false` when compiling with
                 command line switch $(DDSUBLINK dmd, switch-betterC, $(TT -betterC))))
-        $(TROW $(ARGS $(D D_Coverage)) , $(ARGS $(DDLINK code_coverage, Code coverage analysis, Code coverage analysis) instrumentation
+        $(TROW $(ARGS $(D D_Coverage)) , $(ARGS $(DDLINK articles/code_coverage, Code coverage analysis, Code coverage analysis) instrumentation
                 (command line switch $(DDSUBLINK dmd, switch-cov, $(TT -cov))) is being generated))
         $(TROW $(ARGS $(D D_Ddoc)) , $(ARGS $(DDLINK spec/ddoc, Embedded Documentation, Ddoc) documentation
                 (command line switch $(DDSUBLINK dmd, switch-D, $(TT -D))) is being generated))


### PR DESCRIPTION
It's easy to forget the subdirectory prefix with these macros.

It would be great if the test suite could check that the number of broken links doesn't increase for each pull request.