### PR TITLE
Fix source links for druntime

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -149,7 +149,7 @@ _=
 DMDSRC=$(HTTPS github.com/dlang/dmd/blob/master/src/dmd/$0, $0)
 DOT_PREFIXED=.$1$(DOT_PREFIXED $+)
 DOT_PREFIXED_SKIP=$(DOT_PREFIXED $+)
-DRUNTIMESRC=$(HTTPS github.com/dlang/druntime/blob/master/src/$0, $0)
+DRUNTIMESRC=$(HTTPS github.com/dlang/dmd/blob/master/druntime/src/$0, $0)
 _=
 
 $(COMMENT URL prefix for the site root.


### PR DESCRIPTION
Since druntime has moved to dmd, all the source links are broken.