### PR TITLE
[spec/function] Tweak Optional Parameters section

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -843,7 +843,7 @@ $(H2 $(LNAME2 optional-parenthesis, Optional Parentheses))
         ---
         )
 
-    $(P Note that parentheses are required to call a delegate or a function pointer:)
+    $(P Due to ambiguity, parentheses are required to call a delegate or a function pointer:)
 
     ---
     void main()


### PR DESCRIPTION
Link to UFCS.
Improve wording for functions returning a function pointer.
Split 'calling result' example in two and rename functions.