### PR TITLE
[spec/class.dd] Move abstract class docs to class.dd & add examples

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -831,32 +831,8 @@ void main() @nogc
 $(H2 $(LNAME2 abstract, $(D abstract) Attribute))
 
 $(P
-        An abstract member function must be overridden by a derived class.
-        Only virtual member functions may be declared abstract; non-virtual
-        member functions and free-standing functions cannot be declared
-        abstract.
-)
-
-$(P
-        Classes become abstract if any of its virtual member functions
-        are declared abstract or if they are defined within an
-        abstract attribute.
-        Note that an abstract class may also contain non-virtual member functions.
-)
-
-$(P
-        Classes defined within an abstract attribute or with abstract member
-        functions cannot be instantiated directly.
-        They can only be instantiated as a base class of
-        another, non-abstract, class.
-)
-
-$(P
-        Member functions declared as abstract can still have function
-        bodies. This is so that even though they must be overridden,
-        they can still provide $(SINGLEQUOTE base class functionality),
-        e.g. through $(D super.foo()) in a derived class.
-        Note that the class is still abstract and cannot be instantiated directly.
+        An $(DDSUBLINK spec/class, abstract, abstract class) must be overridden by a derived class.
+        Declaring an abstract member function makes the class abstract.
 )
 
 $(H2 $(LNAME2 final, `final` Attribute))

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -1214,17 +1214,35 @@ $(P
 )
 
 $(P
-        Classes become abstract if any of its virtual member functions
+        A class is abstract if any of its virtual member functions
         are declared abstract or if they are defined within an
         abstract attribute.
         Note that an abstract class may also contain non-virtual member functions.
-)
-
-$(P
-        Classes defined within an abstract attribute or with abstract member
-        functions cannot be instantiated directly.
+        Abstract classes cannot be instantiated directly.
         They can only be instantiated as a base class of
         another, non-abstract, class.
+)
+
+$(SPEC_RUNNABLE_EXAMPLE_FAIL
+---
+class C
+{
+    abstract void f();
+}
+
+auto c = new C; // error, C is abstract
+
+class D : C {}
+
+auto d = new D; // error, D is abstract
+
+class E : C
+{
+    override void f() {}
+}
+
+auto e = new E; // OK
+---
 )
 
 $(P
@@ -1233,6 +1251,25 @@ $(P
         they can still provide $(SINGLEQUOTE base class functionality),
         e.g. through $(D super.foo()) in a derived class.
         Note that the class is still abstract and cannot be instantiated directly.
+)
+
+$(P
+        A class can be declared abstract:
+)
+
+$(SPEC_RUNNABLE_EXAMPLE_FAIL
+---
+abstract class A
+{
+    // ...
+}
+
+auto a = new A; // error, A is abstract
+
+class B : A {}
+
+auto b = new B; // OK
+---
 )
 
 

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -1203,6 +1203,39 @@ $(P When a scope class reference goes out of scope, the destructor (if any) for
 it is automatically called. This holds true even if the scope was exited via a
 thrown exception.)
 
+
+$(H2 $(LNAME2 abstract, Abstract Classes))
+
+$(P
+        An abstract member function must be overridden by a derived class.
+        Only virtual member functions may be declared abstract; non-virtual
+        member functions and free-standing functions cannot be declared
+        abstract.
+)
+
+$(P
+        Classes become abstract if any of its virtual member functions
+        are declared abstract or if they are defined within an
+        abstract attribute.
+        Note that an abstract class may also contain non-virtual member functions.
+)
+
+$(P
+        Classes defined within an abstract attribute or with abstract member
+        functions cannot be instantiated directly.
+        They can only be instantiated as a base class of
+        another, non-abstract, class.
+)
+
+$(P
+        Member functions declared as abstract can still have function
+        bodies. This is so that even though they must be overridden,
+        they can still provide $(SINGLEQUOTE base class functionality),
+        e.g. through $(D super.foo()) in a derived class.
+        Note that the class is still abstract and cannot be instantiated directly.
+)
+
+
 $(H2 $(LNAME2 final, Final Classes))
 
         $(P Final classes cannot be subclassed:)


### PR DESCRIPTION
They fit better in class.dd and the final class docs are there (as well as synchronized classes). 
Link to class.dd from attribute.dd instead.

The first commit just moves the paragraphs.
The second commit tweaks the docs and adds examples.

Move abstract class attribute after abstract methods rather than in the middle of them.
