### PR TITLE
Make version drop-down arrow clickable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1706,6 +1706,7 @@ div.openInEditorButton i{
    font-family: FontAwesome;
    content: "\f0d7";
    margin-left: -15px;
+   pointer-events: none; /* propagate click */
 }
 /* Runnable-examples css -end */
 

--- a/css/style.css
+++ b/css/style.css
@@ -1700,7 +1700,7 @@ div.openInEditorButton i{
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
-    max-width: 100%;
+    max-width: 120%;
 }
 .fa-select::after {
    font-family: FontAwesome;


### PR DESCRIPTION
Otherwise only the text is clickable to show the list of options.

E.g. at the top right:
https://dlang.org/spec/expression.html
![image](https://user-images.githubusercontent.com/1107820/227518618-5513d099-5282-4db4-becd-6676e017fce8.png)
