### PR TITLE
The `@live` feature is only active with dip1021

### DIFF
--- a/spec/ob.dd
+++ b/spec/ob.dd
@@ -4,7 +4,7 @@ $(SPEC_S Live Functions,
 
 $(HEADERNAV_TOC)
 
-$(B Experimental, Subject to Change)
+$(B Experimental, Subject to Change, use `-preview=dip1021` to activate)
 
 $(P If a memory object has only one pointer to it, that pointer is the $(I owner)
 of the memory object. With the single owner, it becomes straightforward to


### PR DESCRIPTION
After a few puzzling minutes, I finally figured out by poking at different preview options that `@live` functions only are enabled with the `-preview=dip1021` switch.

This is not mentioned *anywhere*, not in the DIP itself (which never says anything about `@live` functions), nor on this page, nor in the preview switch documentation (which says it's about Mutable function arguments), nor in the [changelog where live functions were added](https://dlang.org/changelog/2.092.0.html#ob)

Actually, that preview switch doc should be updated to say it enables live functions.