### PR TITLE
Use downloads.dlang.org for all main download links

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -247,8 +247,8 @@ Macros:
     SBTN=$(SPANC sig_btn,$(BTN $1,$+)<br>$(BTN $1.sig,sig))
     BTN=<a href="$1" class="btn">$+</a>
     H3I=<h3 class="download">$0</h3>
-    DLSITE=https://s3.us-west-2.amazonaws.com/downloads.dlang.org/releases/2022/$0
-    B_DLSITE=https://s3.us-west-2.amazonaws.com/downloads.dlang.org/pre-releases/2022/$0
+    DLSITE=https://downloads.dlang.org/releases/2022/$0
+    B_DLSITE=https://downloads.dlang.org/pre-releases/2022/$0
     DOWNLOAD =
     $(DIV,
         $(DIVC download_image, $2)

--- a/js/platform-downloads.js
+++ b/js/platform-downloads.js
@@ -30,7 +30,7 @@
     var html = '';
     for (var i = 0; i < files.length; ++i) {
         var f = files[i];
-        var url = 'https://s3.us-west-2.amazonaws.com/downloads.dlang.org/releases/2022/' + f.name + f.suffix;
+        var url = 'https://downloads.dlang.org/releases/2022/' + f.name + f.suffix;
         html += '<a href="' + url + '" class="btn action">Download ' + f.text + '</a>';
     }
     if (files.length > 1) {


### PR DESCRIPTION
This is using our new downloads bucket, the old s3 bucket is there for archive only (no longer receiving any updates).