### PR TITLE
Update download release year to 2023

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -247,8 +247,8 @@ Macros:
     SBTN=$(SPANC sig_btn,$(BTN $1,$+)<br>$(BTN $1.sig,sig))
     BTN=<a href="$1" class="btn">$+</a>
     H3I=<h3 class="download">$0</h3>
-    DLSITE=https://downloads.dlang.org/releases/2022/$0
-    B_DLSITE=https://downloads.dlang.org/pre-releases/2022/$0
+    DLSITE=https://downloads.dlang.org/releases/2023/$0
+    B_DLSITE=https://downloads.dlang.org/pre-releases/2023/$0
     DOWNLOAD =
     $(DIV,
         $(DIVC download_image, $2)


### PR DESCRIPTION
https://dlang.org/download.html currently links https://downloads.dlang.org/releases/2022/dmd_2.101.2-0_amd64.deb, which is a 404. https://downloads.dlang.org/releases/2023/dmd_2.101.2-0_amd64.deb (`s/2022/2023`) works, however.