### PR TITLE
spec/template.dd: correct misleading IFTI example

### DIFF
--- a/spec/template.dd
+++ b/spec/template.dd
@@ -1209,14 +1209,14 @@ $(H3 $(LNAME2 ifti, Implicit Function Template Instantiation (IFTI)))
 $(H4 $(LNAME2 ifti-restrictions, Restrictions))
 
     $(P Function template type parameters that are to be implicitly
-        deduced may not have specializations:)
+        deduced must appear in the type of at least one function parameter:)
 
         ------
-        void $(CODE_HIGHLIGHT foo)(T : T*)(T t) { ... }
+        void foo(T : U*, U)(U t) { ... }
 
-        int x,y;
-        foo!(int*)(x);   // ok, T is not deduced from function argument
-        foo(&y);         // error, T has specialization
+        int x;
+        foo!(int*)(x);   // ok, U is deduced and T is specified explicitly
+        foo(x);         // error, only U can be deduced, not T
         ------
 
         $(P When the template parameters must be deduced, the


### PR DESCRIPTION
Contrary to what was previously stated in the text, the example did not
fail because the template parameter T was specialized. Instead, it
failed because the T used in the template parameter list referred to a
different type than the T used in the function parameter list, and the
former could not be deduced from the latter.

To make the example clearer, the second T has been changed to U, and the
text has been updated accordingly.