### PR TITLE
Change grammar to allow builtin types as UDAs in parens

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -1012,7 +1012,7 @@ $(H2 $(LNAME2 uda, User-Defined Attributes))
 
 $(GRAMMAR
 $(GNAME UserDefinedAttribute):
-    $(D @ $(LPAREN)) $(GLINK2 expression, ArgumentList) $(D $(RPAREN))
+    $(D @ $(LPAREN)) $(GLINK2 expression, TemplateArgumentList) $(D $(RPAREN))
     $(D @) $(GLINK2 template, TemplateSingleArgument)
     $(D @) $(GLINK_LEX Identifier) $(D $(LPAREN)) $(GLINK2 expression, ArgumentList)$(OPT) $(D $(RPAREN))
     $(D @) $(GLINK2 template, TemplateInstance)


### PR DESCRIPTION
DMD supports this since https://github.com/dlang/dmd/pull/14881