### PR TITLE
Result of pure factory function

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -533,7 +533,9 @@ $(H3 $(LNAME2 pure-factory-functions, Pure Factory Functions))
         The mutable
         references of the result similarly cannot refer to any object that
         existed before the function call.
-        This allows the result to be implicitly cast to `immutable` or `const shared`.
+        This allows the result to be implicitly cast
+        from anything to `immutable` or `const shared`,
+        and from `const shared` to (unshared) `const`.
         For example:)
 
         $(SPEC_RUNNABLE_EXAMPLE_COMPILE

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -535,7 +535,7 @@ $(H3 $(LNAME2 pure-factory-functions, Pure Factory Functions))
         existed before the function call.
         This allows the result to be implicitly cast
         from anything to `immutable` or `const shared`,
-        and from `const shared` to (unshared) `const`.
+        and from `shared` and `const shared` to (unshared) `const`.
         For example:)
 
         $(SPEC_RUNNABLE_EXAMPLE_COMPILE

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -533,7 +533,7 @@ $(H3 $(LNAME2 pure-factory-functions, Pure Factory Functions))
         The mutable
         references of the result similarly cannot refer to any object that
         existed before the function call.
-        This allows the result to be implicitly cast to `immutable`.
+        This allows the result to be implicitly cast to `immutable` or `const shared`.
         For example:)
 
         $(SPEC_RUNNABLE_EXAMPLE_COMPILE

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -533,7 +533,7 @@ $(H3 $(LNAME2 pure-factory-functions, Pure Factory Functions))
         The mutable
         references of the result similarly cannot refer to any object that
         existed before the function call.
-        This allows the result to be implicitly cast to any qualifier.
+        This allows the result to be implicitly cast to `immutable`.
         For example:)
 
         $(SPEC_RUNNABLE_EXAMPLE_COMPILE


### PR DESCRIPTION
The result of a pure factory function can be converted to `immutable` or `const shared`, and from `shared` and `const shared` to _unshared_ `const`. It cannot be converted to “any qualifier” as the spec currently suggests:
* It cannot be converted to mutable (unless already mutable). This makes sense because a `pure` function may access `immutable` global state, which in turn could be read-only memory.
* Likewise, the result cannot be converted to `inout` because `inout` might become _mutable_ in the caller’s frame; the same argument as above applies.
* It cannot be converted from _unshared_ to `shared`, which might be a general limitation or a local limitation. I don’t really know how `shared` works or is supposed to work to judge that.

All other conversions are possible irrespective of the function being `pure`. That is not worth mentioning in section edited by this PR.

I checked all combinations of _mutable,_ `const`, `immutable`, `const shared`, and `shared`.