### PR TITLE
Fix Issue 23807 - FunctionLiteral spec should not use Parameters

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2056,10 +2056,24 @@ $(GNAME FunctionLiteral):
     $(IDENTIFIER) $(D =>) $(GLINK AssignExpression)
 
 $(GNAME ParameterWithAttributes):
-    $(GLINK2 function, Parameters) $(GLINK2 function, FunctionAttributes)$(OPT)
+    $(I FunctionLiteralParameters) $(GLINK2 function, FunctionAttributes)$(OPT)
 
 $(GNAME ParameterWithMemberAttributes):
-    $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT)
+    $(I FunctionLiteralParameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT)
+
+$(GNAME FunctionLiteralParameters):
+    `(` $(I FunctionLiteralParameterList)$(OPT) `)`
+
+$(GNAME FunctionLiteralParameterList):
+    $(I FunctionLiteralParameter)
+    $(I FunctionLiteralParameter), $(I FunctionLiteralParameterList)$(OPT)
+    $(GLINK2 function, VariadicArgumentsAttributes)$(OPT) $(D ...)
+
+$(GNAME FunctionLiteralParameter):
+    $(GLINK2 function, ParameterAttributes)$(OPT) $(GLINK2 type, FundamentalType)
+    $(GLINK2 function, ParameterAttributes)$(OPT) $(GLINK2 type, BasicType)$(OPT) $(GLINK2 declaration, Declarator)
+    $(GLINK2 function, ParameterAttributes)$(OPT) $(GLINK2 type, BasicType)$(OPT) $(GLINK2 declaration, Declarator) $(D ...)
+    $(GLINK2 function, ParameterAttributes)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator) $(D =) $(ASSIGNEXPRESSION)
 
 $(GNAME FunctionLiteralBody2):
     $(D =>) $(GLINK AssignExpression)
@@ -2070,16 +2084,18 @@ $(GNAME RefOrAutoRef):
     $(D auto ref)
 )
 
-    $(P $(I FunctionLiteral)s (also known as $(LNAME2 lambdas, $(I Lambdas))) enable embedding anonymous functions
+    $(P $(I FunctionLiteral)s enable embedding anonymous functions
         and anonymous delegates directly into expressions.
-        $(I Type) is the return type of the function or delegate -
+        Short function literals are known as $(LNAME2 lambdas, $(I lambdas)).
+    )
+      * $(I Type) is the return type of the function or delegate -
         if omitted it is $(RELATIVE_LINK2 lambda-return-type, inferred).
-        $(I ParameterWithAttributes) or $(I ParameterWithMemberAttributes)
+      * $(I ParameterWithAttributes) or $(I ParameterWithMemberAttributes)
         can be used to specify the parameters for the function. If these are
         omitted, the function defaults to the empty parameter list $(D ( )).
-        The type of a function literal is a
+      * Parameter types can be $(RELATIVE_LINK2 lambda-parameter-inference, omitted).
+      * The type of a function literal is a
         $(DDSUBLINK spec/function, closures, delegate or a pointer to function).
-    )
 
     $(P For example:)
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -32,8 +32,7 @@ $(GNAME Parameters):
 
 $(GNAME ParameterList):
     $(GLINK Parameter)
-    $(GLINK Parameter) $(D ,)
-    $(GLINK Parameter) $(D ,) $(GSELF ParameterList)
+    $(GLINK Parameter) $(D ,) $(GSELF ParameterList)$(OPT)
     $(GLINK VariadicArgumentsAttributes)$(OPT) $(D ...)
 
 $(GNAME Parameter):

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -784,7 +784,7 @@ $(H4 $(LNAME2 alias_value, Value Aliases))
         ------
         ))
 
-        $(LI Lambdas
+        $(LI Function Literals
         $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ------
         template Foo(alias fun)


### PR DESCRIPTION
https://dlang.org/spec/expression.html#FunctionLiteral
https://dlang.org/spec/function.html#Parameters

A literal's parameter can just be a _FundamentalType_ or `...` but in all other cases an identifier is required. This specifies the current dmd behaviour. Some test code:
```d
void main()
{
    alias Int = int;
    alias a = (const i, Int, const...) { writeln(Int); }; // Int is a variable, not a type
    alias b = (short, const int k = 1) { writeln(k); }; // removing `int` for k is an error
    a(4,3);
    b(3);
    b(3,2);
}
```

Also use list for description and add item for omitted parameter types.

function.dd: Merge two variants of _ParameterList_ grammar using OPT.