### PR TITLE
Parallelism fixes

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -794,13 +794,13 @@ chm-nav-prerelease.json : $(DDOC) std.ddoc spec/spec.ddoc ${GENERATED}/modlist-p
 ################################################################################
 
 d-latest.tag d-tags-latest.json : tools/chmgen.d $(STABLE_DMD) $(ALL_FILES) phobos-latest druntime-latest chm-nav-latest.json
-	$(STABLE_RDMD) $< --root=$W --target latest
+	$(STABLE_RDMD) $< --root=$W --target latest --dir ${GENERATED}/chmgen-latest
 
 d-release.tag d-tags-release.json : tools/chmgen.d $(STABLE_DMD) $(ALL_FILES) phobos-release druntime-release chm-nav-release.json
-	$(STABLE_RDMD) $< --root=$W --target release
+	$(STABLE_RDMD) $< --root=$W --target release --dir ${GENERATED}/chmgen-release
 
 d-prerelease.tag d-tags-prerelease.json : tools/chmgen.d $(STABLE_DMD) $(ALL_FILES) phobos-prerelease druntime-prerelease chm-nav-prerelease.json
-	$(STABLE_RDMD) $< --root=$W --target prerelease
+	$(STABLE_RDMD) $< --root=$W --target prerelease --dir ${GENERATED}/chmgen-prerelease
 
 ################################################################################
 # Style tests

--- a/tools/chmgen.d
+++ b/tools/chmgen.d
@@ -133,7 +133,6 @@ void main(string[] args)
         "only-tags", &onlyTags,
         "root", &docRoot,
         "dir", &chmDir,
-        "pre", &prerelease,
         "target", &target,
     );
     prerelease = target == "prerelease";


### PR DESCRIPTION
Fixes which should allow building dlang.org with parallelism (`make -jN`).