### PR TITLE
spec/lex: Permit DoubleQuotedCharacters in Filespec

### DIFF
--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -1127,7 +1127,7 @@ $(GNAME SpecialTokenSequence):
 )
 $(GRAMMAR_LEX
 $(GNAME Filespec):
-    $(B ") $(GLINK Characters)$(OPT) $(B ")
+    $(B ") $(GLINK DoubleQuotedCharacters)$(OPT) $(B ")
 )
 
         $(P Special token sequences are processed by the lexical analyzer, may
@@ -1145,10 +1145,6 @@ $(GNAME Filespec):
         $(P This sets the current source line number to $(GLINK IntegerLiteral),
         and optionally the current source file name to $(GLINK Filespec),
         beginning with the next line of source text.
-        )
-
-        $(P The backslash character is not treated specially inside
-        $(GLINK Filespec) strings.
         )
 
         $(P For example:


### PR DESCRIPTION
Follow-up for [13728](https://github.com/dlang/dmd/pull/13728), Filespec is not equal to C `#line`, and inconsistent with double-quoted strings in the rest of the D language grammar.