### PR TITLE
Changed the "here" link in Predefined Macros

### DIFF
--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -1030,7 +1030,7 @@ $(P
 
 $(P The implementations of all predefined macros are implementation-defined. The
 reference implementation's macro definitions can be found $(HTTPS
-github.com/dlang/dmd/blob/master/src/dmd/res/default_ddoc_theme.ddoc, here).)
+github.com/dlang/dmd/blob/master/compiler/src/dmd/res/default_ddoc_theme.ddoc, here).)
 
 $(P
     Ddoc does not generate HTML code. It formats into the basic


### PR DESCRIPTION
The link was dead, I fixed it to point to the new path.