### PR TITLE
Plan release schedule for 2023

### DIFF
--- a/changelog/release-schedule.dd
+++ b/changelog/release-schedule.dd
@@ -4,24 +4,26 @@ $(D_S $(TITLE),
 
 $(UL
     $(LI New release are published every $(I two) months, on the first day of every even month.)
-    $(LI Two weeks before a new release `master` is merged into `stable` and a first beta is released.)
+    $(LI One month before a new release `master` is merged into `stable` and a first beta is released.)
     $(LI Point releases are published unscheduled when important issues or regressions get fixed.)
 )
 
-$(P The release schedule for 2022 is as follows:)
+$(P The release schedule for 2023 is as follows:)
 
     $(DIVC release-schedule,
         $(TABLE
-            $(BETA_RELEASE 2022-02-15, 2.099.0)
-            $(BETA_RELEASE 2022-03-01, 2.099.0)
-            $(BETA_RELEASE 2022-04-15, 2.100.0)
-            $(MINOR_RELEASE 2022-05-01, 2.100.0)
-            $(BETA_RELEASE 2022-07-15, 2.101.0)
-            $(MINOR_RELEASE 2022-08-01, 2.101.0)
-            $(BETA_RELEASE 2022-09-15, 2.102.0)
-            $(MINOR_RELEASE 2022-10-01, 2.102.0)
-            $(BETA_RELEASE 2022-11-15, 2.103.0)
-            $(MINOR_RELEASE 2022-12-01, 2.103.0)
+            $(BETA_RELEASE 2022-01-01, 2.102.0)
+            $(MINOR_RELEASE 2022-02-01, 2.102.0)
+            $(BETA_RELEASE 2022-03-01, 2.103.0)
+            $(MINOR_RELEASE 2022-04-01, 2.103.0)
+            $(BETA_RELEASE 2022-05-01, 2.104.0)
+            $(MINOR_RELEASE 2022-06-01, 2.104.0)
+            $(BETA_RELEASE 2022-07-01, 2.105.0)
+            $(MINOR_RELEASE 2022-08-01, 2.105.0)
+            $(BETA_RELEASE 2022-09-01, 2.106.0)
+            $(MINOR_RELEASE 2022-10-01, 2.106.0)
+            $(BETA_RELEASE 2022-11-01, 2.107.0)
+            $(MINOR_RELEASE 2022-12-01, 2.107.0)
         )
     )
 )


### PR DESCRIPTION
Nothing in 2022 went to plan, let's restart the cadence in releases from the New Year onwards.