### PR TITLE
Use DuckDuckGo for search

### DIFF
--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -128,7 +128,7 @@ html(lang='en-US')
             a.expand-toggle(href="#{root_dir}search.html", title="Search")
               span Search
             #search-box
-              form(method='get', action='https://google.com/search', autocomplete='off')
+              form(method='get', action='https://duckduckgo.com/', autocomplete='off')
                 input#domains(type='hidden', name='domains', value='dlang.org')
                 |             
                 input#sourceid(type='hidden', name='sourceid', value='google-search')


### PR DESCRIPTION
Many people, including myself, distrust Google and stay away from it as much as possible. To that end, I propose that search be routed through DuckDuckGo to make sure that everybody can search the site with peace of mind from a privacy standpoint.