### PR TITLE
spec/iasm.dd: Move GCC syntax to the bottom of the page

### DIFF
--- a/spec/iasm.dd
+++ b/spec/iasm.dd
@@ -1242,50 +1242,6 @@ $(H3 $(LNAME2 simd, SIMD))
 
     $(P SSE, SSE2, SSE3, SSSE3, SSE4.1, SSE4.2 and AVX are supported.)
 
-$(H2 $(LNAME2 gcc, GCC syntax))
-
-$(P The $(LINK2 https://gdcproject.org/, GNU D Compiler) uses an alternative, GCC-based syntax for inline assembler:)
-
-$(GRAMMAR
-$(GNAME GccAsmStatement):
-    $(D asm) $(GLINK2 function, FunctionAttributes)$(OPT) $(D {) $(GLINK GccAsmInstructionList) $(D })
-
-$(GNAME GccAsmInstructionList):
-    $(GLINK GccAsmInstruction) $(D ;)
-    $(GLINK GccAsmInstruction) $(D ;) $(GSELF GccAsmInstructionList)
-
-$(GNAME GccAsmInstruction):
-    $(GLINK GccBasicAsmInstruction)
-    $(GLINK GccExtAsmInstruction)
-    $(GLINK GccGotoAsmInstruction)
-
-$(GNAME GccBasicAsmInstruction):
-    $(GLINK2 expression, AssignExpression)
-
-$(GNAME GccExtAsmInstruction):
-    $(GLINK2 expression, AssignExpression) $(D :) $(GLINK GccAsmOperands)$(OPT)
-    $(GLINK2 expression, AssignExpression) $(D :) $(GLINK GccAsmOperands)$(OPT) $(D :) $(GLINK GccAsmOperands)$(OPT)
-    $(GLINK2 expression, AssignExpression) $(D :) $(GLINK GccAsmOperands)$(OPT) $(D :) $(GLINK GccAsmOperands)$(OPT) $(D :) $(GLINK GccAsmClobbers)$(OPT)
-
-$(GNAME GccGotoAsmInstruction):
-    $(GLINK2 expression, AssignExpression) $(D :) $(D :) $(GLINK GccAsmOperands)$(OPT) $(D :) $(GLINK GccAsmClobbers)$(OPT) $(D :) $(GLINK GccAsmGotoLabels)$(OPT)
-
-$(GNAME GccAsmOperands):
-    $(GLINK GccSymbolicName)$(OPT) $(GLINK_LEX StringLiteral) $(D $(LPAREN)) $(GLINK2 expression, AssignExpression) $(D $(RPAREN))
-    $(GLINK GccSymbolicName)$(OPT) $(GLINK_LEX StringLiteral) $(D $(LPAREN)) $(GLINK2 expression, AssignExpression) $(D $(RPAREN)) $(D ,) $(GSELF GccAsmOperands)
-
-$(GNAME GccSymbolicName):
-    $(D [) $(GLINK_LEX Identifier) $(D ])
-
-$(GNAME GccAsmClobbers):
-    $(GLINK_LEX StringLiteral)
-    $(GLINK_LEX StringLiteral) $(D ,) $(GSELF GccAsmClobbers)
-
-$(GNAME GccAsmGotoLabels):
-    $(GLINK_LEX Identifier)
-    $(GLINK_LEX Identifier) $(D ,) $(GSELF GccAsmGotoLabels)
-)
-
 $(COMMENT
 $(H3 $(LNAME2 other, Other))
     $(P AES, CMUL, FSGSBASE, RDRAND, FP16C and FMA are supported.)
@@ -1372,6 +1328,50 @@ vmxon
 SMX
 
 getsec
+)
+
+$(H2 $(LNAME2 gcc, GCC syntax))
+
+$(P The $(LINK2 https://gdcproject.org/, GNU D Compiler) uses an alternative, GCC-based syntax for inline assembler:)
+
+$(GRAMMAR
+$(GNAME GccAsmStatement):
+    $(D asm) $(GLINK2 function, FunctionAttributes)$(OPT) $(D {) $(GLINK GccAsmInstructionList) $(D })
+
+$(GNAME GccAsmInstructionList):
+    $(GLINK GccAsmInstruction) $(D ;)
+    $(GLINK GccAsmInstruction) $(D ;) $(GSELF GccAsmInstructionList)
+
+$(GNAME GccAsmInstruction):
+    $(GLINK GccBasicAsmInstruction)
+    $(GLINK GccExtAsmInstruction)
+    $(GLINK GccGotoAsmInstruction)
+
+$(GNAME GccBasicAsmInstruction):
+    $(GLINK2 expression, AssignExpression)
+
+$(GNAME GccExtAsmInstruction):
+    $(GLINK2 expression, AssignExpression) $(D :) $(GLINK GccAsmOperands)$(OPT)
+    $(GLINK2 expression, AssignExpression) $(D :) $(GLINK GccAsmOperands)$(OPT) $(D :) $(GLINK GccAsmOperands)$(OPT)
+    $(GLINK2 expression, AssignExpression) $(D :) $(GLINK GccAsmOperands)$(OPT) $(D :) $(GLINK GccAsmOperands)$(OPT) $(D :) $(GLINK GccAsmClobbers)$(OPT)
+
+$(GNAME GccGotoAsmInstruction):
+    $(GLINK2 expression, AssignExpression) $(D :) $(D :) $(GLINK GccAsmOperands)$(OPT) $(D :) $(GLINK GccAsmClobbers)$(OPT) $(D :) $(GLINK GccAsmGotoLabels)$(OPT)
+
+$(GNAME GccAsmOperands):
+    $(GLINK GccSymbolicName)$(OPT) $(GLINK_LEX StringLiteral) $(D $(LPAREN)) $(GLINK2 expression, AssignExpression) $(D $(RPAREN))
+    $(GLINK GccSymbolicName)$(OPT) $(GLINK_LEX StringLiteral) $(D $(LPAREN)) $(GLINK2 expression, AssignExpression) $(D $(RPAREN)) $(D ,) $(GSELF GccAsmOperands)
+
+$(GNAME GccSymbolicName):
+    $(D [) $(GLINK_LEX Identifier) $(D ])
+
+$(GNAME GccAsmClobbers):
+    $(GLINK_LEX StringLiteral)
+    $(GLINK_LEX StringLiteral) $(D ,) $(GSELF GccAsmClobbers)
+
+$(GNAME GccAsmGotoLabels):
+    $(GLINK_LEX Identifier)
+    $(GLINK_LEX Identifier) $(D ,) $(GSELF GccAsmGotoLabels)
 )
 
 $(SPEC_SUBNAV_PREV_NEXT float, Floating Point, ddoc, Embedded Documentation)


### PR DESCRIPTION
The generated contents table erroneously includes a dead "Other" subcategory because of the "$(COMMENT)" section that follows for DMD-style inline asm.

![image](https://user-images.githubusercontent.com/397929/159187964-45d28360-1596-443f-a5a5-6368b1e5ff86.png)
