### PR TITLE
Update release schedule for 2022

### DIFF
--- a/changelog/release-schedule.dd
+++ b/changelog/release-schedule.dd
@@ -3,29 +3,25 @@ Ddoc
 $(D_S $(TITLE),
 
 $(UL
-    $(LI New release are published every $(I two) months, on the first day of every uneven month.)
+    $(LI New release are published every $(I two) months, on the first day of every even month.)
     $(LI Two weeks before a new release `master` is merged into `stable` and a first beta is released.)
     $(LI Point releases are published unscheduled when important issues or regressions get fixed.)
 )
 
-$(P The release schedule for 2021 is as follows:)
+$(P The release schedule for 2022 is as follows:)
 
     $(DIVC release-schedule,
         $(TABLE
-            $(BETA_RELEASE 2020-12-15, 2.095.0)
-            $(MINOR_RELEASE 2021-01-01, 2.095.0)
-            $(BETA_RELEASE 2021-02-15, 2.096.0)
-            $(MINOR_RELEASE 2021-03-01, 2.096.0)
-            $(BETA_RELEASE 2021-04-15, 2.097.0)
-            $(MINOR_RELEASE 2021-05-01, 2.097.0)
-            $(BETA_RELEASE 2021-06-15, 2.098.0)
-            $(MINOR_RELEASE 2021-07-01, 2.098.0)
-            $(BETA_RELEASE 2021-08-15, 2.099.0)
-            $(MINOR_RELEASE 2021-09-01, 2.099.0)
-            $(BETA_RELEASE 2021-10-15, 2.100.0)
-            $(MINOR_RELEASE 2021-11-01, 2.100.0)
-            $(BETA_RELEASE 2021-12-15, 2.101.0)
-            $(MINOR_RELEASE 2022-01-01, 2.101.0)
+            $(BETA_RELEASE 2022-02-15, 2.099.0)
+            $(BETA_RELEASE 2022-03-01, 2.099.0)
+            $(BETA_RELEASE 2022-04-15, 2.100.0)
+            $(MINOR_RELEASE 2022-05-01, 2.100.0)
+            $(BETA_RELEASE 2022-07-15, 2.101.0)
+            $(MINOR_RELEASE 2022-08-01, 2.101.0)
+            $(BETA_RELEASE 2022-09-15, 2.102.0)
+            $(MINOR_RELEASE 2022-10-01, 2.102.0)
+            $(BETA_RELEASE 2022-11-15, 2.103.0)
+            $(MINOR_RELEASE 2022-12-01, 2.103.0)
         )
     )
 )


### PR DESCRIPTION
There was a large gap between 2.098 (October 2021) and 2.099 (March 2022), but I think we're back on track with 2.100