### PR TITLE
spec: Fix AliasAssign location in grammar

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -11,7 +11,6 @@ $(GNAME Declaration):
     $(GLINK2 function, FuncDeclaration)
     $(GLINK VarDeclarations)
     $(GLINK AliasDeclaration)
-    $(GLINK AliasAssign)
     $(GLINK AggregateDeclaration)
     $(GLINK2 enum, EnumDeclaration)
     $(GLINK2 module, ImportDeclaration)

--- a/spec/module.dd
+++ b/spec/module.dd
@@ -34,6 +34,7 @@ $(GNAME DeclDef):
     $(GLINK2 template, TemplateDeclaration)
     $(GLINK2 template-mixin, TemplateMixinDeclaration)
     $(GLINK2 template-mixin, TemplateMixin)
+    $(GLINK2 declaration, AliasAssign)
     $(GLINK MixinDeclaration)
     $(GLINK EmptyDeclaration)
 


### PR DESCRIPTION
Reference: https://github.com/CyberShadow/tree-sitter-d/issues/9

`AliasAssign` cannot be a `Declaration` because it is not allowed in the function context.

@WalterBright Could you please confirm this is correct? Thanks!