### PR TITLE
[spec/attribute] Document `final` attribute

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -18,7 +18,7 @@ $(GNAME Attribute):
     $(RELATIVE_LINK2 static, $(D static))
     $(RELATIVE_LINK2 linkage, $(D extern))
     $(RELATIVE_LINK2 abstract, $(D abstract))
-    $(D final)
+    $(RELATIVE_LINK2 final, `final`)
     $(RELATIVE_LINK2 override, $(D override))
     $(D synchronized)
     $(RELATIVE_LINK2 auto, $(D auto))
@@ -375,7 +375,8 @@ attributes in documents predating $(LINK2 http://wiki.dlang.org/DIP22, DIP22).)
 
         $(P Symbols with $(D private) visibility can only be accessed from
         within the same module.
-        Private member functions are implicitly final and cannot be overridden.
+        Private member functions are implicitly $(DDSUBLINK spec/function, final, `final`)
+        and cannot be overridden.
         )
 
         $(P $(D package) extends private so that package members can be accessed
@@ -662,6 +663,15 @@ $(P
         they can still provide $(SINGLEQUOTE base class functionality),
         e.g. through $(D super.foo()) in a derived class.
         Note that the class is still abstract and cannot be instantiated directly.
+)
+
+$(H2 $(LNAME2 final, `final` Attribute))
+
+$(UL
+$(LI A class can be declared $(DDSUBLINK spec/class, final, `final`) to prevent
+    subclassing.)
+$(LI A class method can be declared $(DDSUBLINK spec/function, final, `final`)
+    to prevent a derived class overriding it.)
 )
 
 $(H2 $(LNAME2 mustuse-attribute, `@mustuse` Attribute))

--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -672,6 +672,7 @@ $(LI A class can be declared $(DDSUBLINK spec/class, final, `final`) to prevent
     subclassing.)
 $(LI A class method can be declared $(DDSUBLINK spec/function, final, `final`)
     to prevent a derived class overriding it.)
+$(LI Interfaces can define $(DDSUBLINK spec/interface, method-bodies, `final` methods).)
 )
 
 $(H2 $(LNAME2 mustuse-attribute, `@mustuse` Attribute))

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -1208,7 +1208,8 @@ final class A { }
 class B : A { }  // error, class A is final
 ---
 
-        $(P Methods of a final class are `final` by default.)
+        $(P Methods of a final class are always
+        $(DDSUBLINK spec/function, final, `final`).)
 
 $(H2 $(LNAME2 nested, Nested Classes))
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1012,6 +1012,9 @@ void test()
         has its parameters changed, and all derived classes need to have
         their overriding functions updated.)
 
+        $(P The $(LNAME2 final, `final`) method attribute
+        prevents a subclass from overriding the method.)
+
         $(P The following are not virtual:)
         $(UL
         $(LI Struct and union member functions)
@@ -3730,7 +3733,7 @@ $(H2 $(LNAME2 pseudo-member, Uniform Function Call Syntax (UFCS)))
         ---
 
         $(RATIONALE This provides a way to add external functions to a class as if they were
-        public final member functions.
+        public $(RELATIVE_LINK2 final, `final`) member functions.
         This enables minimizing the number of functions in a class to only the essentials that
         are needed to take care of the object's private state, without the temptation to add
         a kitchen-sink's worth of member functions.


### PR DESCRIPTION
Methods of a final class are always final (not by default).
Explain `final` in Virtual Functions section and add anchor.