### PR TITLE
Extract and test RUNNABLE_EXAMPLE tests including Phobos

### DIFF
--- a/spec/module.dd
+++ b/spec/module.dd
@@ -235,7 +235,6 @@ $(H3 $(LNAME2 name_lookup, Symbol Name Lookup))
 
 $(P The simplest form of importing is to just list the modules being imported:)
 
-$(RUNNABLE_EXAMPLE
 ---------
 module myapp.main;
 
@@ -251,7 +250,6 @@ class Foo : BaseClass
     }
 }
 ---------
-)
 
 $(P When a symbol name is used unqualified, a two-phase lookup is used.
 First, the module scope is searched, starting from the innermost scope.
@@ -408,7 +406,7 @@ $(H3 $(LNAME2 selective_imports, Selective Imports))
 $(P Specific symbols can be exclusively imported from a module and bound into
 the current namespace:)
 
-$(RUNNABLE_EXAMPLE
+$(SPEC_RUNNABLE_EXAMPLE_FAIL
 ---
 import std.stdio : writeln, foo = write;
 
@@ -429,7 +427,7 @@ $(H3 $(LNAME2 renamed_selective_imports, Renamed and Selective Imports))
 
 $(P When renaming and selective importing are combined:)
 
-$(RUNNABLE_EXAMPLE
+$(SPEC_RUNNABLE_EXAMPLE_FAIL
 ------------
 import io = std.stdio : foo = writeln;
 

--- a/tools/dspec_tester.d
+++ b/tools/dspec_tester.d
@@ -121,6 +121,7 @@ int main(string[] args)
         SpecType("$(SPEC_RUNNABLE_EXAMPLE_COMPILE", CompileConfig.TestMode.compile),
         SpecType("$(SPEC_RUNNABLE_EXAMPLE_RUN", CompileConfig.TestMode.run),
         SpecType("$(SPEC_RUNNABLE_EXAMPLE_FAIL", CompileConfig.TestMode.fail),
+        SpecType("$(RUNNABLE_EXAMPLE", CompileConfig.TestMode.run),
     ];
     foreach (file; specDir.dirEntries("*.dd", SpanMode.depth).parallel(1))
     {

--- a/tools/dspec_tester.d
+++ b/tools/dspec_tester.d
@@ -16,7 +16,6 @@ Author: Sebastian Wilzbach
 */
 
 import std.algorithm;
-import std.path;
 import std.stdio;
 import std.range;
 import std.regex;
@@ -90,8 +89,8 @@ int main(string[] args)
 {
     import std.file, std.getopt;
     import std.parallelism : parallel;
+    import std.path;
     import std.process : environment;
-    import std.range : chain;
     import std.typecons : Tuple;
 
     const rootDir = __FILE_FULL_PATH__.dirName.dirName;
@@ -136,7 +135,7 @@ int main(string[] args)
         if (modImport.length)
         {
             modImport = "std" ~ modImport[stdDir.length..$];
-            modImport.popBackN(2); // ".d"
+            modImport = modImport.stripExtension();
             modImport = modImport.findSplitBefore(dirSeparator ~ "package")[0];
             modImport = modImport.replace(dirSeparator, ".");
         }

--- a/tools/dspec_tester.d
+++ b/tools/dspec_tester.d
@@ -127,7 +127,7 @@ int main(string[] args)
         SpecType("$(SPEC_RUNNABLE_EXAMPLE_FAIL", CompileConfig.TestMode.fail),
         SpecType("$(RUNNABLE_EXAMPLE", CompileConfig.TestMode.run),
     ];
-    auto fnames = chain(specDir.dirEntries("_*.dd", SpanMode.depth),
+    auto fnames = chain(specDir.dirEntries("*.dd", SpanMode.depth),
         stdDir.dirEntries("*.d", SpanMode.depth));
     foreach (file; fnames.parallel(1))
     {

--- a/tools/dspec_tester.d
+++ b/tools/dspec_tester.d
@@ -202,7 +202,7 @@ auto compileAndCheck(R)(R buffer, CompileConfig config, string modImport)
     if (!buffer.find!(a => !a.isWhite).startsWith("module"))
     {
         buffer = "import std.stdio;\n" ~ buffer; // used too often
-        if (modImport)
+        if (modImport.length)
             buffer = "import " ~ modImport ~ ";" ~ buffer;
         if (!hasMain)
             buffer = "void main() {\n" ~ buffer ~ "\n}";

--- a/tools/dspec_tester.d
+++ b/tools/dspec_tester.d
@@ -127,9 +127,9 @@ int main(string[] args)
         SpecType("$(SPEC_RUNNABLE_EXAMPLE_FAIL", CompileConfig.TestMode.fail),
         SpecType("$(RUNNABLE_EXAMPLE", CompileConfig.TestMode.run),
     ];
-    auto fnames = chain(specDir.dirEntries("*.dd", SpanMode.depth),
+    auto files = chain(specDir.dirEntries("*.dd", SpanMode.depth),
         stdDir.dirEntries("*.d", SpanMode.depth));
-    foreach (file; fnames.parallel(1))
+    foreach (file; files.parallel(1))
     {
         // auto-import current module if in phobos
         string modImport = file.name.find(stdDir);


### PR DESCRIPTION
Extract & run the tests (like for dlang.org SPEC_RUNNABLE_EXAMPLE_*) to check the examples actually compile.
RUNNABLE_EXAMPLE seems to have been introduced to phobos in 2018 to std.exception. Recently I added it to std.regex, and I have a pull to add it to std.experimental.allocator: https://github.com/dlang/phobos/pull/8604.

In theory it could be used in druntime too, but as of now it isn't.

---

Depends on https://github.com/dlang/phobos/pull/8611.

Remove RUNNABLE_EXAMPLE from 1 module.dd example where it imported a module that doesn't exist.
Show path of file when printing number of examples found.