### PR TITLE
Update word count examples

### DIFF
--- a/spec/hash-map.dd
+++ b/spec/hash-map.dd
@@ -488,88 +488,49 @@ $(H2 $(LNAME2 examples, Examples))
 
 $(H3 $(LNAME2 aa_example, Associative Array Example: word count))
 
-        $(P Let's consider the file is ASCII encoded with LF EOL.
-        In general case we should use $(I dchar c) for iteration
-        over code points and functions from $(LINK2 $(ROOT_DIR)phobos/std_uni.html,std.uni).
-        )
-
-$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+$(RUNNABLE_EXAMPLE
+$(RUNNABLE_EXAMPLE_STDIN
+too many cooks
+too many ingredients
+)
         ---------
-        import std.algorithm : sort;
-        import std.file;         // D file I/O
+        import std.algorithm;
         import std.stdio;
-        import std.ascii;
 
-        void main(string[] args)
+        void main()
         {
-            ulong totalWords, totalLines, totalChars;
             ulong[string] dictionary;
+            ulong wordCount, lineCount, charCount;
 
-            writeln("   lines   words   bytes file");
-            foreach (arg; args[1 .. $]) // for each argument except the first one
+            foreach (line; stdin.byLine(KeepTerminator.yes))
             {
-                ulong wordCount, lineCount, charCount;
-
-                foreach (line; File(arg).byLine())
+                charCount += line.length;
+                foreach (word; splitter(line))
                 {
-                    bool inWord;
-                    size_t wordStart;
-
-                    void tryFinishWord(size_t wordEnd)
-                    {
-                        if (inWord)
-                        {
-                            auto word = line[wordStart .. wordEnd];
-                            ++dictionary[word.idup];   // increment count for word
-                            inWord = false;
-                        }
-                    }
-
-                    foreach (i, char c; line)
-                    {
-                        if (std.ascii.isDigit(c))
-                        {
-                            // c is a digit (0..9)
-                        }
-                        else if (std.ascii.isAlpha(c))
-                        {
-                            // c is an ASCII letter (A..Z, a..z)
-                            if (!inWord)
-                            {
-                                wordStart = i;
-                                inWord = true;
-                                ++wordCount;
-                            }
-                        }
-                        else
-                            tryFinishWord(i);
-                        ++charCount;
-                    }
-                    tryFinishWord(line.length);
-                    ++lineCount;
+                    wordCount += 1;
+                    if (auto count = word in dictionary)
+                        *count += 1;
+                    else
+                        dictionary[word.idup] = 1;
                 }
 
-                writefln("%8s%8s%8s %s", lineCount, wordCount, charCount, arg);
-                totalWords += wordCount;
-                totalLines += lineCount;
-                totalChars += charCount;
+                lineCount += 1;
             }
+
+            writeln("   lines   words   bytes");
+            writefln("%8s%8s%8s", lineCount, wordCount, charCount);
 
             const char[37] hr = '-';
-            if (args.length > 2)
-            {
-                writeln(hr);
-                writefln("%8s%8s%8s total", totalLines, totalWords, totalChars);
-            }
 
             writeln(hr);
-            foreach (word; dictionary.keys.sort)
+            foreach (word; sort(dictionary.keys))
             {
                 writefln("%3s %s", dictionary[word], word);
             }
         }
         ---------
 )
+    $(P See $(DDLINK wc, wc, wc) for the full version.)
 
 $(H3 $(LNAME2 aa_example_iteration, Associative Array Example: counting pairs))
 

--- a/wc.dd
+++ b/wc.dd
@@ -2,17 +2,18 @@ Ddoc
 
 $(D_S Example: wc,
 
-    $(P This program is the D version of the classic wc (wordcount) C
+    $(P This program is the D version of the classic `wc` (wordcount) C
     program.
     It serves to demonstrate how to read files, slice arrays,
     and simple symbol table management with associative arrays.
     )
 
+$(RUNNABLE_EXAMPLE
 ----
 import std.stdio;
 import std.algorithm;
 
-int main(string[] args)
+void main(string[] args)
 {
     ulong wordCount;
     ulong lineCount;
@@ -21,20 +22,20 @@ int main(string[] args)
     int[string] dictionary;
     writeln("   lines   words   bytes file");
 
-    foreach(arg; args[1 .. args.length])
+    foreach (arg; args[1 .. $])
     {
         ulong lWordCount;
         ulong lCharCount;
         ulong lLineCount;
 
         auto file = File(arg);
-        foreach(line; file.byLine(KeepTerminator.yes))
+        foreach (line; file.byLine(KeepTerminator.yes))
         {
             lCharCount += line.length;
-            foreach(word; splitter(line))
+            foreach (word; splitter(line))
             {
                 lWordCount += 1;
-                if(auto count = word in dictionary)
+                if (auto count = word in dictionary)
                     *count += 1;
                 else
                     dictionary[word.idup] = 1;
@@ -62,9 +63,9 @@ int main(string[] args)
     {
             writefln("%3s %s", dictionary[word], word);
     }
-    return 0;
 }
 ----
+)
 )
 
 Macros:

--- a/wc.dd
+++ b/wc.dd
@@ -51,13 +51,15 @@ void main(string[] args)
         charCount += lCharCount;
     }
 
+    const char[37] hr = '-';
+
     if (args.length > 2)
     {
-        writefln("--------------------------------------\n%8s%8s%8s total",
-                        lineCount, wordCount, charCount);
+        writeln(hr);
+        writefln("%8s%8s%8s total", lineCount, wordCount, charCount);
     }
 
-    writeln("--------------------------------------");
+    writeln(hr);
 
     foreach (word; sort(dictionary.keys))
     {


### PR DESCRIPTION
Make hash-map.dd work on `stdin` so it can be run online; link to wc.dd.
Sync hash-map.dd code with newer wc.dd using `splitter` which works with Unicode.
This makes the hash-map.dd example shorter and easier to understand.
Tweak wc.dd example.