### PR TITLE
Improve `return ref` examples

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1751,7 +1751,7 @@ int* pluto(ref int i) @safe
 
 int* mars(return ref int i) @safe
 {
-    return &i;  // OK with -dip1000
+    return &i;  // OK with -preview=dip1000
 }
 ---
 )
@@ -1777,7 +1777,7 @@ void main() @safe
 {
     int i;
     S s;
-    s.f(i); // OK with -dip1000, lifetime of `s` is shorter than `i`
+    s.f(i); // OK with -preview=dip1000, lifetime of `s` is shorter than `i`
     *s.p = 2;
     assert(i == 2);
 }

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1706,21 +1706,22 @@ $(H3 $(LNAME2 return-ref-parameters, Return Ref Parameters))
         returned reference will not outlive the matching argument's lifetime.
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_FAIL
 ---
 ref int identity(return ref int x) {
-  return x; // pass-through function that does nothing
+    return x; // pass-through function that does nothing
 }
 
 ref int fun() {
-  int x;
-  return identity(x); // Error: escaping reference to local variable x
+    int x;
+    return identity(x); // Error: escaping reference to local variable x
 }
 
 ref int gun(return ref int x) {
-  return identity(x); // OK
+    return identity(x); // OK
 }
 ---
-
+)
         $(P Struct non-static methods marked with the `return` attribute ensure the returned
         reference will not outlive the struct instance.
         )
@@ -1739,25 +1740,48 @@ ref int escape()
 }
 ---
 
-        $(P Returning the address of a `ref` variable is also checked.)
+        $(P Returning the address of a `ref` variable is also checked in `@safe` code.)
 
+$(SPEC_RUNNABLE_EXAMPLE_FAIL
 ---
-int* pluto(ref int i)
+int* pluto(ref int i) @safe
 {
     return &i; // error: returning &i escapes a reference to parameter i
 }
 
-int* mars(return ref int i)
+int* mars(return ref int i) @safe
 {
-    return &i;  // ok
+    return &i;  // OK with -dip1000
 }
 ---
+)
 
-$(P If the function returns `void`, and the first parameter is `ref` or `out`, then
+$(P If a function returns `void`, and the first parameter is `ref` or `out`, then
 all subsequent `return ref` parameters are considered as being assigned to
 the first parameter for lifetime checking.
 The `this` reference parameter to a struct non-static member function is
 considered the first parameter.)
+
+---
+struct S
+{
+    private int* p;
+
+    void f(return ref int i) scope @safe
+    {
+        p = &i;
+    }
+}
+
+void main() @safe
+{
+    int i;
+    S s;
+    s.f(i); // OK with -dip1000, lifetime of `s` is shorter than `i`
+    *s.p = 2;
+    assert(i == 2);
+}
+---
 
 $(P If there are multiple `return ref` parameters, the lifetime of the return
 value is the smallest lifetime of the corresponding arguments.)
@@ -1777,7 +1801,10 @@ int mercury(return ref int i)
 $(P Template functions, auto functions, nested functions and $(DDSUBLINK spec/expression, function_literals, lambdas)
  can deduce the `return` attribute.)
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
+@safe:
+
 ref int templateFunction()(ref int i)
 {
     return i; // ok
@@ -1794,10 +1821,6 @@ void uranus()
     {
         return i; // ok
     }
-}
-
-void venus()
-{
     auto lambdaFunction =
         (ref int i)
         {
@@ -1805,6 +1828,7 @@ void venus()
         };
 }
 ---
+)
 
 $(H3 $(LNAME2 scope-parameters, Scope Parameters))
 


### PR DESCRIPTION
Make some examples runnable.
Mention `@safe` is needed to check returning address of `return ref` parameter - the (now default) DIP25 is not enough.
Note -dip1000 *is* still needed to return the address of a `return ref` parameter.
Add example for void function with `return ref` parameter - this needs -dip1000 so can't be made runnable yet.

Note the example compiler is currently 2.102 which needs -dip25, so the example with the mars function errors but pluto always errors anyway so _FAIL is OK.