### PR TITLE
Fix issue 23314 - Language spec falsely states that struct field inva…

### DIFF
--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -1725,8 +1725,6 @@ $(GNAME Invariant):
     ---
     )
 
-    $(P Any invariants for fields are applied before the struct invariant.)
-
     $(P There may be multiple invariants in a struct. They are applied in lexical order.)
 
     $(P Struct $(I Invariant)s must hold at the exit of the struct constructor (if any),


### PR DESCRIPTION
…riants are checked

This behavior has never been implemented, and users should not rely on
it in their code.