### PR TITLE
spec/arrays: Improve static array .tupleof docs

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -585,13 +585,13 @@ Returns an array literal with each element of the literal being the $(D .init) p
             ---
             void foo(int, int, int) { /* ... */ }
 
-            int[3] ia = 8;
-            foo(ia.tupleof); // same as `foo(8, 8, 8);`
+            int[3] ia = [1, 2, 3];
+            foo(ia.tupleof); // same as `foo(1, 2, 3);`
 
-            float[3] fa = [1.1, 2.2, 3.3];
-            //ia = fa; // error
-            ia.tupleof = fa.tupleof;
-            assert(ia == [1, 2, 3]);
+            float[3] fa;
+            //fa = ia; // error
+            fa.tupleof = ia.tupleof;
+            assert(fa == [1F, 2F, 3F]);
             ---
             )
             ))

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -580,7 +580,21 @@ Returns an array literal with each element of the literal being the $(D .init) p
         $(TROW $(D .ptr), Returns a pointer to the first element of the array.)
         $(TROW $(D .dup), Create a dynamic array of the same size and copy the contents of the array into it. The copy will have any immutability or const stripped. If this conversion is invalid the call will not compile.)
         $(TROW $(D .idup), Create a dynamic array of the same size and copy the contents of the array into it. The copy is typed as being immutable. If this conversion is invalid the call will not compile.)
-        $(TROW $(D .tupleof), $(ARGS Returns an $(DDSUBLINK spec/template, variadic-templates, expression sequence) of all elements of the array, as with $(D .tupleof) for structs and $(DDSUBLINK spec/class, class_properties, classes).))
+        $(TROW $(D .tupleof), $(ARGS Returns an $(DDSUBLINK spec/template, homogeneous_sequences, lvalue sequence) of each element in the array:
+            $(SPEC_RUNNABLE_EXAMPLE_RUN
+            ---
+            void foo(int, int, int) {}
+
+            int[3] ia;
+            foo(ia.tupleof);
+
+            float[3] fa = [1.1, 2.2, 3.3];
+            //ia = fa; // error
+            ia.tupleof = fa.tupleof;
+            assert(ia == [1, 2, 3]);
+            ---
+            )
+            ))
         )
 
         $(P Dynamic array properties are:)

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -583,10 +583,10 @@ Returns an array literal with each element of the literal being the $(D .init) p
         $(TROW $(D .tupleof), $(ARGS Returns an $(DDSUBLINK spec/template, homogeneous_sequences, lvalue sequence) of each element in the array:
             $(SPEC_RUNNABLE_EXAMPLE_RUN
             ---
-            void foo(int, int, int) {}
+            void foo(int, int, int) { /* ... */ }
 
-            int[3] ia;
-            foo(ia.tupleof);
+            int[3] ia = 8;
+            foo(ia.tupleof); // same as `foo(8, 8, 8);`
 
             float[3] fa = [1.1, 2.2, 3.3];
             //ia = fa; // error

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -914,8 +914,8 @@ $(H4 $(LNAME2 homogeneous_sequences, Homogeneous Sequences))
     $(UL
         $(LI `.tupleof` can be $(DDSUBLINK spec/class, class_properties, used on a class)
             or struct instance to obtain an lvalue sequence of its fields.)
-        $(LI `.tupleof` can be used on a static array instance to obtain an lvalue
-            sequence of its elements.)
+        $(LI `.tupleof` can be $(DDSUBLINK spec/arrays, array-properties, used on a static array)
+            instance to obtain an lvalue sequence of its elements.)
     )
 
 $(H4 $(LNAME2 seq-ops, Sequence Operations))


### PR DESCRIPTION
Add example & remove link to class .tupleof.
Add link from template.dd.