### PR TITLE
Fix slice to static array implicit conversion docs

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1511,23 +1511,30 @@ $(GNAME Slice):
 $(H3 $(LNAME2 slice_to_static_array, Slice Conversion to Static Array))
 
     $(P If the slice bounds can be known at compile time, the slice expression
-    may be implicitly convertible to an lvalue of static array. For example:)
+    may be implicitly convertible to a static array lvalue. For example:)
 
         -------------
         arr[a .. b]     // typed T[]
         -------------
 
+        $(P
         If both $(CODE a) and $(CODE b) are integers (which may be constant-folded),
         the slice expression can be converted to a static array of type
         $(D T[b - a]).
+        )
+        $(NOTE a static array can also be $(DDSUBLINK spec/arrays, assignment,
+        assigned from a slice), performing a runtime check that the lengths match.)
 
-        $(SPEC_RUNNABLE_EXAMPLE_RUN
+        $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ---
-        int[] arr = [1, 2, 3];
-        int[2] sa = arr[1 .. 3];
+        void f(int[2] sa);
 
-        assert(sa == [2, 3]);
-        //sa = arr[0 .. 3]; // error, cannot match length
+        int[] arr = [1, 2, 3];
+        //f(arr); // error, can't convert
+        f(arr[1 .. 3]); // OK
+        //f(arr[0 .. 3]); // error
+
+        int[2] g() { return arr[0 .. 2]; }
         ---
         )
 
@@ -1550,16 +1557,17 @@ $(H3 $(LNAME2 slice_to_static_array, Slice Conversion to Static Array))
         -------------
         )
 
+    $(COMMENT Not implemented yet - https://issues.dlang.org/show_bug.cgi?id=13700
     $(P Certain other forms of slice expression can be implicitly converted to a static array
-        when the slice length can be known at compile-time.
+        when the slice length can be known at compile-time.)
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
         -------------
         int[] da = [1, 2, 3];
         int i = da[0]; // runtime variable
 
-        int[2] sa = da[i .. i + 2];
-        assert(sa == [2, 3]);
+        int[2] f() { return da[i .. i + 2]; }
+        assert(f() == [2, 3]);
         -------------
         )
 
@@ -1580,6 +1588,7 @@ $(H3 $(LNAME2 slice_to_static_array, Slice Conversion to Static Array))
         $(TROW $(D arr[e+a .. e+b]), $(D b - a) $(I if) $(D a <= b))
         $(TROW $(D arr[e-a .. e-b]), $(D a - b) $(I if) $(D a >= b))
         )
+    )
 
 $(H2 $(LNAME2 primary_expressions, Primary Expressions))
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1561,7 +1561,7 @@ $(H3 $(LNAME2 slice_to_static_array, Slice Conversion to Static Array))
     $(P Certain other forms of slice expression can be implicitly converted to a static array
         when the slice length can be known at compile-time.)
 
-        $(SPEC_RUNNABLE_EXAMPLE_RUN
+        $(COMMENT SPEC_RUNNABLE_EXAMPLE_RUN
         -------------
         int[] da = [1, 2, 3];
         int i = da[0]; // runtime variable


### PR DESCRIPTION
Show implicit conversion, not assignment in examples. 
Add link to array assignment.
Hide unimplemented conversions from runtime indexed slice of known length. The docs were merged but the compiler pull was not merged - see: https://github.com/dlang/dmd/pull/4209#issuecomment-74065882