### PR TITLE
Fix 23541 - [ImportC] dlang.org contains incorrect links

### DIFF
--- a/spec/importc.dd
+++ b/spec/importc.dd
@@ -188,7 +188,7 @@ $(H2 $(LNAME2 preprocessor, Preprocessor))
 
     $(H4 $(LNAME2 clang-preprocessor, Clang C Preprocessor))
 
-    $(P The $(LINK2 https://freecompilercamp.org/clang-basics/, Clang Preprocessor) can be invoked as:)
+    $(P The Clang Preprocessor can be invoked as:)
 
     $(CONSOLE
     clang -E file.c -o file.i
@@ -207,7 +207,7 @@ $(H2 $(LNAME2 preprocessor, Preprocessor))
 
     $(H4 $(LNAME2 dmpp, dmpp C Preprocessor))
 
-    $(P The $(LINK2 https://www.DigitalMars/dmpp, dmpp C Preprocessor) can be invoked as:)
+    $(P The $(LINK2 https://github.com/DigitalMars/dmpp, dmpp C Preprocessor) can be invoked as:)
 
     $(CONSOLE
     dmpp file.c


### PR DESCRIPTION
I couldn't find a suitable replacement link for the Clang Preprocessor, so leave it blank for now.