### PR TITLE
Fix Issue  6583 - cast() operation not fully specified

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1145,15 +1145,31 @@ $(H4 $(LNAME2 cast_class, Class References))
     )
 
 $(H4 $(LNAME2 cast_pointers, Pointers))
-    $(P Casting a pointer)
+    $(P Casting a pointer modifies the type that will be obtained as a result of dereferencing,
+        along with the number of bytes on which the pointer arithmetic is performed.
+    )
+
+    $(P In the following example, variable val has 4 bytes and then its address is casted to char* in the ch variable.
+        Now, if ch is dereferenced, the printed value will be the character 'a' 
+        which corresponds to the integer value 97 (the least significant byte of val). If ch is incremented,
+        the printed value will be the character 'b' (the second least significant byte of val).
+    )
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
             -------------
-            int a = 353;
-            char *c = cast(char*) (&a);
-            writeln(*c);
+            int val = 25185; // 00000000 00000000 01100010 01100001
+            char *ch = cast(char*)(&val);
+
+            writeln(*ch);    // a
+            writeln(cast(int)(*ch)); // 97
+            writeln(*(ch + 1));  // b
+            writeln(cast(int)(*(ch + 1)));   // 98
             -------------
         )
+
+    $(P Here is an example of the reverse process. It will result in undefined behaviour due to the fact that 
+        the memory space following the c variables location has unknown content.
+    )
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
             -------------
@@ -1162,6 +1178,8 @@ $(H4 $(LNAME2 cast_pointers, Pointers))
             writeln(*p);
             -------------
         )
+
+    $(P The same thing can be done using a dynamically allocated array.)
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
             -------------
@@ -3022,4 +3040,3 @@ Macros:
         USUAL_ARITHMETIC_CONVERSIONS=$(DDSUBLINK spec/type, usual-arithmetic-conversions, Usual Arithmetic Conversions)
         INTEGER_PROMOTIONS=$(DDSUBLINK spec/type, integer-promotions, Integer Promotions)
         _=
-

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1150,7 +1150,7 @@ $(H4 $(LNAME2 cast_pointers, Pointers))
     )
 
     $(P In the following example, variable val has 4 bytes and then its address is casted to char* in the ch variable.
-        Now, if ch is dereferenced, the printed value will be the character 'a' 
+        Now, if ch is dereferenced, the printed value will be the character 'a'
         which corresponds to the integer value 97 (the least significant byte of val). If ch is incremented,
         the printed value will be the character 'b' (the second least significant byte of val).
     )
@@ -1167,7 +1167,7 @@ $(H4 $(LNAME2 cast_pointers, Pointers))
             -------------
         )
 
-    $(P Here is an example of the reverse process. It will result in undefined behaviour due to the fact that 
+    $(P Here is an example of the reverse process. It will result in undefined behaviour due to the fact that
         the memory space following the c variables location has unknown content.
     )
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1144,6 +1144,43 @@ $(H4 $(LNAME2 cast_class, Class References))
         (i.e. a reinterpret cast).
     )
 
+$(H4 $(LNAME2 cast_pointers, Pointers))
+    $(P Casting a pointer)
+
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
+            -------------
+            int a = 353;
+            char *c = cast(char*) (&a);
+            writeln(*c);
+            -------------
+        )
+
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
+            -------------
+            char c = 'a';
+            int *p = cast(int*) (&c);
+            writeln(*p);
+            -------------
+        )
+
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
+            -------------
+            import core.stdc.stdlib;
+
+            int *p = cast(int*) malloc(5 * int.sizeof);
+            for (int i = 0; i < 5; i++) {
+                p[i] = i + 'a';
+            }
+            // p = {97, 98, 99, 100, 101}
+
+            char* c = cast(char*) p;     // c = {97, 0, 0, 0, 98, 0, 0, 0, 99 ...}
+            for (int i = 0; i < 5 * int.sizeof; i++) {
+                writeln(c[i]);
+            }
+            -------------
+        )
+
+
 $(H4 $(LNAME2 cast_array, Arrays))
 
     $(P Casting a dynamic array to another dynamic array is done only if the
@@ -2985,3 +3022,4 @@ Macros:
         USUAL_ARITHMETIC_CONVERSIONS=$(DDSUBLINK spec/type, usual-arithmetic-conversions, Usual Arithmetic Conversions)
         INTEGER_PROMOTIONS=$(DDSUBLINK spec/type, integer-promotions, Integer Promotions)
         _=
+

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1101,21 +1101,21 @@ $(GNAME CastExpression):
         -------------
 
 $(H4 $(LNAME2 cast_basic_data_types, Basic Data Types))
-    $(P There are some cases where the $(DDSUBLINK spec/type, implicit-conversions, implicit conversion)
-        cannot be applied, so cast may be used to force the type system to accept the reinterpretation.
+    $(P For situations where $(DDSUBLINK spec/type, implicit-conversions, implicit conversions)
+        on basic types cannot be performed, the type system may be forced to accept the
+        reinterpretation of a memory region by using a cast.
     )
 
-    $(P This situation may occur, for example, when trying to assign a value stored on four bytes
-        to a variable stored on one byte. Without a cast, the following error will be displayed:
-        "cannot implicitly convert expression a of type int to byte".
+    $(P An example of such a scenario is represented by trying to store a wider type
+        into a narrower one:
     )
 
     -------------
     int a;
-    byte b = a; // error
+    byte b = a; // cannot implicitly convert expression a of type int to byte
     -------------
 
-    $(P When the destination type is smaller than the source type,
+    $(P When casting a source type that is wider than the destination type,
         the value is truncated to the destination size.
     )
 
@@ -1134,8 +1134,8 @@ $(H4 $(LNAME2 cast_basic_data_types, Basic Data Types))
             -------------
         )
 
-    $(P Casting from a narrower type to a wider type could be done automatically,
-        the sign of the value being extended to reach the required dimension.
+    $(P For integral types casting from a narrower type to a wider type
+        is done by performing sign extension.
     )
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1105,9 +1105,10 @@ $(H4 $(LNAME2 cast_basic_data_types, Basic Data Types))
         cannot be applied, so cast may be used to force the type system to accept the reinterpretation.
     )
 
-    This situation may occur, for example, when trying to assign a value stored on four bytes
-    to a variable stored on one byte. Without a cast, the following error will be displayed:
-    "cannot implicitly convert expression a of type int to byte".
+    $(P This situation may occur, for example, when trying to assign a value stored on four bytes
+        to a variable stored on one byte. Without a cast, the following error will be displayed:
+        "cannot implicitly convert expression a of type int to byte".
+    )
 
     -------------
     int a;

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1100,6 +1100,66 @@ $(GNAME CastExpression):
         (foo) - p;      // subtract p from foo
         -------------
 
+$(H4 $(LNAME2 cast_basic_data_types, Basic Data Types))
+    $(P Cast between different types of data will not be performed automatically.
+        The next operation generates the following error:
+        "cannot implicitly convert expression a of type int to byte".
+    )
+
+        -------------
+        int a;
+        byte b = a;
+        -------------
+
+    $(P In the following example, the cast operation will truncate the number.)
+
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
+            -------------
+            int a = 64389; // 00000000 00000000 11111011 10000101
+            byte b = cast(byte) a;       // 10000101
+            ubyte c = cast(ubyte) a;     // 10000101
+            short d = cast(short) a;     // 11111011 10000101
+            ushort e = cast(ushort) a;   // 11111011 10000101
+
+            writeln(b);
+            writeln(c);
+            writeln(d);
+            writeln(e);
+            -------------
+        )
+
+    $(P In this case, the sign will be extended.)
+
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
+            -------------
+            ubyte a = 133;  // 10000101
+            byte b = cast(byte)a;   // 10000101
+
+            writeln(a);
+            writeln(b);
+
+            ushort c = cast(ushort) a;  // 00000000 10000101
+            short d = cast(short)b; // 11111111 10000101
+
+            writeln(c);
+            writeln(d);
+            -------------
+        )
+
+    $(P It is also possible to cast pointers to basic data types but this operation
+        does not provide control over the obtained result.
+    )
+
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
+            -------------
+            import core.stdc.stdlib;
+
+            int *p = cast(int*) malloc(int.sizeof);
+            int a = cast(int) p;
+            writeln(a);
+            -------------
+        )
+
 $(H4 $(LNAME2 cast_class, Class References))
 
     $(P Any casting of a class reference to a
@@ -1146,13 +1206,7 @@ $(H4 $(LNAME2 cast_class, Class References))
 
 $(H4 $(LNAME2 cast_pointers, Pointers))
     $(P Casting a pointer modifies the type that will be obtained as a result of dereferencing,
-        along with the number of bytes on which the pointer arithmetic is performed.
-    )
-
-    $(P In the following example, variable val has 4 bytes and then its address is casted to char* in the ch variable.
-        Now, if ch is dereferenced, the printed value will be the character 'a'
-        which corresponds to the integer value 97 (the least significant byte of val). If ch is incremented,
-        the printed value will be the character 'b' (the second least significant byte of val).
+        along with the number of bytes on which pointer arithmetic is performed.
     )
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
@@ -1167,19 +1221,7 @@ $(H4 $(LNAME2 cast_pointers, Pointers))
             -------------
         )
 
-    $(P Here is an example of the reverse process. It will result in undefined behaviour due to the fact that
-        the memory space following the c variables location has unknown content.
-    )
-
-        $(SPEC_RUNNABLE_EXAMPLE_RUN
-            -------------
-            char c = 'a';
-            int *p = cast(int*) (&c);
-            writeln(*p);
-            -------------
-        )
-
-    $(P The same thing can be done using a dynamically allocated array.)
+    $(P The same outcome can be obtained by using a dynamically allocated array.)
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
             -------------
@@ -1195,6 +1237,18 @@ $(H4 $(LNAME2 cast_pointers, Pointers))
             for (int i = 0; i < 5 * int.sizeof; i++) {
                 writeln(c[i]);
             }
+            -------------
+        )
+
+    $(P The following code results in undefined behavior due to accessing memory
+        outside of the bounds of variable c.
+    )
+
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
+            -------------
+            char c = 'a';
+            int *p = cast(int*) (&c);
+            writeln(*p);
             -------------
         )
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1101,17 +1101,22 @@ $(GNAME CastExpression):
         -------------
 
 $(H4 $(LNAME2 cast_basic_data_types, Basic Data Types))
-    $(P Cast between different types of data will not be performed automatically.
-        The next operation generates the following error:
-        "cannot implicitly convert expression a of type int to byte".
+    $(P There are some cases where the $(DDSUBLINK spec/type, implicit-conversions, implicit conversion)
+        cannot be applied, so cast may be used to force the type system to accept the reinterpretation.
     )
+        
+    This situation may occur, for example, when trying to assign a value stored on four bytes
+    to a variable stored on one byte. Without a cast, the following error will be displayed:
+    "cannot implicitly convert expression a of type int to byte".
 
-        -------------
-        int a;
-        byte b = a;
-        -------------
+    -------------
+    int a;
+    byte b = a; // error
+    -------------
 
-    $(P In the following example, the cast operation will truncate the number.)
+    $(P When the destination type is smaller than the source type,
+        the value is truncated to the destination size.
+    )
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
             -------------
@@ -1128,35 +1133,23 @@ $(H4 $(LNAME2 cast_basic_data_types, Basic Data Types))
             -------------
         )
 
-    $(P In this case, the sign will be extended.)
-
-        $(SPEC_RUNNABLE_EXAMPLE_RUN
-            -------------
-            ubyte a = 133;  // 10000101
-            byte b = cast(byte)a;   // 10000101
-
-            writeln(a);
-            writeln(b);
-
-            ushort c = cast(ushort) a;  // 00000000 10000101
-            short d = cast(short)b; // 11111111 10000101
-
-            writeln(c);
-            writeln(d);
-            -------------
-        )
-
-    $(P It is also possible to cast pointers to basic data types but this operation
-        does not provide control over the obtained result.
+    $(P Casting from a narrower type to a wider type could be done automatically,
+        the sign of the value being extended to reach the required dimension.
     )
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
             -------------
-            import core.stdc.stdlib;
+            ubyte a = 133;  // 10000101
+            byte b = a;     // 10000101
 
-            int *p = cast(int*) malloc(int.sizeof);
-            int a = cast(int) p;
             writeln(a);
+            writeln(b);
+
+            ushort c = a;   // 00000000 10000101
+            short d = b;    // 11111111 10000101
+
+            writeln(c);
+            writeln(d);
             -------------
         )
 
@@ -1205,8 +1198,9 @@ $(H4 $(LNAME2 cast_class, Class References))
     )
 
 $(H4 $(LNAME2 cast_pointers, Pointers))
-    $(P Casting a pointer modifies the type that will be obtained as a result of dereferencing,
-        along with the number of bytes on which pointer arithmetic is performed.
+    $(P Casting a pointer variable to another pointer type modifies the value that
+        will be obtained as a result of dereferencing, along with the number of bytes
+        on which pointer arithmetic is performed.
     )
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
@@ -1221,7 +1215,10 @@ $(H4 $(LNAME2 cast_pointers, Pointers))
             -------------
         )
 
-    $(P The same outcome can be obtained by using a dynamically allocated array.)
+    $(P Similarly, when casting a dynamically allocated array to a type of smaller size,
+        the bytes of the initial array will be divided and regrouped according to the new
+        dimension.
+    )
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
             -------------
@@ -1240,8 +1237,8 @@ $(H4 $(LNAME2 cast_pointers, Pointers))
             -------------
         )
 
-    $(P The following code results in undefined behavior due to accessing memory
-        outside of the bounds of variable c.
+    $(P When casting a pointer of type A to a pointer of type B and type B is wider than type A,
+        attempts at accessing the memory exceeding the size of A will result in undefined behaviour.
     )
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
@@ -1249,6 +1246,21 @@ $(H4 $(LNAME2 cast_pointers, Pointers))
             char c = 'a';
             int *p = cast(int*) (&c);
             writeln(*p);
+            -------------
+        )
+
+    $(P It is also possible to cast pointers to basic data types.
+        A common practice could be to cast the pointer to an int value
+        and then print its address:
+    )
+
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
+            -------------
+            import core.stdc.stdlib;
+
+            int *p = cast(int*) malloc(int.sizeof);
+            int a = cast(int) p;
+            writeln(a);
             -------------
         )
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1189,9 +1189,9 @@ $(H4 $(LNAME2 cast_pointers, Pointers))
             for (int i = 0; i < 5; i++) {
                 p[i] = i + 'a';
             }
-            // p = {97, 98, 99, 100, 101}
+            // p = [97, 98, 99, 100, 101]
 
-            char* c = cast(char*) p;     // c = {97, 0, 0, 0, 98, 0, 0, 0, 99 ...}
+            char* c = cast(char*) p;     // c = [97, 0, 0, 0, 98, 0, 0, 0, 99 ...]
             for (int i = 0; i < 5 * int.sizeof; i++) {
                 writeln(c[i]);
             }

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1104,7 +1104,7 @@ $(H4 $(LNAME2 cast_basic_data_types, Basic Data Types))
     $(P There are some cases where the $(DDSUBLINK spec/type, implicit-conversions, implicit conversion)
         cannot be applied, so cast may be used to force the type system to accept the reinterpretation.
     )
-        
+
     This situation may occur, for example, when trying to assign a value stored on four bytes
     to a variable stored on one byte. Without a cast, the following error will be displayed:
     "cannot implicitly convert expression a of type int to byte".


### PR DESCRIPTION
Added some information and examples about pointers and the casting process
 https://issues.dlang.org/show_bug.cgi?id=6583