### PR TITLE
Fix &lt; and &gt; in C_HEADER_DESCRIPTION

### DIFF
--- a/html.ddoc
+++ b/html.ddoc
@@ -175,7 +175,7 @@ _=
 _=Generic blurb to describe C header bindings
 
 C_HEADER_DESCRIPTION = This module contains bindings to selected types and
-functions from the standard C header $(HTTP $1, $(D $(LESS)$2$(GREATER))). Note that this
+functions from the standard C header $(HTTP $1, $(D <$2>)). Note that this
 is not automatically generated, and may omit some types/functions from the
 original C header.
 _=


### PR DESCRIPTION
E.g. at top of https://dlang.org/library/core/stdc/stdlib.html:
```
from the standard C header &lt;stdlib.h&gt;.
```