### PR TITLE
Fix Issue 15379 - "final" attribute on function parameter

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -73,6 +73,10 @@ $(GNAME VariadicArgumentsAttribute):
     $(D shared)
 )
 
+$(NOTE In D2, declaring a parameter `final` is a semantic error, but not a parse error.)
+
+$(P See also: $(RELATIVE_LINK2 param-storage, parameter storage classes).)
+
 $(H3 Function attributes)
 
 $(GRAMMAR


### PR DESCRIPTION
`final` is not allowed here in D2.
```d
void foo(final int a){} // error!
```
```
finalpar.d(1): Error: variable `finalpar.foo.a` cannot be `final`, perhaps you meant `const`?
```