### PR TITLE
[spec/const3] Tweak Unique Expression conversions

### DIFF
--- a/spec/const3.dd
+++ b/spec/const3.dd
@@ -676,42 +676,44 @@ format:)
     $(TROW $(D inout shared),       $(NO),  $(NO),  $(NO),  $(YES), $(NO),  $(NO),  $(YES), $(YES), $(NO) )
     )
 
-        $(P If an implicit conversion is disallowed by the table, an $(GLINK2 expression, Expression)
-        may be converted if:
-        )
+$(H3 $(LNAME2 unique-expressions, Unique Expressions))
 
-        $(P An expression may be converted from mutable or shared to immutable if the expression
+        $(P If an implicit conversion is disallowed by the table, an $(GLINK2 expression, Expression)
+        may be implicitly converted as follows:
+        )
+        $(UL
+        $(LI From mutable or shared to immutable if the expression
         is unique and all expressions it transitively refers to are either unique or immutable.
         )
-
-        $(P An expression may be converted from mutable to shared if the expression
+        $(LI From mutable to shared if the expression
         is unique and all expressions it transitively refers to are either unique, immutable,
         or shared.
         )
-
-        $(P An expression may be converted from immutable to mutable if the expression
-        is unique.
+        $(LI From immutable to mutable if the expression is unique.
         )
-
-        $(P An expression may be converted from shared to mutable if the expression
-        is unique.
+        $(LI From shared to mutable if the expression is unique.
+        )
         )
 
         $(P A $(I Unique Expression) is one for which there are no other references to the
         value of the expression and all expressions it transitively refers to are either
         also unique or are immutable. For example:)
+
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 void main()
 {
     immutable int** p = new int*(null); // ok, unique
 
     int x;
-    immutable int** q = new int*(&x); // error, there may be other references to x
+    //immutable int** q = new int*(&x); // error, there may be other references to x
 
     immutable int y;
     immutable int** r = new immutable(int)*(&y); // ok, y is immutable
 }
 ---
+)
+        $(P See also: $(DDSUBLINK spec/function, pure-factory-functions, Pure Factory Functions).)
 
         $(P Otherwise, a $(GLINK2 expression, CastExpression) can be used to force a conversion
         when an implicit version is disallowed, but this cannot be done in $(D @safe) code,


### PR DESCRIPTION
Add subheading with anchor.
Use list to group unique conversions.
Make example runnable.
Link to pure factory functions.