### PR TITLE
Document existing behavior

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2062,8 +2062,10 @@ $(H3 $(LNAME2 function_literals, Function Literals))
 
 $(GRAMMAR
 $(GNAME FunctionLiteral):
-    $(D function) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithAttributes)$(OPT) $(GLINK FunctionLiteralBody2)
-    $(D delegate) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithMemberAttributes)$(OPT) $(GLINK FunctionLiteralBody2)
+    $(D function) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type) $(GLINK ParameterWithAttributes)$(OPT) $(GLINK FunctionLiteralBody2)
+    $(D delegate) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type) $(GLINK ParameterWithMemberAttributes)$(OPT) $(GLINK FunctionLiteralBody2)
+    $(D function) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithAttributes) $(GLINK FunctionLiteralBody2)
+    $(D delegate) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithMemberAttributes) $(GLINK FunctionLiteralBody2)
     $(GLINK RefOrAutoRef)$(OPT) $(GLINK ParameterWithMemberAttributes) $(GLINK FunctionLiteralBody2)
     $(GLINK2 statement, BlockStatement)
     $(IDENTIFIER) $(D =>) $(GLINK AssignExpression)

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2064,8 +2064,8 @@ $(GRAMMAR
 $(GNAME FunctionLiteral):
     $(D function) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type) $(GLINK ParameterWithAttributes)$(OPT) $(GLINK FunctionLiteralBody2)
     $(D delegate) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type) $(GLINK ParameterWithMemberAttributes)$(OPT) $(GLINK FunctionLiteralBody2)
-    $(D function) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithAttributes) $(GLINK FunctionLiteralBody2)
-    $(D delegate) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithMemberAttributes) $(GLINK FunctionLiteralBody2)
+    $(D function) $(GLINK RefOrAutoRef)$(OPT) $(GLINK ParameterWithAttributes) $(GLINK FunctionLiteralBody2)
+    $(D delegate) $(GLINK RefOrAutoRef)$(OPT) $(GLINK ParameterWithMemberAttributes) $(GLINK FunctionLiteralBody2)
     $(GLINK RefOrAutoRef)$(OPT) $(GLINK ParameterWithMemberAttributes) $(GLINK FunctionLiteralBody2)
     $(GLINK2 statement, BlockStatement)
     $(IDENTIFIER) $(D =>) $(GLINK AssignExpression)


### PR DESCRIPTION
In § 10.22.8 [Function Literals](https://dlang.org/spec/expression.html#function_literals), in the rules starting with `function` and `delegate`, suggest that `Type` and `ParameterWithAttributes`/​`ParameterWithMemberAttributes` are both optional, but in DMD, in fact they are not: At least one of them *must* be stated. This PR documents the current behavior.

These are allowed:
```d
auto f1 = function ()  => 1;  // Okay: No BasicType, but    ParameterWithAttributes
auto f2 = function int => 2; // Okay:    BasicType, but no ParameterWithAttributes

auto d1 = delegate ()  => 1;  // Okay: No BasicType, but    ParameterWithMemberAttributes
auto d2 = delegate int => 2; // Okay:    BasicType, but no ParameterWithMemberAttributes
```

These are rejected by DMD:
```d
auto f3 = function => 3; // Error: Neither BasicType nor ParameterWithAttributes
auto d3 = delegate => 3; // Error: Neither BasicType nor ParameterWithMemberAttributes
```

The changes in Markdown syntax:
```diff
- function RefOrAutoRef? Type? ParameterWithAttributes? FunctionLiteralBody2
- delegate RefOrAutoRef? Type? ParameterWithMemberAttributes? FunctionLiteralBody2
+ function RefOrAutoRef? Type ParameterWithAttributes? FunctionLiteralBody2
+ delegate RefOrAutoRef? Type ParameterWithMemberAttributes? FunctionLiteralBody2
+ function RefOrAutoRef? ParameterWithAttributes FunctionLiteralBody2
+ delegate RefOrAutoRef? ParameterWithMemberAttributes FunctionLiteralBody2
```