### PR TITLE
Missing space

### DIFF
--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -477,7 +477,7 @@ $(H3 $(LNAME2 compare, Overloading $(D <), $(D <)$(D =), $(D >), and $(D >)$(D =
         $(D 0), $(ARGS $(D b.opCmp(a)) $(D >) $(D 0)))
         $(TROW $(D a) $(D <)$(D= b), $(ARGS $(D a.opCmp(b))
         $(D <)$(D= 0)), $(ARGS $(D b.opCmp(a)) $(D >)$(D = 0)))
-        $(TROW $(D a) $(D >)$(D b), $(ARGS $(D a.opCmp(b))
+        $(TROW $(D a) $(D >) $(D b), $(ARGS $(D a.opCmp(b))
         $(D >) $(D 0)), $(ARGS $(D b.opCmp(a)) $(D <) $(D 0)))
         $(TROW $(D a) $(D >)$(D = b), $(ARGS $(D a.opCmp(b))
         $(D >)$(D = 0)), $(ARGS $(D b.opCmp(a)) $(D <)$(D= 0)))


### PR DESCRIPTION
See table in row 3 first column in docs (is **a >b**):
https://dlang.org/spec/operatoroverloading.html#compare

I don't know the doc-gen but the space now matches the first row for **a < b** (4 lines above in the source file)