### PR TITLE
Fix issue 23237 - temp force 2.100.0 download

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -197,7 +197,7 @@ $(LI $(LINK2 http://www.digitalmars.com/download/freecompiler.html, Digital Mars
 Macros:
         TITLE=Downloads
 
-    DMDV2=$(LATEST)
+    DMDV2=2.100.0
 
     BETA=$(COMMENT $0)
     _=BETA=$0


### PR DESCRIPTION
This is a temporary fix for the broken 2.100.1 downloads until someone with access can solve the actual problem.