### PR TITLE
Fix definition of DecimalFloat in the Lexer

### DIFF
--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -845,10 +845,10 @@ $(GNAME Float):
 
 $(GNAME DecimalFloat):
     $(GLINK LeadingDecimal) $(B .)
-    $(GLINK LeadingDecimal) $(B .) $(GLINK DecimalDigits)
-    $(GLINK DecimalDigits) $(B .) $(GLINK DecimalDigitsNoStartingUS) $(GLINK DecimalExponent)
-    $(B .) $(GLINK DecimalInteger)
-    $(B .) $(GLINK DecimalInteger) $(GLINK DecimalExponent)
+    $(GLINK LeadingDecimal) $(B .) $(GLINK DecimalDigitsNoStartingUS)
+    $(GLINK LeadingDecimal) $(B .) $(GLINK DecimalDigitsNoStartingUS) $(GLINK DecimalExponent)
+    $(B .) $(GLINK DecimalDigitsNoStartingUS)
+    $(B .) $(GLINK DecimalDigitsNoStartingUS) $(GLINK DecimalExponent)
     $(GLINK LeadingDecimal) $(GLINK DecimalExponent)
 
 $(GNAME DecimalExponent):


### PR DESCRIPTION
According to the current definition, `_` is not always allowed but
`6_022_.140_857E+20_` is officially valid. The new definition fix that.

Note: DMD implementation is correct and support this number