### PR TITLE
circleci: Increase memory allocated to the CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
     working_directory: ~/dlang.org
     docker:
       - image: cimg/base:current-20.04
+    resource_class: medium+
     parallelism: 1
     steps:
       - checkout


### PR DESCRIPTION
We're now hitting 100%, or coming dangerously near to it.

For example, this the resource usage of a succeeding build: https://app.circleci.com/pipelines/github/dlang/dlang.org/2487/workflows/ffc63ff4-3650-48ef-a419-ac05c7f15599/jobs/4987/resources

It's now a coin toss whether we start swapping and get killed or succeed now.

This is the same commit, but the pipeline instead failed: https://app.circleci.com/pipelines/github/dlang/dlang.org/2488/workflows/c1b19d21-2e6c-412c-97b9-4c79cc6cebb6/jobs/4988/resources

By default the containers we're given are a "medium" resource class - 2 vCPUs, 4GB RAM.  The medium+ resource class gives us 3 vCPUs, 6GB RAM.