### PR TITLE
Tweak POD struct docs

### DIFF
--- a/glossary.dd
+++ b/glossary.dd
@@ -184,9 +184,9 @@ void test()
 
         $(DT $(LNAME2 pod, $(ACRONYM POD, Plain Old Data)))
         $(DD Refers to a struct that contains no hidden members,
-        does not have virtual functions, does not inherit,
         has no destructor,
         and can be initialized and copied via simple bit copies.
+        See $(DDSUBLINK spec/struct, POD, Structs).
         )
 
         $(DT $(LNAME2 predicate, Predicate)) $(DD A function or

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -102,7 +102,7 @@ $(H2 $(LNAME2 POD, Plain Old Data))
     $(OL
     $(LI it is not nested)
     $(LI it has no postblits, copy constructors, destructors, or assignment operators)
-    $(LI it has no `ref` fields or fields that are themselves non-POD)
+    $(LI it has no fields that are themselves non-POD)
     )
 
     $(BEST_PRACTICE Structs or unions that interface with C code should be POD.)


### PR DESCRIPTION
A struct cannot have virtual functions or inheritance.
There are no `ref` fields - I'm not sure what @WalterBright [meant by this](https://github.com/dlang/dlang.org/pull/2143/files#r816978003).