### PR TITLE
Move Template(Mixin)Declaration to Declaration in grammar

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -18,6 +18,8 @@ $(GNAME Declaration):
     $(GLINK2 version, ConditionalDeclaration)
     $(GLINK2 version, StaticForeachDeclaration)
     $(GLINK2 version, StaticAssert)
+    $(GLINK2 template, TemplateDeclaration)
+    $(GLINK2 template-mixin, TemplateMixinDeclaration)
 )
 
 $(P See also $(GLINK2 module, DeclDef).

--- a/spec/module.dd
+++ b/spec/module.dd
@@ -31,8 +31,6 @@ $(GNAME DeclDef):
     $(GLINK2 version, DebugSpecification)
     $(GLINK2 version, VersionSpecification)
     $(GLINK2 version, StaticAssert)
-    $(GLINK2 template, TemplateDeclaration)
-    $(GLINK2 template-mixin, TemplateMixinDeclaration)
     $(GLINK2 template-mixin, TemplateMixin)
     $(GLINK MixinDeclaration)
     $(GLINK EmptyDeclaration)


### PR DESCRIPTION
This allows to declare them inside functions.
For mixin templates this is supported by DMD since https://github.com/dlang/dmd/pull/14240
Declaring normal templates in functions is also supported by DMD.