### PR TITLE
Update changelog and downloads links to use https

### DIFF
--- a/changelog/changelog.ddoc
+++ b/changelog/changelog.ddoc
@@ -22,7 +22,7 @@ Log</option>
 VERSION=
 $(DIVC version,
 $(P
-$(B $(LARGE $(LINK2 http://downloads.dlang.org/releases/2.x/$(VER), Download D $(VER))))$(BR)
+$(B $(LARGE $(LINK2 https://downloads.dlang.org/releases/2.x/$(VER), Download D $(VER))))$(BR)
 $(SMALL released $1, $2)
 )
 $4

--- a/changelog/prerelease.ddoc
+++ b/changelog/prerelease.ddoc
@@ -1,7 +1,7 @@
 VERSION=
 $(DIVC version,
 $(P
-$(B $(LARGE $(LINK2 http://downloads.dlang.org/pre-releases/2.x/$(VER), Download D $(VER) Beta)))$(BR)
+$(B $(LARGE $(LINK2 https://downloads.dlang.org/pre-releases/2.x/$(VER), Download D $(VER) Beta)))$(BR)
 $(SMALL to be released $1, $2)
 )
 $4

--- a/download.dd
+++ b/download.dd
@@ -9,7 +9,7 @@ $(TABLEC download-compilers,
   )
   $(TR
     $(TD $(LINK2 #dmd,                                               $(IMG compiler-dmd.png)))
-    $(TD $(LINK2 http://gdcproject.org/downloads,                    $(IMG compiler-gdc.svg)))
+    $(TD $(LINK2 https://gdcproject.org/downloads,                   $(IMG compiler-gdc.svg)))
     $(TD $(LINK2 https://github.com/ldc-developers/ldc#installation, $(IMG compiler-ldc.png)))
   )
   $(TR
@@ -35,7 +35,7 @@ $(TABLEC download-compilers,
     $(TD
       $(H3 LDC)
       $(UL
-        $(LI $(LINK2 http://llvm.org/, LLVM)-based D compiler)
+        $(LI $(LINK2 https://llvm.org/, LLVM)-based D compiler)
         $(LI Strong optimization)
         $(LI
           $(LINK2 https://wiki.dlang.org/Build_D_for_Android, Android support)
@@ -49,7 +49,7 @@ $(TABLEC download-compilers,
       $(DIVC download-link, $(LINK2 dmd-windows.html, About) &middot; $(LINK2 #dmd, Download))
     )
     $(TD
-      $(DIVC download-link, $(LINK2 http://gdcproject.org/, About) &middot; $(LINK2 http://gdcproject.org/downloads, Download))
+      $(DIVC download-link, $(LINK2 https://gdcproject.org/, About) &middot; $(LINK2 https://gdcproject.org/downloads, Download))
     )
     $(TD
       $(DIVC download-link, $(LINK2 https://wiki.dlang.org/LDC, About) &middot; $(LINK2 https://github.com/ldc-developers/ldc#installation, Download))
@@ -131,7 +131,7 @@ $(DIVC download_channels,
 )
 
 $(H3
-    $(LINK2 http://downloads.dlang.org, Release Archive)
+    $(LINK2 https://downloads.dlang.org, Release Archive)
 )
 $(LINK2 gpg_keys.html, GPG keys)$(BR)
 $(LINK2 https://github.com/dlang, D on GitHub)
@@ -153,7 +153,7 @@ $(DOWNLOAD_OTHER $(NIX), $(LINK2 https://search.nixos.org/packages?show=dmd&quer
 $(LINK2 https://github.com/dukc/oldDDerivations, derivations for building various versions yourself)
 )
 
-$(DOWNLOAD_OTHER $(UBUNTU) $(DEBIAN), Ubuntu/Debian, $(LINK2 http://d-apt.sourceforge.net/, APT repository)
+$(DOWNLOAD_OTHER $(UBUNTU) $(DEBIAN), Ubuntu/Debian, $(LINK2 https://d-apt.sourceforge.net/, APT repository)
 $(CONSOLE sudo wget https://netcologne.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
 sudo apt-get update --allow-insecure-repositories
 sudo apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
@@ -188,9 +188,9 @@ $(H2 Other Downloads)
 $(UL
 $(LI $(LINK2 https://github.com/dlang/visuald/releases, VisualD - D Plugin for Visual Studio))
 
-$(LI $(LINK2 http://dlang.org/spec/spec.html, D Programming Language Specification): $(BTN https://dlang.org/dlangspec.mobi, mobi))
+$(LI $(LINK2 https://dlang.org/spec/spec.html, D Programming Language Specification): $(BTN https://dlang.org/dlangspec.mobi, mobi))
 
-$(LI $(LINK2 http://www.digitalmars.com/download/freecompiler.html, Digital Mars C and C++ Compiler Downloads))
+$(LI $(LINK2 https://www.digitalmars.com/download/freecompiler.html, Digital Mars C and C++ Compiler Downloads))
 )
 )
 


### PR DESCRIPTION
Can now use https for downloads, as the site now has a new front for its bucket.  Others redirect to https anyway.