### PR TITLE
[spec] Tweak invariant docs

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -937,30 +937,7 @@ $(GNAME Invariant):
     succeed.
     )
 
-    $(P If the invariant does not hold, then the program enters an invalid state.)
-
-    $(P Any class invariants for base classes are applied before the class invariant for the derived class.)
-
-    $(P There may be multiple invariants in a class. They are applied in lexical order.)
-
-    $(P Class $(I Invariant)s must hold at the exit of the class constructor (if any),
-    at the entry of the class destructor (if any).)
-
-    $(P Class $(I Invariant)s must hold
-    at the entry and exit of all public or exported non-static member functions.
-    The order of application of invariants is:
-    $(OL
-    $(LI preconditions)
-    $(LI invariant)
-    $(LI function body)
-    $(LI invariant)
-    $(LI postconditions)
-    )
-    )
-
-    $(P The invariant need not hold if the class instance is implicitly constructed using
-    the default $(D .init) value.)
-
+    $(SPEC_RUNNABLE_EXAMPLE_COMPILE
     ---
     class Date
     {
@@ -981,6 +958,38 @@ $(GNAME Invariant):
         int hour;
     }
     ---
+    )
+
+    $(P Any class invariants for base classes are applied before the class invariant for the derived class.)
+
+    $(P There may be multiple invariants in a class. They are applied in lexical order.)
+
+    $(P Class $(I Invariant)s must hold at the exit of the class constructor (if any), and
+    at the entry of the class destructor (if any).)
+
+    $(P Class $(I Invariant)s must hold
+    at the entry and exit of all public or exported non-static member functions.
+    The order of application of invariants is:)
+    $(OL
+    $(LI preconditions)
+    $(LI invariant)
+    $(LI function body)
+    $(LI invariant)
+    $(LI postconditions)
+    )
+
+    $(P If the invariant does not hold, then the program enters an invalid state.)
+
+    $(IMPLEMENTATION_DEFINED
+    $(OL
+    $(LI Whether the class $(I Invariant) is executed at runtime or not. This is typically
+    controlled with a compiler switch.)
+    $(LI The behavior when the invariant does not hold is typically the same as
+    for when $(GLINK2 expression, AssertExpression)s fail.)
+    )
+    )
+
+    $(UNDEFINED_BEHAVIOR happens if the invariant does not hold and execution continues.)
 
     $(P Public or exported non-static member functions cannot be called from within an invariant.)
 
@@ -997,17 +1006,6 @@ $(GNAME Invariant):
         }
     }
     ---
-
-    $(UNDEFINED_BEHAVIOR happens if the invariant does not hold and execution continues.)
-
-    $(IMPLEMENTATION_DEFINED
-    $(OL
-    $(LI Whether the class $(I Invariant) is executed at runtime or not. This is typically
-    controlled with a compiler switch.)
-    $(LI The behavior when the invariant does not hold is typically the same as
-    for when $(GLINK2 expression, AssertExpression)s fail.)
-    )
-    )
 
     $(BEST_PRACTICE
     $(OL

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -1608,30 +1608,6 @@ $(GNAME Invariant):
     succeed.
     )
 
-    $(P If the invariant does not hold, then the program enters an invalid state.)
-
-    $(P Any invariants for fields are applied before the struct invariant.)
-
-    $(P There may be multiple invariants in a struct. They are applied in lexical order.)
-
-    $(P Struct $(I Invariant)s must hold at the exit of the struct constructor (if any),
-    and at the entry of the struct destructor (if any).)
-
-    $(P Struct $(I Invariant)s must hold
-    at the entry and exit of all public or exported non-static member functions.
-    The order of application of invariants is:
-    )
-    $(OL
-    $(LI preconditions)
-    $(LI invariant)
-    $(LI function body)
-    $(LI invariant)
-    $(LI postconditions)
-    )
-
-    $(P The invariant need not hold if the struct instance is implicitly constructed using
-    the default $(D .init) value.)
-
     $(SPEC_RUNNABLE_EXAMPLE_COMPILE
     ---
     struct Date
@@ -1655,6 +1631,41 @@ $(GNAME Invariant):
     ---
     )
 
+    $(P Any invariants for fields are applied before the struct invariant.)
+
+    $(P There may be multiple invariants in a struct. They are applied in lexical order.)
+
+    $(P Struct $(I Invariant)s must hold at the exit of the struct constructor (if any),
+    and at the entry of the struct destructor (if any).)
+
+    $(P Struct $(I Invariant)s must hold
+    at the entry and exit of all public or exported non-static member functions.
+    The order of application of invariants is:
+    )
+    $(OL
+    $(LI preconditions)
+    $(LI invariant)
+    $(LI function body)
+    $(LI invariant)
+    $(LI postconditions)
+    )
+
+    $(P The invariant need not hold if the struct instance is implicitly constructed using
+    the default $(D .init) value.)
+
+    $(P If the invariant does not hold, then the program enters an invalid state.)
+
+    $(IMPLEMENTATION_DEFINED
+    $(OL
+    $(LI Whether the struct $(I Invariant) is executed at runtime or not. This is typically
+    controlled with a compiler switch.)
+    $(LI The behavior when the invariant does not hold is typically the same as
+    for when $(GLINK2 expression, AssertExpression)s fail.)
+    )
+    )
+
+    $(UNDEFINED_BEHAVIOR happens if the invariant does not hold and execution continues.)
+
     $(P Public or exported non-static member functions cannot be called from within an invariant.)
 
     $(SPEC_RUNNABLE_EXAMPLE_FAIL
@@ -1671,17 +1682,6 @@ $(GNAME Invariant):
         }
     }
     ---
-    )
-
-    $(UNDEFINED_BEHAVIOR happens if the invariant does not hold and execution continues.)
-
-    $(IMPLEMENTATION_DEFINED
-    $(OL
-    $(LI Whether the struct $(I Invariant) is executed at runtime or not. This is typically
-    controlled with a compiler switch.)
-    $(LI The behavior when the invariant does not hold is typically the same as
-    for when $(GLINK2 expression, AssertExpression)s fail.)
-    )
     )
 
     $(BEST_PRACTICE


### PR DESCRIPTION
For both class & struct:
Move example under 'invariant form' paragraph.
Move 'if the invariant does not hold' under when invariant *is* called.
Move notes about failed invariant under 'if the invariant does not hold'. This is clearer than putting all notes at the end of the section, plus 'the program enters an invalid state' is begging for immediate clarification.

Class:
Remove sentence about .init value - this is a null reference (this likely came from the struct docs).
Make example runnable.

Unfortunately the diff is not very review friendly, but I didn't edit any moved text except adding a missing 'and' for this sentence:
```diff
-    $(P Class $(I Invariant)s must hold at the exit of the class constructor (if any),
+    $(P Class $(I Invariant)s must hold at the exit of the class constructor (if any), and
     at the entry of the class destructor (if any).)
```