### PR TITLE
Fix issue 22503 - Invalid changelog entry for isValidCodePoint

### DIFF
--- a/changelog/2.098.0.dd
+++ b/changelog/2.098.0.dd
@@ -37,7 +37,7 @@ $(LI $(RELATIVE_LINK2 improve_posix_imports,Improve POSIX imports))
 
 $(BUGSTITLE_TEXT_HEADER Library changes,
 
-$(LI $(RELATIVE_LINK2 add_isValidCharacter,New function `isValidCharacter` in `std.utf`))
+$(LI $(RELATIVE_LINK2 add_isValidCharacter,New function `isValidCodepoint` in `std.utf`))
 
 )
 
@@ -1067,10 +1067,10 @@ The `O_CLOEXEC` symbol was added to `core/sys/posix/fcntl.d`.
 
 $(BUGSTITLE_TEXT_BODY Library changes,
 
-$(LI $(LNAME2 add_isValidCharacter,New function `isValidCharacter` in `std.utf`)
+$(LI $(LNAME2 add_isValidCharacter,New function `isValidCodepoint` in `std.utf`)
 $(CHANGELOG_SOURCE_FILE phobos, changelog/add_isValidCharacter.dd)
 $(P
-A new function `isValidCharacter` has been added to `std.utf`. It can
+A new function `isValidCodepoint` has been added to `std.utf`. It can
 be used to check if a single character forms a valid code point. For
 example the `char` `0x80` is not a valid code point, because it can
 only be used in trailing characters of UTF8 sequences, whereas the
@@ -1078,8 +1078,8 @@ wchar `ä` is a valid character:
 )
 
 ```
-assert(!isValidCharacter(cast(char) 0x80));
-assert(isValidCharacter('ä'));
+assert(!isValidCodepoint(cast(char) 0x80));
+assert(isValidCodepoint('ä'));
 ```
 )
 


### PR DESCRIPTION
Trivial rename. Keep the old name in the anchor to not break links.