### PR TITLE
[spec/template] Improve nested template docs

### DIFF
--- a/spec/template.dd
+++ b/spec/template.dd
@@ -1471,6 +1471,7 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
         instantiated functions will implicitly capture the context of the
         enclosing scope.)
 
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
         ----
         class C
         {
@@ -1502,30 +1503,45 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
             assert(c.num == 10);
         }
         ----
+        )
 
-    $(P Above, $(D Foo!().foo) will work just the same as a member function
+    $(P Above, $(D Foo!().foo) will work just the same as a `final` member function
         of class $(D C), and $(D Bar!().bar) will work just the same as a nested
         function within function $(D main$(LPAREN)$(RPAREN)).)
 
-$(H3 $(LNAME2 limitations, Limitations))
+$(H3 $(LNAME2 limitations, Aggregate Type Limitations))
 
-    $(P Templates cannot be used to add non-static fields or
-        virtual functions to classes or interfaces.
-        For example:)
+    $(P A nested template cannot add non-static fields to an aggregate type.
+        Fields declared in a nested template will be implicitly `static`.)
+    $(P A nested template cannot add virtual functions to a class or interface.
+        Methods inside a nested template will be implicitly `final`.)
 
+        $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ------
         class Foo
         {
             template TBar(T)
             {
-                T xx;               // becomes a static field of Foo
-                int func(T) { ... } // non-virtual
+                T xx;           // becomes a static field of Foo
+                void func(T) {} // implicitly final
+                //abstract void baz(); // error, final functions cannot be abstract
 
-                static T yy;                        // Ok
-                static int func(T t, int y) { ... } // Ok
+                static T yy;                    // Ok
+                static void func(T t, int y) {} // Ok
             }
         }
+
+        void main()
+        {
+            alias bar = Foo.TBar!int;
+            bar.xx++;
+            //bar.func(1); // error, no this
+
+            auto o = new Foo;
+            o.TBar!int.func(1); // OK
+        }
         ------
+        )
 
 $(H3 $(LNAME2 implicit-nesting, Implicit Nesting))
 

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -1507,6 +1507,26 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
         of class $(D C), and $(D Bar!().bar) will work just the same as a nested
         function within function $(D main$(LPAREN)$(RPAREN)).)
 
+$(H3 $(LNAME2 limitations, Limitations))
+
+    $(P Templates cannot be used to add non-static fields or
+        virtual functions to classes or interfaces.
+        For example:)
+
+        ------
+        class Foo
+        {
+            template TBar(T)
+            {
+                T xx;               // becomes a static field of Foo
+                int func(T) { ... } // non-virtual
+
+                static T yy;                        // Ok
+                static int func(T t, int y) { ... } // Ok
+            }
+        }
+        ------
+
 $(H3 $(LNAME2 implicit-nesting, Implicit Nesting))
 
     $(P If a template has a $(RELATIVE_LINK2 aliasparameters, template alias parameter),
@@ -1729,26 +1749,6 @@ $(GNAME Constraint):
         auto x = Bar!int;       // OK, int is an integral type
         auto y = Bar!double;    // Error, double does not satisfy constraint
         ---
-
-$(H2 $(LNAME2 limitations, Limitations))
-
-    $(P Templates cannot be used to add non-static fields or
-        virtual functions to classes or interfaces.
-        For example:)
-
-        ------
-        class Foo
-        {
-            template TBar(T)
-            {
-                T xx;               // becomes a static field of Foo
-                int func(T) { ... } // non-virtual
-
-                static T yy;                        // Ok
-                static int func(T t, int y) { ... } // Ok
-            }
-        }
-        ------
 
 $(SPEC_SUBNAV_PREV_NEXT operatoroverloading, Operator Overloading, template-mixin, Template Mixins)
 )


### PR DESCRIPTION
Reparent aggregate limitations section to nested templates.

In separate commit:
Make examples runnable.
Tweak wording.
Document that templates inside a struct can't introduce non-static fields (like for a class).
Extend method template example.
