### PR TITLE
[spec/class] Improve list of class components

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -55,7 +55,7 @@ $(UL
         $(LI dynamic fields)
         $(LI $(DDSUBLINK spec/attribute, static, static) fields)
         $(LI $(RELATIVE_LINK2 nested, nested classes))
-        $(LI $(RELATIVE_LINK2 member-functions, member functions)
+        $(LI $(RELATIVE_LINK2 member-functions, member functions))
         $(UL
             $(LI static member functions)
             $(LI $(DDSUBLINK spec/function, virtual-functions, Virtual Functions))

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -48,7 +48,7 @@ $(GNAME Interface):
 
 $(P A class consists of:)
 
-$(COMMENT list of notable components, not general things or attributes)
+$(COMMENT list of notable components, not exhaustive)
 $(UL
         $(LI a super class)
         $(LI $(DDLINK spec/interface, Interfaces, interfaces)

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -46,30 +46,26 @@ $(GNAME Interface):
     $(GLINK2 type, BasicType)
 )
 
-$(P Classes consist of:)
+$(P A class consists of:)
 
+$(COMMENT list of notable components, not general things or attributes)
 $(UL
         $(LI a super class)
-        $(LI interfaces)
-        $(LI a nested anonymous metaclass for classes declared with `extern (Objective-C)`)
+        $(LI $(DDLINK spec/interface, Interfaces, interfaces)
         $(LI dynamic fields)
-        $(LI static fields)
-        $(LI types)
-        $(LI $(RELATIVE_LINK2 synchronized-classes, an optional synchronized attribute))
+        $(LI $(DDSUBLINK spec/attribute, static, static) fields)
+        $(LI $(RELATIVE_LINK2 nested, nested classes))
         $(LI $(RELATIVE_LINK2 member-functions, member functions)
         $(UL
             $(LI static member functions)
             $(LI $(DDSUBLINK spec/function, virtual-functions, Virtual Functions))
             $(LI $(RELATIVE_LINK2 constructors, Constructors))
             $(LI $(RELATIVE_LINK2 destructors, Destructors))
-            $(LI $(RELATIVE_LINK2 static-constructor, Static Constructors))
-            $(LI $(RELATIVE_LINK2 static-destructor, Static Destructors))
-            $(LI $(GLINK SharedStaticConstructor)s)
-            $(LI $(GLINK SharedStaticDestructor)s)
             $(LI $(RELATIVE_LINK2 invariants, Class Invariants))
-            $(LI $(DDSUBLINK spec/unittest, unittest, Unit Tests))
-            $(LI $(RELATIVE_LINK2 alias-this, Alias This))
+            $(LI $(DDLINK spec/operatoroverloading, Operator Overloading, Operator Overloading))
         )
+        $(LI $(RELATIVE_LINK2 alias-this, Alias This))
+        $(LI other declarations (see $(GLINK2 module, DeclDef)))
         )
 )
 
@@ -271,7 +267,7 @@ $(H3 $(LNAME2 objc-member-functions, Objective-C linkage))
         )
 
         $(P Static member functions with Objective-C linkage are placed in
-        the hidden nested metaclass as non-static member functions.
+        a hidden nested metaclass as non-static member functions.
         )
 
 


### PR DESCRIPTION
This should not be exhaustive (we already have a TOC) but should mention notable things.

Add:
* nested classes
* operator overloading
* item for other declarations - link to [DeclDef](https://dlang.org/spec/module.html#DeclDef)
* links for interfaces, static fields

Remove:
* anonymous metaclass for Objective-C (not D so not that relevant, it is mentioned in member functions section)
* types - covered by DeclDef
* synchronized attribute - this is not a *component* of a class (it's in the TOC)
* static constructors and destructors - these are in the TOC but they don't
  seem to be particularly relevant to classes. In another
  pull I could merge these sections from class.dd into the module.dd
  docs: https://dlang.org/spec/module.html#staticorder, as they are
  children of DeclDef.
* unittests - covered by DeclDef, not that relevant to classes.

Move alias this out of methods.