### PR TITLE
Fix Issue 18496 - Complement expressions now actually int promote

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -973,6 +973,9 @@ $(TABLE
     $(TROW `!`, Logical NOT)
 )
 
+    $(P The usual $(INTEGER_PROMOTIONS) are performed prior to unary
+    `-` and `+` operations.)
+
 $(H3 $(LNAME2 complement_expressions, Complement Expressions))
 
 $(GRAMMAR
@@ -982,9 +985,7 @@ $(GNAME ComplementExpression):
 
     $(P $(I ComplementExpression)s work on integral types (except $(D bool)).
         All the bits in the value are complemented.
-    )
-
-    $(P $(B Note:) the usual $(INTEGER_PROMOTIONS) are not performed
+        The usual $(INTEGER_PROMOTIONS) are performed
         prior to the complement operation.
     )
 


### PR DESCRIPTION
Also document promotion before unary `-` and `+`.