### PR TITLE
[spec/statement] Move note about case frequency up

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1318,6 +1318,14 @@ switch (i)
 }
 --------------
 
+        $(P $(B Implementation Note:) The compiler's code generator may
+        assume that the case
+        statements are sorted by frequency of use, with the most frequent
+        appearing first and the least frequent last. Although this is
+        irrelevant as far as program correctness is concerned, it is of
+        performance interest.
+        )
+
 $(H3 $(LNAME2 case-range, Case Range Statement))
 
 $(GRAMMAR
@@ -1423,13 +1431,6 @@ switch (name)
         less error prone. `char`, `wchar` and `dchar` strings are allowed.
         )
 
-        $(P $(B Implementation Note:) The compiler's code generator may
-        assume that the case
-        statements are sorted by frequency of use, with the most frequent
-        appearing first and the least frequent last. Although this is
-        irrelevant as far as program correctness is concerned, it is of
-        performance interest.
-        )
 
 $(H2 $(LEGACY_LNAME2 FinalSwitchStatement, final-switch-statement, Final Switch Statement))
 


### PR DESCRIPTION
#3179 added a string switch subheading but the note applies generally to case statements.
No changes to wording.