### PR TITLE
Donation page overhaul

### DIFF
--- a/foundation/donate.dd
+++ b/foundation/donate.dd
@@ -18,7 +18,7 @@ $(UL
     $(LI organizes the yearly $(HTTP dconf.org, DConf), the international annual conference of D Language developers and users.)
     $(LI pays for hardware costs
         (e.g. this website, $(LINK2 http://dlang.org/download.html, dmd downloads),
-        the $(LINK2 https://tour.dlang.org, D tour) and more))
+        the $(LINK2 https://tour.dlang.org, D tour) and more).)
     $(LI is an accepted Google Summer of Code (GSOC) organization, with projects hosted during
         $(HTTPS summerofcode.withgoogle.com/archive/2016/organizations/4688223091556352/, GSOC 2016) and
         $(HTTPS summerofcode.withgoogle.com/archive/2019/organizations/6223494952517632/, GSOC 2019).
@@ -36,107 +36,21 @@ enables the D Language Foundation to fulfill its mission.)
 
 $(H3 How will my donation be used?)
 
-$(P $(B The General Fund) supports all of the D Language Foundation's regular
-operations (DConf expenses, part-time workers, blog post bounties, etc.), and is
-sometimes used to seed new initiatives. One of the important ways we make use of
-the General Fund is $(LINK2
+$(P Donations go toward supporting the D Language Foundation's regular, non-sponsored
+operations (DConf expenses, part-time workers, blog post bounties, reimbursements, etc.).
+One of the important ways we make use of donations is $(LINK2
 http://dlang.org/blog/2016/12/05/the-d-language-foundations-scholarship-program,
 in awarding scholarships) to highly skilled students. Each $(DOLLAR)5 you donate
 contributes to approximately one hour of work by a talented graduate student,
 and these hours add quickly toward important projects that further the state of
 the art in the D programming language.)
 
-$(P If you want to support us and have no particular project you'd like your
-donation to be directed toward, then your money is best aimed at the General
-Fund where we'll use it as we need it. You may donate to the General Fund via
-$(HTTPS www.flipcause.com/secure/cause_pdetails/NDMzMzE=, our targeted Flipcause
-campaign) or via any of the other donation methods listed further down this page
-(the General Fund is the default with these methods when you leave no comments
-directing us where to target the donation).)
-
-$(P $(B The Human Resource Fund for D Ecoystem Tasks) is earmarked for contract
-work to complete important tasks in the D ecosystem that are too complex for a
-simple bounty. For example, it has been used to fund work on Android support in
-the LDC D compiler and to port DRuntime to WebASM. We will have more work to
-fund in the future, so we welcome $(HTTPS
-/www.flipcause.com/secure/cause_pdetails/NTUxOTc=, all donations to this fund)
-to support that future work.)
-
-$(P $(B The Task Bounty system) allows any donation to be targeted specifically
-toward increasing an existing bounty or seeding a new one. Visit the $(HTTPS
-www.flipcause.com/secure/cause_pdetails/NjI2Njg=, Task Bounties page) to see
-the list of currently available bounties. Click on any of the cards to increase
-the bounty for a specific task. The first card in the list is the "Task Bounty
-Catch-All". Clicking this allows you to:
-
-$(UL
-    $(LI increase multiple bounties at once: enter the total you'd like to
-    donate and leave a note decribing how it is to be dispersed among which
-    bounties.)
-    $(LI seed a new bounty: enter the amount you'd like to donate and
-    leave a comment specifying a Bugzilla issue number; if it is a more complex
-    task for which there is no Bugzilla issue number, please idicate it as
-    such in your comment and someone will be in touch with you for the details.)
-))
-
-$(P You may $(HTTPS dlang.org/blog/2019/08/17/bug-bounties-have-arrived/, read
-more about Task Bounties) at the D Blog.)
-
-$(P If you have a specific target or project that you wish to directly support
-and you feel it does not fit well into our Task Bounty system, please $(LINK2
-mailto:foundation@dlang.org, contact the D Language Foundation).)
-
 $(H3 How can I donate?)
-
-$(P Of the following methods of donating to the D Language Foundation, Flipcause
-is the only one that allows you to directly target your donation at any of our
-specific funds or initiatives. But you can still do so with any of the other
-approaches by either leaving us a note in the provided comment field or, where
-no comment field is available, $(LINK2 mailto:social@dlang.org, emailing us to
-let us know.))
-
-$(DONATE_ITEM Donate through Flipcause, users,
-
-    Flipcause helps non-profit organizations like the D Language Foundation manage their
-    donations and provide more value to donors. Donating through Flipcause can enable us
-    to more efficiently put your donation to use. You can choose to donate to our General
-    Fund or to a specific campaign. Click on one of the images below to visit a campaign
-    site for the details.
-    $(BR)$(BR)
-    If you have trouble donating through Flipcause or would simply prefer another supported
-    payment processor, you can still contribute to one of the campaigns through the other
-    options on this page. Please be sure to leave a note with the donation telling us which
-    campaign you'd like the funds to go to!
-    $(BR)$(BR)
-
-    $(TABLE
-        $(TR
-        $(TD <a href="https://www.flipcause.com/secure/cause_pdetails/NTUxOTc=">
-                <img src="$(ROOT_DIR)images/campaign-hr.png"></a>)
-        $(TD <a href="https://www.flipcause.com/secure/cause_pdetails/NDMzMzE=">
-                <img src="$(ROOT_DIR)images/campaign-general.png"></a>)
-        $(TD <a href="https://www.flipcause.com/secure/cause_pdetails/NjI2Njg=">
-                <img src="$(ROOT_DIR)images/campaign-bounties.png"></a>)
-        )
-    )
-)
-
-$(DONATE_ITEM Donate through OpenCollective, users,
-
-    Make a $(I transparent) donation and select the package you're comfortable with. If
-    you want the money to be directed toward a specific campaign, task, or bounty, please be sure to leave
-    a note letting us know!
-    $(BR) $(BR)
-
-<a href="https://opencollective.com/dlang" target="_blank">
-  <img src="https://opencollective.com/dlang/donate/button@2x.png?color=blue" width=250 />
-</a>
-)
 
 $(DONATE_ITEM Donate through PayPal, paypal,
 
     Click the yellow Donate button to make a donation to the D Language Foundation via PayPal. If
-    you want the money to be directed toward a specific campaign, task, or bounty, please be sure to leave
+    you want the money to be directed toward a specific campaign, project, task, or bounty, please be sure to leave
     a note letting us know!
     $(BR) $(BR)
 
@@ -146,6 +60,18 @@ $(DONATE_ITEM Donate through PayPal, paypal,
     <input type="image" src="https://www.paypal.com/en_US/i/btn/btn_donate_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Donate" />
     <img alt="" border="0" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1" />
     </form>
+)
+
+$(DONATE_ITEM Donate through OpenCollective, users,
+
+    Make a $(I transparent) donation and select the package you're comfortable with. If
+    you want the money to be directed toward a specific campaign, project, task, or bounty, please be sure to leave
+    a note letting us know!
+    $(BR) $(BR)
+
+<a href="https://opencollective.com/dlang" target="_blank">
+  <img src="https://opencollective.com/dlang/donate/button@2x.png?color=blue" width=250 />
+</a>
 )
 
 $(DONATE_ITEM Donate by credit card, credit-card,


### PR DESCRIPTION
Our Flipcause account is no more. This removes all references to it and reworks the text somewhat.