### PR TITLE
[spec] Improve return docs

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1339,6 +1339,7 @@ $(P
     }
     ---
 
+    $(P The type of a *ThrowExpression* is $(DDSUBLINK spec/type, noreturn, `noreturn`).)
 
 $(BEST_PRACTICE Use $(DDSUBLINK spec/expression, assert_expressions, Assert Expressions)
 rather than $(LINK2 $(ROOT_DIR)library/object#.Error, Error) to report program bugs

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -362,7 +362,8 @@ $(H2 $(LNAME2 function-return-values, Function Return Values))
         is required if the function specifies a return type that is not void,
         unless the function contains inline assembler code.)
 
-        $(P Function return values not marked as $(D ref) are considered to be rvalues.
+        $(P Function return values not marked as $(RELATIVE_LINK2 ref-functions, `ref`)
+        are considered to be rvalues.
         This means they cannot be passed by reference to other functions.
         )
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -357,10 +357,16 @@ $(GNAME OutStatement):
 
 $(H2 $(LNAME2 function-return-values, Function Return Values))
 
-        $(P At least one $(DDSUBLINK spec/statement, return-statement, return statement),
-        throw statement, noreturn statement or assert(0) expression
+        $(P At least one $(DDSUBLINK spec/statement, return-statement, return statement)
         is required if the function specifies a return type that is not void,
-        unless the function contains inline assembler code.)
+        unless:)
+        $(UL
+        $(LI the function executes an infinite loop)
+        $(LI the function executes an `assert(0)` statement)
+        $(LI the function evaluates an expression of type
+            $(DDSUBLINK spec/type, noreturn, `noreturn`))
+        $(LI the function contains inline assembler code)
+        )
 
         $(P Function return values not marked as $(RELATIVE_LINK2 ref-functions, `ref`)
         are considered to be rvalues.

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -179,7 +179,7 @@ $(GNAME OutStatement):
 
         $(P Preconditions and postconditions do not affect the type of the function.)
 
-    $(H3 Preconditions)
+    $(H3 $(LNAME2 preconditions, Preconditions))
 
         $(P An $(GLINK InContractExpression) is a precondition.)
 
@@ -234,7 +234,7 @@ $(GNAME OutStatement):
         ---
 
 
-    $(H3 Postconditions)
+    $(H3 $(LNAME2 postconditions, Postconditions))
 
         $(P An $(GLINK OutContractExpression) is a postcondition.)
 
@@ -356,6 +356,11 @@ $(GNAME OutStatement):
 
 
 $(H2 $(LNAME2 function-return-values, Function Return Values))
+
+        $(P At least one $(DDSUBLINK spec/statement, return-statement, return statement),
+        throw statement, noreturn statement or assert(0) expression
+        is required if the function specifies a return type that is not void,
+        unless the function contains inline assembler code.)
 
         $(P Function return values not marked as $(D ref) are considered to be rvalues.
         This means they cannot be passed by reference to other functions.

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1494,36 +1494,32 @@ $(GNAME ReturnStatement):
     $(D return) $(EXPRESSION)$(OPT) $(D ;)
 )
 
-$(P `return` exits the current function and supplies its return value.)
+$(P `return` exits the current function and supplies its
+$(DDSUBLINK spec/function, function-return-values, return value).)
 
 $(P *Expression* is required if the function specifies a return type that is
 not void. The *Expression* is implicitly converted to the function return
 type.)
 
-        $(P At least one return statement, throw statement, or assert(0) expression
-        is required if the function specifies a return type that is not void,
-        unless the function contains inline assembler code.)
-
-$(COMMENT
-        *Expression* is allowed even if the function specifies
-        a $(D_KEYWORD void) return type. The *Expression* will be evaluated,
-        but nothing will be returned.
+$(P
+        An *Expression* of type void is allowed if the function specifies
+        a void return type. The *Expression* will be evaluated,
+        but nothing will be returned. This is useful in generic programming.
         If the *Expression* has no side effects, and the return
-        type is $(D_KEYWORD void), then it is illegal.
+        type is void, then it is illegal.
 )
         $(P Before the function actually returns,
-        any objects with scope storage duration are destroyed,
-        any enclosing finally clauses are executed,
-        any scope(exit) statements are executed,
-        any scope(success) statements are executed,
+        any objects with `scope` storage duration are destroyed,
+        any enclosing `finally` clauses are executed,
+        any `scope(exit)` statements are executed,
+        any `scope(success)` statements are executed,
         and any enclosing synchronization
         objects are released.)
 
-        $(P The function will not return if any enclosing finally clause
-        does a return, goto or throw that exits the finally clause.)
+        $(P The function will not return if any enclosing `finally` clause
+        does a return, goto or throw that exits the `finally` clause.)
 
-        $(P If there is an out postcondition
-        (see $(DDLINK spec/contracts, Contract Programming, Contract Programming)),
+        $(P If there is an $(DDSUBLINK spec/function, postconditions, `out` postcondition),
         that postcondition is executed
         after the *Expression* is evaluated and before the function
         actually returns.)

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -578,7 +578,8 @@ $(H3 $(LNAME2 noreturn, $(D noreturn)))
     A value of type `noreturn` will never be produced and the compiler can
     optimize such code accordingly.)
 
-    $(P A function that never returns has the return type `noreturn`. This can
+    $(P A function that $(DDSUBLINK spec/function, function-return-values, never returns)
+    has the return type `noreturn`. This can
     occur due to an infinite loop or always throwing an exception.)
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE


### PR DESCRIPTION
function.dd:
Add anchors for contract preconditions, postconditions (see below).
Move sentence about non-void return type requiring at least one terminating statement from statement.dd to Return Values section. Also mention noreturn statements.
Add link to ref functions.

statement.dd:
Link to function return values.
Uncomment returning a expression when return type is void. This was commented out in 549bdb109 because the expression could be non-void before [this issue](https://issues.dlang.org/show_bug.cgi?id=5399) was fixed (mentioned in commit message). Document that the expression must be void in this case, and that this is useful in generic programming.
Link to `out` contract docs rather than contracts.