### PR TITLE
Revert download and changelog version changes

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -197,7 +197,7 @@ $(LI $(LINK2 http://www.digitalmars.com/download/freecompiler.html, Digital Mars
 Macros:
         TITLE=Downloads
 
-    DMDV2=2.100.0
+    DMDV2=$(LATEST)
 
     BETA=$(COMMENT $0)
     _=BETA=$0

--- a/index.dd
+++ b/index.dd
@@ -17,8 +17,8 @@ $(DIVC intro, $(DIV, $(DIV,
         $(DIVC download,
             $(DIVC btn-group-vertical,
               <a href="download.html" class="btn">Downloads</a>
-              $(SPANC smallprint, Latest version: 2.100.0
-                  &ndash; $(LINK2 changelog/2.100.0.html, Changelog))
+              $(SPANC smallprint, Latest version: $(LATEST)
+                  &ndash; $(LINK2 changelog/$(LATEST).html, Changelog))
             )
         )
     )
@@ -720,7 +720,7 @@ Macros:
     _=
     LAYOUT_PREFIX=
     LAYOUT_SUFFIX=
-    $(SCRIPTLOAD $(ROOT_DIR)js/platform-downloads.js,  data-latest="2.100.0")
+    $(SCRIPTLOAD $(ROOT_DIR)js/platform-downloads.js,  data-latest="$(LATEST)")
     LAYOUT_TITLE=
     TOUR=$(DIVC item, $(SECTION4 $(LINK2 $1, $(TC i, fa fa-$2 big-icon)$3), $4))
     TOUR=$(DIVC item, $(SECTION4 $(TC i, fa fa-$1 big-icon)$2, $3))


### PR DESCRIPTION
[Revert "Temp fix homepage download links](https://github.com/dlang/dlang.org/commit/64b902c76a8f1f75c68a41db365e7eecc0a5405c) (#3351)

[Revert "Fix issue 23237 - temp force 2.100.0 download](https://github.com/dlang/dlang.org/commit/92f05854a43ee059e6e83726f0a450a652108e6d) (#3348)

[Revert "Switch back to 2.100.0, 2.100.1 is not released yet"](https://github.com/dlang/dlang.org/commit/701fb2a266a6748aae8a3cc575ef1f85a10acde7) (#3344)

Reverts the mess people have been making of the mechanical parts of the site pages.

To be merged when I get the SMS from the RM.