### PR TITLE
[spec/expression] Improve docs for `this` and `super`

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1623,7 +1623,7 @@ $(H3 $(LNAME2 super, super))
     $(P $(D super) is identical to $(D this), except that it is
         cast to $(D this)'s base class.
         It is an error if there is no base class.
-        It is an error to use $(D super) outside a class.
+        It is an error to use the $(D super) reference outside a non-static class member function.
         (Only class $(D Object) has no base class.)
         If a member function is called with an explicit reference
         to $(D super), a non-virtual call is made.

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1587,9 +1587,10 @@ $(H3 $(LNAME2 this, this))
 
     $(P Within a non-static member function, $(D this) resolves to
         a reference to the object for which the function was called.
-        If the object is an instance of a struct, $(D this) will
-        be a pointer to that instance.
-        If a member function is called with an explicit reference
+    )
+    $(P `typeof(this)` is valid anywhere inside an aggregate type
+        definition.
+        If a class member function is called with an explicit reference
         to $(D typeof(this)), a non-virtual call is made:)
 
         -------------
@@ -1615,14 +1616,14 @@ $(H3 $(LNAME2 this, this))
         }
         -------------
 
-    $(P Assignment to $(D this) is not allowed.)
+    $(P Assignment to $(D this) is not allowed for classes.)
 
 $(H3 $(LNAME2 super, super))
 
     $(P $(D super) is identical to $(D this), except that it is
         cast to $(D this)'s base class.
         It is an error if there is no base class.
-        It is an error to use $(D super) within a struct member function.
+        It is an error to use $(D super) outside a class.
         (Only class $(D Object) has no base class.)
         If a member function is called with an explicit reference
         to $(D super), a non-virtual call is made.

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1019,6 +1019,8 @@ void main()
 }
 ------
 )
+        $(P Base class methods can also be called through the
+        $(DDSUBLINK spec/expression, super, `super`) reference.)
 
         $(IMPLEMENTATION_DEFINED Normally calling a virtual function implies getting the
         address of the function at runtime by indexing into the class's `vtbl[]`.


### PR DESCRIPTION
Fix - `this` is not a pointer for structs, it's a reference.
Mention `typeof(this)` works anywhere inside an aggregate type, not just member functions.
Fix - assigning to `this` does work for structs.
`super` is only allowed inside a class.
Mention using `super` from Calling Base Class Methods.
