### PR TITLE
Fix issue 23872 - Wrong example in Interfacing to C, calling `printf`

### DIFF
--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -259,13 +259,16 @@ printf("hello %.*s\n", cast(int) s.length, s.ptr);
 
 $(H3 `size_t` and `ptrdiff_t`)
 
-        $(P These use the `zd` and `dt` format specifiers respectively:
+        $(P These use the `zu` and `td` format specifiers respectively:
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 ---
-int* p, q;
-printf("size of an int is %zt, pointer difference is %td\n", int.sizeof, p - q);
+import core.stdc.stdio : printf;
+int* p = new int, q = new int;
+printf("size of an int is %zu, pointer difference is %td\n", int.sizeof, p - q);
 ---
+)
 
 $(H3 Non-Standard Format Specifiers)
 


### PR DESCRIPTION
The key part of the printf syntax relating to this example is essentially: `%{length modifier}{conversion format specifier}`. Some common examples:
* length modifiers:
  * (none) -> used for: `int`, `usinging int`
  * `l` -> used for: `long`, `unsigned long`
  * `ll` -> used for: `long long`, `unsigned long long`
  * `z` -> used for: `size_t`
  * `t` -> used for: ptrdiff_t`
* conversion specifiers:
  * `d`, `i` - signed integer integer to decimal representation
  * `u` - unsigned decimal integer to decimal representation
  * `o` -  unsigned decimal integer to octal representation
  * `x` -  unsigned decimal integer to hexadecimal representation

For reference, see: https://en.cppreference.com/w/c/io/fprintf

The issue was reported here:
https://forum.dlang.org/post/wodeaztcqwxulrfrgjvb@forum.dlang.org