### PR TITLE
Improve equivalence

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1612,12 +1612,11 @@ with (expression)
         is semantically equivalent to:
 
 --------------
+(auto ref tmp)
 {
-    Object tmp;
-    tmp = expression;
     ...
     tmp.ident;
-}
+}(expression);
 --------------
 
         $(P Note that *Expression* only gets evaluated once and is not copied.


### PR DESCRIPTION
* Not everything is convertible to `Object`
* `with` does preserve the value category