### PR TITLE
[spec/template] Tweak typed alias parameter example

### DIFF
--- a/spec/template.dd
+++ b/spec/template.dd
@@ -803,14 +803,18 @@ $(H4 $(LNAME2 typed_alias_op, Typed Alias Parameters))
     $(P Alias parameters can also be typed.
         These parameters will accept symbols of that type:)
 
+        $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ------
-        template Foo(alias int x) { }
-        int x;
-        float f;
+        template Foo(alias int p) { alias a = p; }
 
-        Foo!x;  // ok
-        Foo!f;  // fails to instantiate
+        int i = 0;
+        Foo!i.a++;  // ok
+        assert(i == 1);
+
+        float f;
+        //Foo!f;  // fails to instantiate
         ------
+        )
 
 $(H4 $(LNAME2 alias_parameter_specialization, Specialization))
 


### PR DESCRIPTION
Show that the parameter can still behave as a variable alias, it's more capable than just a value parameter.