### PR TITLE
[spec] Improve concatenation docs

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -409,19 +409,18 @@ $(H2 $(LNAME2 array-concatenation, Array Concatenation))
         to concatenate arrays:
         )
 
-$(SPEC_RUNNABLE_EXAMPLE_COMPILE
----------
-int[] a;
-int[] b;
-int[] c;
+$(SPEC_RUNNABLE_EXAMPLE_RUN
+---
+int[] a = [1, 2];
+assert(a ~ 3 == [1, 2, 3]); // concatenate array with a single value
 
-a = b ~ c; // Create an array from the concatenation
-           // of the b and c arrays
----------
+int[] b = a ~ [3, 4];
+assert(b == [1, 2, 3, 4]); // concatenate two arrays
+---
 )
 
-        $(P Many languages overload the + operator to mean concatenation.
-        This confusingly leads to, does:
+        $(P Many languages overload the + operator for concatenation.
+        This confusingly leads to a dilemma - does:
         )
 
 ---------
@@ -436,20 +435,31 @@ a = b ~ c; // Create an array from the concatenation
         concatenation.
         )
 
+        $(P Concatenation always creates a copy of its operands, even
+        if one of the operands is a 0 length array, so:
+        )
+
+$(SPEC_RUNNABLE_EXAMPLE_RUN
+---------
+auto b = [7];
+auto a = b;      // a refers to b
+assert(a is b);
+
+a = b ~ []; // a refers to a copy of b
+assert(a !is b);
+assert(a == b);
+---------
+)
+
+        $(P See also: $(DDSUBLINK spec/expression, identity_expressions, `is` operator).)
+
+$(H2 $(LNAME2 array-appending, Array Appending))
+
         $(P Similarly, the ~= operator means append, as in:
         )
 
 ---------
 a ~= b; // a becomes the concatenation of a and b
----------
-
-        $(P Concatenation always creates a copy of its operands, even
-        if one of the operands is a 0 length array, so:
-        )
-
----------
-a = b;           // a refers to b
-a = b ~ c[0..0]; // a refers to a copy of b
 ---------
 
         $(P Appending does not always create a copy, see $(RELATIVE_LINK2 resize,

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -864,13 +864,12 @@ $(GNAME CatExpression):
     $(GLINK AddExpression) $(D ~) $(GLINK MulExpression)
 )
 
-    $(P A $(I CatExpression) concatenates arrays, producing
-        a dynamic array with the result. The arrays must be
-        arrays of the same element type. If one operand is an array
-        and the other is of that array's element type, that element
-        is converted to an array of length 1 of that element,
-        and then the concatenation is performed.
-    )
+    $(P A $(I CatExpression) concatenates a container's data with other data, producing
+        a new container.)
+
+    $(P For a dynamic array, the other operand must either be another array or a
+        single value that implicitly converts to the element type of the array.
+        See $(DDSUBLINK spec/arrays, array-concatenation, Array Concatenation).)
 
 $(H2 $(LNAME2 mul_expressions, Mul Expressions))
 


### PR DESCRIPTION
Split out from #3157.

Improve array concatenation example.
Add heading for *Array Appending*, separate relevant paragraphs.

Make *CatExpression* discuss a container, not just an array.
Mention concatenating a single value.