### PR TITLE
[spec] Tweak function docs

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2083,16 +2083,18 @@ $(GNAME RefOrAutoRef):
     $(D auto ref)
 )
 
-    $(P $(I FunctionLiteral)s (also known as $(LNAME2 lambdas, $(I Lambdas))) enable embedding anonymous functions
+    $(P $(I FunctionLiteral)s enable embedding anonymous functions
         and anonymous delegates directly into expressions.
-        $(I Type) is the return type of the function or delegate -
+        Short function literals are known as $(LNAME2 lambdas, $(I lambdas)).
+    )
+      * $(I Type) is the return type of the function or delegate -
         if omitted it is $(RELATIVE_LINK2 lambda-return-type, inferred).
-        $(I ParameterWithAttributes) or $(I ParameterWithMemberAttributes)
+      * $(I ParameterWithAttributes) or $(I ParameterWithMemberAttributes)
         can be used to specify the parameters for the function. If these are
         omitted, the function defaults to the empty parameter list $(D ( )).
-        The type of a function literal is a
+      * Parameter types can be $(RELATIVE_LINK2 lambda-parameter-inference, omitted).
+      * The type of a function literal is a
         $(DDSUBLINK spec/function, closures, delegate or a pointer to function).
-    )
 
     $(P For example:)
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -32,8 +32,7 @@ $(GNAME Parameters):
 
 $(GNAME ParameterList):
     $(GLINK Parameter)
-    $(GLINK Parameter) $(D ,)
-    $(GLINK Parameter) $(D ,) $(GSELF ParameterList)
+    $(GLINK Parameter) $(D ,) $(GSELF ParameterList)$(OPT)
     $(GLINK VariadicArgumentsAttributes)$(OPT) $(D ...)
 
 $(GNAME Parameter):

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -784,7 +784,7 @@ $(H4 $(LNAME2 alias_value, Value Aliases))
         ------
         ))
 
-        $(LI Lambdas
+        $(LI Function Literals
         $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ------
         template Foo(alias fun)


### PR DESCRIPTION
*Short* function literals are known as lambdas.
Use list for description and add item for omitted lambda parameter types.

function.dd: Merge two variants of _ParameterList_ grammar using OPT.

template.dd: Change alias kind to function literal, (not just lambda).