### PR TITLE
Temp fix homepage download links

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -17,8 +17,8 @@ $(DIVC intro, $(DIV, $(DIV,
         $(DIVC download,
             $(DIVC btn-group-vertical,
               <a href="download.html" class="btn">Downloads</a>
-              $(SPANC smallprint, Latest version: $(LATEST)
-                  &ndash; $(LINK2 changelog/$(LATEST).html, Changelog))
+              $(SPANC smallprint, Latest version: 2.100.0
+                  &ndash; $(LINK2 changelog/2.100.0.html, Changelog))
             )
         )
     )
@@ -728,7 +728,7 @@ Macros:
     _=
     LAYOUT_PREFIX=
     LAYOUT_SUFFIX=
-    $(SCRIPTLOAD $(ROOT_DIR)js/platform-downloads.js,  data-latest="$(LATEST)")
+    $(SCRIPTLOAD $(ROOT_DIR)js/platform-downloads.js,  data-latest="2.100.0")
     LAYOUT_TITLE=
     TOUR=$(DIVC item, $(SECTION4 $(LINK2 $1, $(TC i, fa fa-$2 big-icon)$3), $4))
     TOUR=$(DIVC item, $(SECTION4 $(TC i, fa fa-$1 big-icon)$2, $3))


### PR DESCRIPTION
Temporarily fixes the download links in `index.dd` as mentioned here: https://github.com/dlang/dlang.org/pull/3348#issuecomment-1191821963