### PR TITLE
Fix Issue 12298 - Templates can be used in mixin even when not declared as mixin template

### DIFF
--- a/spec/template-mixin.dd
+++ b/spec/template-mixin.dd
@@ -203,6 +203,26 @@ void main()
     duff_loop();  // executes foo() 10 times
 }
 ------
+
+        $(P A template declaration that is preceded by the $(D mixin) keyword
+        may only be instantiated only by being mixin-ed. A template declaration
+        that is not preceded by the $(D mixin) keyword may be both instantiated
+        normally and mixin-ed:)
+
+$(SPEC_RUNNABLE_EXAMPLE_RUN
+------
+mixin template Foo() { int foo; }
+template Bar() { int bar; }
+
+mixin Foo;  // can only be used by being mixin-ed
+mixin Bar;  // also can be mixed in
+
+void main()
+{
+    auto b = Bar!().bar;  // can instantiate normally
+ // auto c = Foo!().foo; -> error: mixin templates are not regula templates
+}
+------
 )
 
 $(H2 $(LNAME2 mixin_scope, Mixin Scope))

--- a/spec/template-mixin.dd
+++ b/spec/template-mixin.dd
@@ -205,7 +205,7 @@ void main()
 ------
 
         $(P A template declaration that is preceded by the $(D mixin) keyword
-        may only be instantiated only by being mixin-ed. A template declaration
+        may only be instantiated by being mixin-ed. A template declaration
         that is not preceded by the $(D mixin) keyword may be both instantiated
         normally and mixin-ed:)
 


### PR DESCRIPTION
I don't see any reason why this should be banned. Also, it seems that this is used extensively in dmd's testsuite. Come to think of it, I don't see why we need mixin template declarations, when we could just use normal templates.