### PR TITLE
Fix Issue 23426 - Example Run button shows wrong line numbers for errors

### DIFF
--- a/js/run.js
+++ b/js/run.js
@@ -190,6 +190,7 @@ function wrapIntoMain(code) {
         var codeOut = "void main()\n{\n";
         // writing to the stdout is probably often used
         codeOut += "    import std.stdio: write, writeln, writef, writefln;\n    ";
+        codeOut += "#line 1\n";
         codeOut += code.split("\n").join("\n    ");
         codeOut += "\n}";
         return codeOut;

--- a/js/run_examples.js
+++ b/js/run_examples.js
@@ -22,6 +22,7 @@ function wrapIntoMain(code) {
     // dynamically wrap into main if needed
     if (code.indexOf("void main") >= 0) {
         codeOut = "import " + currentPackage + "; ";
+        codeOut += "#line 1\n";
         codeOut += code;
     }
     else {
@@ -29,6 +30,7 @@ function wrapIntoMain(code) {
         codeOut += "    import " + currentPackage + ";\n";
         // writing to the stdout is probably often used
         codeOut += (currentPackage == "std.file") ? "    import std.stdio: writeln, writef, writefln;\n    " : "    import std.stdio: write, writeln, writef, writefln;\n    ";
+        codeOut += "#line 1\n";
         codeOut += code.split("\n").join("\n    ");
         codeOut += "\n}";
     }


### PR DESCRIPTION
Fix JS to insert `#line 1` so the auto-inserted `import std.stdio`/`void main` don't skew the line numbers.