### PR TITLE
[spec/expression] Improve index and slice docs

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -849,7 +849,7 @@ assert(a[2] == 4);
 )
 
     $(P $(GLINK IndexExpression) can also be used with a pointer and has
-    the same behaviour as adding an integer then dereferencing the result.)
+    the same behaviour as adding an integer, then dereferencing the result.)
 
     $(P If the second operand is a pointer, and the first is an integral type,
         and the operator is $(D +),
@@ -1352,7 +1352,7 @@ $(GNAME IndexExpression):
     )
 
     $(P The index operator can be $(DDSUBLINK spec/operatoroverloading, array, overloaded).
-        Using multiple indexes in *ArgumentList* is only supported for operator
+        Using multiple indices in *ArgumentList* is only supported for operator
         overloading.)
 
 $(H2 $(LNAME2 slice_expressions, Slice Expressions))

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -849,7 +849,7 @@ assert(a[2] == 4);
 )
 
     $(P $(GLINK IndexExpression) can also be used with a pointer and has
-    the same behaviour as adding an integer.)
+    the same behaviour as adding an integer then dereferencing the result.)
 
     $(P If the second operand is a pointer, and the first is an integral type,
         and the operator is $(D +),
@@ -1316,6 +1316,8 @@ $(TABLE
     $(THEAD Operator, Description)
     $(TROW `++`, Increment after use - see $(RELATIVE_LINK2 order-of-evaluation, order of evaluation))
     $(TROW `--`, Decrement after use)
+    $(TROW *IndexExpression*, Select a single element)
+    $(TROW *SliceExpression*, Select a series of elements)
 )
 
 $(H2 $(LNAME2 index_expressions, Index Expressions))
@@ -1348,6 +1350,10 @@ $(GNAME IndexExpression):
         A new declaration scope is created for the evaluation of the
         $(I ArgumentList) and `$` appears in that scope only.
     )
+
+    $(P The index operator can be $(DDSUBLINK spec/operatoroverloading, array, overloaded).
+        Using multiple indexes in *ArgumentList* is only supported for operator
+        overloading.)
 
 $(H2 $(LNAME2 slice_expressions, Slice Expressions))
 
@@ -1399,7 +1405,12 @@ $(GNAME Slice):
     )
 
     $(P If the $(D [ ]) form is used, the slice is of all the elements in $(I PostfixExpression).
+        The expression cannot be a pointer.
     )
+
+    $(P The slice operator can be $(DDSUBLINK spec/operatoroverloading, slice, overloaded).
+        Using more than one *Slice* is only supported for operator
+        overloading.)
 
     $(P A $(I SliceExpression) is not a modifiable lvalue.)
 


### PR DESCRIPTION
Fix mention of pointer index.
Add summary descriptions for index and slice expressions.
Mention overloading of index and slice operations.