### PR TITLE
Fixed issue 18830 - document "new" with "scope" in @nogc Functions

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -3558,7 +3558,10 @@ $(H2 $(LNAME2 nogc-functions, No-GC Functions))
         $(LI $(DDSUBLINK spec/expression, AssocArrayLiteral, constructing an associative array))
         $(LI $(DDSUBLINK spec/expression, IndexExpression, indexing) an associative array
             $(NOTE because it may throw $(D RangeError) if the specified key is not present))
-        $(LI $(DDSUBLINK spec/expression, NewExpression, allocating an object with `new`) on the heap)
+        $(LI $(DDSUBLINK spec/expression, NewExpression, allocating an object with `new`) on the heap
+            $(NOTE `new` declarations of $(D class types) are
+            compatible with $(D @nogc) if used for $(D scope)
+            variables, as they result in allocations on the stack))
         $(LI calling functions that are not `@nogc`, unless the call is
             in a $(GLINK2 version, ConditionalStatement)
             controlled by a $(GLINK2 version, DebugCondition))
@@ -3576,6 +3579,7 @@ $(H2 $(LNAME2 nogc-functions, No-GC Functions))
                 aa["abc"];         // (6) error, indexing may allocate and throws
 
                 auto p = new int;  // (7) error, operator new allocates
+                scope auto p = new GenericClass(); // (7) Ok
                 bar();             // (8) error, bar() may allocate
                 debug bar();       // (8) Ok
             }

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -3559,9 +3559,8 @@ $(H2 $(LNAME2 nogc-functions, No-GC Functions))
         $(LI $(DDSUBLINK spec/expression, IndexExpression, indexing) an associative array
             $(NOTE because it may throw $(D RangeError) if the specified key is not present))
         $(LI $(DDSUBLINK spec/expression, NewExpression, allocating an object with `new`) on the heap
-            $(NOTE `new` declarations of $(D class types) are
-            compatible with $(D @nogc) if used for $(D scope)
-            variables, as they result in allocations on the stack))
+            $(NOTE `new` declarations of $(D class types) in function scopes are compatible with
+            $(D @nogc) if used for $(D scope) variables, as they result in allocations on the stack))
         $(LI calling functions that are not `@nogc`, unless the call is
             in a $(GLINK2 version, ConditionalStatement)
             controlled by a $(GLINK2 version, DebugCondition))


### PR DESCRIPTION
Added documentation for allowance of "new" in `@nogc` functions.