### PR TITLE
[spec/ddoc] Macros are expanded inside backticks

### DIFF
--- a/spec/ddoc.dd
+++ b/spec/ddoc.dd
@@ -499,6 +499,8 @@ $(P
     to the syntax used on GitHub, Reddit, Stack Overflow, and other websites. Both
     the opening and closing `$(BACKTICK)` character must appear on the same line to trigger this
     behavior.
+    Note that macros are still expanded inside backticks. See also
+    $(RELATIVE_LINK2 punctuation_escapes, escaping).
 )
 
 $(P


### PR DESCRIPTION
This is the behaviour of ddoc and ddox. (See https://github.com/dlang/phobos/pull/8739#issuecomment-1517971382).