### PR TITLE
Remove -dip1000 note from scope function section

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1747,8 +1747,6 @@ $(H3 $(LNAME2 scope-parameters, Scope Parameters))
     (e.g. by being assigned to a global variable). It has no effect for non-reference types.
     `scope` escape analysis is only done for `@safe` functions. For other functions `scope`
     semantics must be manually enforced.)
-    $(NOTE `scope` escape analysis is currently only done by the `dmd` compiler
-    when the `-dip1000` switch is passed.)
 
 ---
 @safe:


### PR DESCRIPTION
-dip1000 was enabled by default, so this note is no longer relevant