### PR TITLE
Use release version-based paths on the downloads page

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -247,8 +247,8 @@ Macros:
     SBTN=$(SPANC sig_btn,$(BTN $1,$+)<br>$(BTN $1.sig,sig))
     BTN=<a href="$1" class="btn">$+</a>
     H3I=<h3 class="download">$0</h3>
-    DLSITE=https://downloads.dlang.org/releases/2023/$0
-    B_DLSITE=https://downloads.dlang.org/pre-releases/2023/$0
+    DLSITE=https://downloads.dlang.org/releases/2.x/$(DMDV2)/$0
+    B_DLSITE=https://downloads.dlang.org/pre-releases/2.x/$(B_DMDV2)/$0
     DOWNLOAD =
     $(DIV,
         $(DIVC download_image, $2)

--- a/js/platform-downloads.js
+++ b/js/platform-downloads.js
@@ -30,7 +30,7 @@
     var html = '';
     for (var i = 0; i < files.length; ++i) {
         var f = files[i];
-        var url = 'https://downloads.dlang.org/releases/2022/' + f.name + f.suffix;
+        var url = 'https://downloads.dlang.org/releases/2.x/' + latest + '/' + f.name + f.suffix;
         html += '<a href="' + url + '" class="btn action">Download ' + f.text + '</a>';
     }
     if (files.length > 1) {


### PR DESCRIPTION
Doing #3481, #3253,  every year is just silly.