### PR TITLE
[spec/template] Improve alias template docs

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -3037,10 +3037,11 @@ $(D is $(LPAREN)) $(I Type) $(I Identifier) $(D ==) $(I TypeSpecialization) $(D 
 )
 
         $(P
-        More complex types can be pattern matched; the
+        More complex types can be pattern matched. The
         $(I TemplateParameterList) declares symbols based on the
         parts of the pattern that are matched, analogously to the
-        way implied template parameters are matched.
+        way $(DDSUBLINK spec/template, parameters_specialization,
+        implied template parameters) are matched.
         )
 
 $(P $(B Example:) Matching a Template Instantiation))
@@ -3062,6 +3063,20 @@ $(SPEC_RUNNABLE_EXAMPLE_COMPILE
     static assert(is(Args[1] == string));
     ---
 )
+
+        $(P *Type* cannot be matched when *TypeSpecialization* is an
+        $(DDSUBLINK spec/template, alias-template, alias template) instance:
+        )
+
+        $(SPEC_RUNNABLE_EXAMPLE_COMPILE
+        ---
+        struct S(T) {}
+        alias A(T) = S!T;
+
+        static assert(is(A!int : S!T, T));
+        static assert(!is(A!int : A!T, T));
+        ---
+        )
 
 $(P $(B Example:) Matching an Associative Array)
 

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -1247,19 +1247,25 @@ $(H4 $(LNAME2 ifti-restrictions, Restrictions))
     $(P Function template type parameters that are to be implicitly
         deduced must appear in the type of at least one function parameter:)
 
+        $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ------
-        void foo(T : U*, U)(U t) { ... }
+        void foo(T : U*, U)(U t) {}
 
-        int x;
-        foo!(int*)(x);   // ok, U is deduced and T is specified explicitly
-        foo(x);         // error, only U can be deduced, not T
+        void main()
+        {
+            int x;
+            foo!(int*)(x);   // ok, U is deduced and T is specified explicitly
+            //foo(x);        // error, only U can be deduced, not T
+        }
         ------
+        )
 
         $(P When the template parameters must be deduced, the
         $(RELATIVE_LINK2 implicit_template_properties, eponymous members)
         can't rely on a $(LINK2 version.html#StaticIfCondition, `static if`)
         condition since the deduction relies on how the members are used:)
 
+        $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ------
         template foo(T)
         {
@@ -1269,10 +1275,30 @@ $(H4 $(LNAME2 ifti-restrictions, Restrictions))
 
         void main()
         {
-            foo(0); // Error: cannot deduce function from argument types
+            //foo(0); // Error: cannot deduce function from argument types
             foo!int(0); // Ok since no deduction necessary
         }
         ------
+        )
+
+        $(P IFTI does not work when the parameter type is an
+        $(RELATIVE_LINK2 alias-template, alias template) instance:
+        )
+
+        $(SPEC_RUNNABLE_EXAMPLE_COMPILE
+        ---
+        struct S(T) {}
+        alias A(T) = S!T;
+        void f(T)(A!T) {}
+
+        void main()
+        {
+            A!int v;
+            //f(v); // error
+            f!int(v); // OK
+        }
+        ---
+        )
 
 $(H4 $(LNAME2 ifti-conversions, Type Conversions))
 
@@ -1480,12 +1506,17 @@ $(H2 $(LNAME2 alias-template, Alias Templates))
         parameters:)
 
         ------
+        alias ElementType(T : T[]) = T;
         alias Sequence(TL...) = TL;
         ------
 
     It is lowered to:
 
         ------
+        template ElementType(T : T[])
+        {
+            alias ElementType = T;
+        }
         template Sequence(TL...)
         {
             alias Sequence = TL;


### PR DESCRIPTION
Add link to template parameter specialization.
`is` can't match an alias template instance _TypeSpecialization_ (see [DIP1023](https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1023.md)).
Also make 2 IFTI examples runnable.
Document that IFTI doesn't work with a parameter type that is an alias template instance.
Add ElementType alias example.