### PR TITLE
add spec/windows.dd

### DIFF
--- a/spec/ob.dd
+++ b/spec/ob.dd
@@ -303,7 +303,7 @@ $(H3 $(LNAME2 vargs, Variadic Function Arguments))
 $(P Arguments to variadic functions (such as `printf`) are considered to be consumed.
 )
 
-$(SPEC_SUBNAV_PREV importc, ImportC)
+$(SPEC_SUBNAV_PREV_NEXT importc, ImportC, windows, Windows Programming)
 )
 
 Macros:

--- a/spec/spec.dd
+++ b/spec/spec.dd
@@ -55,6 +55,7 @@ $(TOC Table of Contents,
                 $(A betterc.html, Better C),
                 $(A importc.html, Import C),
                 $(A ob.html, Live Functions)
+                $(A windows.html, Windows Programming)
         ))
 )
 

--- a/spec/windows.dd
+++ b/spec/windows.dd
@@ -1,0 +1,46 @@
+Ddoc
+
+$(SPEC_S Windows Programming,
+
+$(HEADERNAV_TOC)
+
+$(P This covers Windows programming with 32 bit OMF, 32 bit Mscoff,
+64 bit Mscoff, console programs, GUI programs, and DLLs.
+)
+
+$(H2 $(LNAME2 mscoff, Windows 32 and 64 bit MSCOFF Programs))
+
+    $(P 32 bit and 64 bit MSCOFF programs use the Microsoft Visual C/C++ compiler as the Associated
+    C Compiler, generate object files in the MSCOFF format, and use the Microsoft linker
+    to link them.
+    )
+
+$(H3 $(LNAME2 mscoff-console, Console Programs))
+
+$(H3 $(LNAME2 mscoff-windows, Windows GUI Programs))
+
+$(H3 $(LNAME2 mscoff-dlls, DLLs))
+
+$(H2 $(LNAME2 omf, Windows 32 bit OMF Programs))
+
+    $(P 32 bit OMF programs use the
+    $(LINK2 https://www.digitalmars.com/download/freecompiler.html, Digital Mars C/C++ compiler)
+    as the Associated C Compiler, generate object files in the OMF format, and use the
+    $(LINK2 https://www.digitalmars.com/ctg/optlink.html, Optlink linker)
+    to link them.
+    )
+
+$(H3 $(LNAME2 omf-console, Console Programs))
+
+$(H3 $(LNAME2 omf-windows, Windows GUI Programs))
+
+$(H3 $(LNAME2 omf-dlls, DLLs))
+
+$(SPEC_SUBNAV_PREV ob, Live Functions)
+)
+
+Macros:
+    CHAPTER=43
+        TITLE=Windows Programming
+        CATEGORY_SPEC=$0
+


### PR DESCRIPTION
The idea is to provide much better information about how Windows executables and dlls work and are constructed.

This is just a skeleton outline of the future page.