### PR TITLE
[spec/function] Tweak function pointer/delegate docs

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2862,7 +2862,9 @@ void test()
 
     $(P Nested functions cannot be overloaded.)
 
-$(H2 $(LNAME2 closures, Delegates, Function Pointers, and Closures))
+$(H2 $(LNAME2 function-pointers-delegates, Function Pointers, Delegates and Closures))
+
+$(H3 $(LNAME2 function-pointers, Function Pointers))
 
         $(P A function pointer can point to a static nested function:)
 
@@ -2896,16 +2898,18 @@ $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 int abc(int x)   { return x + 1; }
 uint def(uint y) { return y + 1; }
 
-int delegate(int)   fp1 = &abc;
-uint delegate(uint) fp2 = &def;
+int function(int)   fp1 = &abc;
+uint function(uint) fp2 = &def;
 // Do not rely on fp1 and fp2 being different values; the compiler may merge
 // them.
 ------
 )
 
+$(H3 $(LNAME2 closures, Delegates & Closures))
+
         $(P A delegate can be set to a non-static nested function:)
 
-$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 ------
 int delegate() dg;
 
@@ -2916,6 +2920,13 @@ void test()
 
     dg = &foo;
     int i = dg(); // i is set to 10
+}
+
+void main()
+{
+    test();
+    int i = dg(); // ok, test.a is in a closure and still exists
+    assert(i == 10);
 }
 ------
 )
@@ -2933,15 +2944,6 @@ void test()
         a closure and is an error.
         )
 
-------
-void bar()
-{
-    int b;
-    test();
-    int i = dg(); // ok, test.a is in a closure and still exists
-}
-------
-
         $(P Delegates to non-static nested functions contain two pieces of
         data: the pointer to the stack frame of the lexically enclosing
         function (called the $(I context pointer)) and the address of the
@@ -2952,7 +2954,7 @@ void bar()
         the same type.
         )
 
-$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 ------
 struct Foo
 {
@@ -2965,15 +2967,17 @@ int foo(int delegate() dg)
     return dg() + 1;
 }
 
-void test()
+void main()
 {
+    Foo f;
+    int i = foo(&f.bar);
+    assert(i == 8);
+
     int x = 27;
     int abc() { return x; }
-    Foo f;
-    int i;
 
-    i = foo(&abc);   // i is set to 28
-    i = foo(&f.bar); // i is set to 8
+    i = foo(&abc);
+    assert(i == 28);
 }
 ------
 )
@@ -2989,6 +2993,8 @@ void test()
         $(P The $(D .funcptr) property of a delegate will return the
         $(I function pointer) value as a function type.
         )
+
+$(H3 $(LNAME2 function-delegate-init, Initialization))
 
         $(P Function pointers are zero-initialized by default.
         They can be initialized to the address of any function (including a function literal).


### PR DESCRIPTION
Add Function Pointers subheading.
Use function pointers in example, delegates aren't necessary.

Add Delegates subheading, reusing existing `closures` anchor.
Merge 2 split examples to make 2nd one runnable.
Tweak next example, use `main` function and asserts.

Add Initialization subheading.