### PR TITLE
posix.mak: Fix make clean recipe

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -166,7 +166,8 @@ DOC_OUTPUT_DIR:=$(PWD)/web
 W:=$(DOC_OUTPUT_DIR)
 GIT_HOME=https://github.com/dlang
 DPL_DOCS_PATH=dpl-docs
-DPL_DOCS=$(DPL_DOCS_PATH)/dpl-docs --DRT-gcopt=parallel:0
+DPL_DOCS=$(DPL_DOCS_PATH)/dpl-docs
+DPL_DOCS_FLAGS=--DRT-gcopt=parallel:0
 REMOTE_DIR=d-programming@digitalmars.com:data
 TMP?=/tmp
 GENERATED=.generated
@@ -687,20 +688,20 @@ $(PHOBOS_LIB): $(DMD)
 apidocs-prerelease : $W/library-prerelease/sitemap.xml $W/library-prerelease/.htaccess
 apidocs-latest : $W/library/sitemap.xml $W/library/.htaccess
 apidocs-serve : $G/docs-prerelease.json
-	${DPL_DOCS} serve-html --std-macros=html.ddoc --std-macros=dlang.org.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
+	${DPL_DOCS} ${DPL_DOCS_FLAGS} serve-html --std-macros=html.ddoc --std-macros=dlang.org.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
 		--override-macros=std-ddox-override.ddoc --package-order=std \
 		--git-target=master --web-file-dir=. $<
 
 $W/library-prerelease/sitemap.xml : $G/docs-prerelease.json
 	@mkdir -p $(dir $@)
-	${DPL_DOCS} generate-html --file-name-style=lowerUnderscored --std-macros=html.ddoc --std-macros=dlang.org.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
+	${DPL_DOCS} ${DPL_DOCS_FLAGS} generate-html --file-name-style=lowerUnderscored --std-macros=html.ddoc --std-macros=dlang.org.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
 		--override-macros=std-ddox-override.ddoc --package-order=std \
 		--git-target=master $(DPL_DOCS_PATH_RUN_FLAGS) \
 		$< $W/library-prerelease
 
 $W/library/sitemap.xml : $G/docs-latest.json
 	@mkdir -p $(dir $@)
-	${DPL_DOCS} generate-html --file-name-style=lowerUnderscored --std-macros=html.ddoc --std-macros=dlang.org.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
+	${DPL_DOCS} ${DPL_DOCS_FLAGS} generate-html --file-name-style=lowerUnderscored --std-macros=html.ddoc --std-macros=dlang.org.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
 		--override-macros=std-ddox-override.ddoc --package-order=std \
 		--git-target=v${LATEST} $(DPL_DOCS_PATH_RUN_FLAGS) \
 		$< $W/library
@@ -724,7 +725,7 @@ $G/docs-latest.json : ${DMD_LATEST} ${DMD_LATEST_DIR} \
 	${DMD_LATEST} -J$(DMD_LATEST_DIR)/src/dmd/res -J$(dir $(DMD_LATEST)) -c -o- -version=CoreDdoc \
 		-version=MARS -version=CoreDdoc -version=StdDdoc -Df$G/.latest-dummy.html \
 		-Xf$@ -I${PHOBOS_LATEST_DIR} @$G/.latest-files.txt
-	${DPL_DOCS} filter $@ --min-protection=Protected \
+	${DPL_DOCS} ${DPL_DOCS_FLAGS} filter $@ --min-protection=Protected \
 		--only-documented $(MOD_EXCLUDES_LATEST)
 	rm -f $G/.latest-files.txt $G/.latest-dummy.html
 
@@ -738,7 +739,7 @@ $G/docs-prerelease.json : ${DMD} ${DMD_DIR} ${DRUNTIME_DIR} | dpl-docs
 	${DMD} -J$(DMD_DIR)/res -J$(DMD_DIR)/compiler/src/dmd/res -J$(dir $(DMD)) -c -o- -version=MARS -version=CoreDdoc \
 		-version=StdDdoc -Df$G/.prerelease-dummy.html \
 		-Xf$@ -I${PHOBOS_DIR} @$G/.prerelease-files.txt
-	${DPL_DOCS} filter $@ --min-protection=Protected \
+	${DPL_DOCS} ${DPL_DOCS_FLAGS} filter $@ --min-protection=Protected \
 		--only-documented $(MOD_EXCLUDES_PRERELEASE)
 	rm -f $G/.prerelease-files.txt $G/.prerelease-dummy.html
 


### PR DESCRIPTION
Since the dmd/druntime merger in #3334, `make clean` has been broken in the dlang.org repository.