### PR TITLE
[spec/expression] Improve this & super docs

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -374,6 +374,8 @@ $(GNAME Constructor):
         }
         ------
 
+$(H3 $(LNAME2 base-construction, Base Class Construction))
+
         $(P Base class construction is done by calling the base class
         constructor by the name $(D super):)
 
@@ -1270,7 +1272,7 @@ $(P
         Member functions declared as abstract can still have function
         bodies. This is so that even though they must be overridden,
         they can still provide $(SINGLEQUOTE base class functionality),
-        e.g. through $(D super.foo()) in a derived class.
+        e.g. through $(DDSUBLINK spec/expression, super, $(D super.foo())) in a derived class.
         Note that the class is still abstract and cannot be instantiated directly.
 )
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1758,7 +1758,7 @@ $(H3 $(LNAME2 identifier, .Identifier))
 
 $(H3 $(LNAME2 this, this))
 
-    $(P Within a non-static member function, $(D this) resolves to
+    $(P Within a constructor or non-static member function, $(D this) resolves to
         a reference to the object for which the function was called.
     )
     $(P `typeof(this)` is valid anywhere inside an aggregate type
@@ -1766,13 +1766,14 @@ $(H3 $(LNAME2 this, this))
         If a class member function is called with an explicit reference
         to $(D typeof(this)), a non-virtual call is made:)
 
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
         -------------
         class A
         {
             char get() { return 'A'; }
 
-            char foo() { return typeof(this).get(); }
-            char bar() { return this.get(); }
+            char foo() { return typeof(this).get(); } // calls `A.get`
+            char bar() { return this.get(); } // dynamic, same as just `get()`
         }
 
         class B : A
@@ -1788,16 +1789,18 @@ $(H3 $(LNAME2 this, this))
             assert(b.bar() == 'B');
         }
         -------------
+        )
 
     $(P Assignment to $(D this) is not allowed for classes.)
+    $(P See also:)
+    * $(DDSUBLINK spec/class, delegating-constructors, Delegating Constructors)
+    * $(DDSUBLINK spec/template, template_this_parameter, template `this` parameters)
 
 $(H3 $(LNAME2 super, super))
 
     $(P $(D super) is identical to $(D this), except that it is
         cast to $(D this)'s base class.
         It is an error if there is no base class.
-        It is an error to use the $(D super) reference outside a non-static class member function,
-        or inside a member function of a class without a base class.
         (The only `extern(D)` class without a base class is `Object`,
         however, note that `extern(C++)` classes have no base class unless specified.)
         If a member function is called with an explicit reference
@@ -1805,6 +1808,7 @@ $(H3 $(LNAME2 super, super))
     )
 
     $(P Assignment to $(D super) is not allowed.)
+    $(P See also: $(DDSUBLINK spec/class, base-construction, Base Class Construction).)
 
 $(H3 $(LNAME2 null, null))
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1761,8 +1761,8 @@ $(H3 $(LNAME2 this, this))
     $(P Within a constructor or non-static member function, $(D this) resolves to
         a reference to the object for which the function was called.
     )
-    $(P `typeof(this)` is valid anywhere inside an aggregate type
-        definition.
+    $(P $(DDSUBLINK spec/type, typeof-this, `typeof(this)`) is valid anywhere
+        inside an aggregate type definition.
         If a class member function is called with an explicit reference
         to $(D typeof(this)), a non-virtual call is made:)
 

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -642,17 +642,16 @@ $(GNAME Typeof):
 
         $(P Special cases: )
     $(OL
-        $(LI $(D typeof(this)) will generate the type of what $(D this)
+        $(LI $(D typeof(return)) will, when inside a function scope,
+        give the return type of that function.
+        )
+        $(LI $(LNAME2 typeof-this, $(D typeof(this))) will generate the type of what $(D this)
         would be in a non-static member function, even if not in a member
         function.
         )
         $(LI Analogously, $(D typeof(super)) will generate the type of what
         $(D super) would be in a non-static member function.
         )
-        $(LI $(D typeof(return)) will, when inside a function scope,
-        give the return type of that function.
-        )
-    )
 
         --------------------
         class A { }
@@ -672,6 +671,7 @@ $(GNAME Typeof):
 
         typeof(this) r;   // error, no enclosing struct or class
         --------------------
+    )
 
         $(P If the expression is a $(DDSUBLINK spec/function, property-functions,
         Property Function), $(D typeof) gives its return type.


### PR DESCRIPTION
`this` can be used in constructors as well as member functions. Make example runnable.
Add see also links for this & super.
Remove sentence about using `super` outside member, this is covered by *identical to `this`* wording and it's a bit complex to repeat correctly including `typeof(super)`.

Add *Base Class Construction* subheading in class.dd.