### PR TITLE
Improve Ownership/Borrowing spec

### DIFF
--- a/spec/ob.dd
+++ b/spec/ob.dd
@@ -148,6 +148,19 @@ If an Owner pointer is assigned to another Owner pointer, the
 former enters the Undefined state.
 )
 
+---
+int* produce();
+void consume(int*);
+
+@live void f()
+{
+    int* p = produce(); // p is owner
+    consume(p);
+    // p is now undefined
+    //writeln(*p); // error
+}
+---
+
 $(DT Borrowed)
 
 $(DD A Borrowed pointer is one that temporarily becomes the sole pointer
@@ -155,19 +168,48 @@ to a memory object graph. It enters that state via assignment
 from an owner pointer, and stays in that state
 until its last use.
 
-A Borrowed pointer must have the `scope` attribute and must
+A Borrowed pointer must be `scope` and must
 be a pointer to mutable.
 )
+
+---
+@live void g()
+{
+    int i;
+    // borrow &i
+    int* p = &i;
+    // using &i here would end p's lifetime
+    // borrow p
+    int* q = p; // q is inferred as scope
+    // using p here would end q's lifetime
+    writeln(*q);
+    // lifetime of q ends before p is used
+    writeln(*p); // OK
+}
+---
 
 $(DT Readonly)
 
 $(DD A Readonly pointer acquires its value from an Owner.
 While the Readonly pointer is live, only Readonly pointers can
 be acquired from that Owner.
-A Readonly pointer must have the `scope` attribute and also
+A Readonly pointer must be `scope` and also
 must not be a pointer to mutable.
 )
 )
+
+---
+@live void h(scope int* p)
+{
+    const q = p;
+    const r = q;
+    // q, r are read only
+    writeln(*q); // can read q and keep r live
+    writeln(*r);
+    // using p ends all its read only pointer lifetimes
+    writeln(*p);
+}
+---
 
 $(H3 $(LNAME2 lifetime, Lifetimes))
 

--- a/spec/ob.dd
+++ b/spec/ob.dd
@@ -163,30 +163,26 @@ void consume(int*);
 
 $(DT Borrowed)
 
-$(DD A Borrowed pointer is one that temporarily becomes the sole pointer
+$(DD A Borrowed pointer is one that temporarily becomes the sole live pointer
 to a memory object graph. It enters that state via assignment
-from an owner pointer, and stays in that state
+from an owner pointer or another borrowed pointer, and stays in that state
 until its last use.
 
 A Borrowed pointer must be `scope` and must
 be a pointer to mutable.
-)
 
 ---
-@live void g()
+@live void g(scope int* p) // p is borrowed
 {
-    int i;
-    // borrow &i
-    int* p = &i;
-    // using &i here would end p's lifetime
     // borrow p
     int* q = p; // q is inferred as scope
-    // using p here would end q's lifetime
+    // <-- using p here would end q's lifetime
     writeln(*q);
     // lifetime of q ends before p is used
     writeln(*p); // OK
 }
 ---
+)
 
 $(DT Readonly)
 

--- a/spec/ob.dd
+++ b/spec/ob.dd
@@ -178,11 +178,18 @@ until its last use.
 
 A Borrowed pointer must be `scope` and must
 be a pointer to mutable.
+A mutable `scope` pointer function parameter is a Borrowed pointer.
 
 ---
+void consume(int* o); // o is owner
+void borrow(scope int* b); // b is borrowed
+
 @live void g(scope int* p) // p is borrowed
 {
-    // borrow p
+    //consume(p); // error, p is not owner
+    borrow(p);
+
+    // lend p to q
     int* q = p; // q is inferred as scope
     // <-- using p here would end q's lifetime
     writeln(*q);

--- a/spec/ob.dd
+++ b/spec/ob.dd
@@ -146,20 +146,28 @@ with an expression not derived from a tracked pointer, it is an Owner.
 
 If an Owner pointer is assigned to another Owner pointer, the
 former enters the Undefined state.
-)
 
 ---
-int* produce();
-void consume(int*);
+void consume(int* o); // o is owner
 
-@live void f()
+@live int* f(int* p) // p is owner
 {
-    int* p = produce(); // p is owner
+    writeln(*p);
+    // transfer ownership to `consume`
     consume(p);
     // p is now undefined
     //writeln(*p); // error
+
+    int* q = new int; // q is owner
+    writeln(*q);
+    p = q; // transfer ownership
+    // q is now undefined
+    //writeln(*q); // error
+    writeln(*p);
+    return p;
 }
 ---
+)
 
 $(DT Borrowed)
 

--- a/spec/ob.dd
+++ b/spec/ob.dd
@@ -66,8 +66,8 @@ $(H2 $(LNAME2 ob, Ownership/Borrowing))
 $(P Tracking the ownership status of a pointer can be safely extended by adding the
 capability of temporarilly $(I borrowing) ownership of a pointer from the $(I owner).
 The $(I owner) can no longer use the pointer as long as the $(I borrower) is still
-using the pointer value (i.e. is $(I live)). Once the $(I borrower) is no longer
-$(I live), the $(I owner) and resume using it. Only one $(I borrower) can be live
+using the pointer value (i.e. it is $(I live)). Once the $(I borrower) is no longer
+$(I live), the $(I owner) can resume using it. Only one $(I borrower) can be live
 at any point.
 )
 
@@ -76,7 +76,7 @@ pointers to read only (`const` or `immutable`) data, i.e. none of them can modif
 object(s) pointed to.
 )
 
-$(P This is collectively called an $(I Ownership/Borrowing) system. It can be state as:
+$(P This is collectively called an $(I Ownership/Borrowing) system. It can be stated as:
 )
 
 $(BLOCKQUOTE At any point in the program, for each memory object,

--- a/spec/ob.dd
+++ b/spec/ob.dd
@@ -190,26 +190,30 @@ be a pointer to mutable.
 
 $(DT Readonly)
 
-$(DD A Readonly pointer acquires its value from an Owner.
+$(DD A Readonly pointer acquires its value from an Owner or Borrowed pointer.
 While the Readonly pointer is live, only Readonly pointers can
 be acquired from that Owner.
 A Readonly pointer must be `scope` and also
 must not be a pointer to mutable.
-)
-)
 
 ---
 @live void h(scope int* p)
 {
+    // acquire 2 read only pointers
     const q = p;
     const r = q;
-    // q, r are read only
-    writeln(*q); // can read q and keep r live
+    // <-- borrowing or using p here would end q and r's lifetime
+
+    // both q and r are live
+    writeln(*q);
     writeln(*r);
     // using p ends all its read only pointer lifetimes
     writeln(*p);
+    //writeln(*q); // error
 }
 ---
+)
+)
 
 $(H3 $(LNAME2 lifetime, Lifetimes))
 

--- a/spec/ob.dd
+++ b/spec/ob.dd
@@ -6,6 +6,8 @@ $(HEADERNAV_TOC)
 
 $(B Experimental, Subject to Change, use `-preview=dip1021` to activate)
 
+$(H2 $(LNAME2 ownership, Ownership))
+
 $(P If a memory object has only one pointer to it, that pointer is the $(I owner)
 of the memory object. With the single owner, it becomes straightforward to
 manage the memory for the object. It also becomes trivial to synchronize access
@@ -61,7 +63,8 @@ $(P Functions with the `@live` attribute enable diagnosing these sorts of errors
 tracking the status of owner pointers.
 )
 
-$(H2 $(LNAME2 ob, Ownership/Borrowing))
+
+$(H2 $(LNAME2 ob, Borrowing))
 
 $(P Tracking the ownership status of a pointer can be safely extended by adding the
 capability of temporarilly $(I borrowing) ownership of a pointer from the $(I owner).
@@ -82,6 +85,9 @@ $(P This is collectively called an $(I Ownership/Borrowing) system. It can be st
 $(BLOCKQUOTE At any point in the program, for each memory object,
 there is exactly one live mutable pointer to it or all the live pointers to
 it are read-only.)
+
+
+$(H2 $(LNAME2 live, `@live` attribute))
 
 $(P Function declarations annotated with the `@live` attribute are checked for compliance with
 the Ownership/Borrowing rules. The checks are run after other semantic processing is complete.


### PR DESCRIPTION
Add ownership, `@live` headings, edit borrowing heading.
Fix typos.
A mutable scope function parameter is borrowed.
Borrowed pointer can borrow from another Borrowed pointer, not just Owner.
Change Borrowed and Readonly pointer states to say they must *be* `scope`, not *have* the scope attribute, as it can be inferred.
Readonly pointer can be from a Borrowed pointer, not just Owner.
Add 3 examples.