### PR TITLE
add Associated C Compiler to glossary

### DIFF
--- a/glossary.dd
+++ b/glossary.dd
@@ -3,6 +3,14 @@ Ddoc
 $(D_S Glossary,
 
 $(DL
+        $(DT $(LNAME2 acc, $(ACRONYM ACC, Associated C Compiler)))
+        $(DD The D compiler is matched to the Associated C Compiler.
+        For example, on Win32 ImportC is matched to the Digital Mars C compiler,
+        and can be matched to the Visual C compiler using the
+        command line switch $(DDSUBLINK dmd, switch-m32mscoff, $(TT -m32mscoff)).
+        Win64 ImportC is matched to the Visual C compiler.
+        On Posix targets, the matching C compiler is Gnu C or Clang C.
+        )
 
         $(DT $(LNAME2 blit, $(ACRONYM BLIT, Block Transfer)))
         $(DD Also known as BLT, blit refers to copying memory


### PR DESCRIPTION
Snipped this out of https://github.com/dlang/dlang.org/pull/3328 because DAutoTest produces a log file of thousands of lines but no line indicating where the error is.