### PR TITLE
[articles/dll-windows] Fix missing sentences

### DIFF
--- a/articles/dll-windows.dd
+++ b/articles/dll-windows.dd
@@ -1,11 +1,11 @@
 Ddoc
 
-$(D_S $(TITLE)
+$(D_S $(TITLE),
 
 $(HEADERNAV_TOC)
 
 Windows DLLs (aka shared libraries) are a method of sharing instances of executable
-code and data between process. Although they perform the same role as shared libraries
+code and data between processes. Although they perform the same role as shared libraries
 in other systems like Linux, OSX, and FreeBSD, they are implemented quite differently.
 The information in this article is specific to Windows DLLs.
 
@@ -15,7 +15,7 @@ $(H2 Build a DLL)
 $(H3 Code for the DLL)
 
 $(OL
-$(LI Create the file myll.d:
+$(LI Create the file mydll.d:
 
 ---
 module mydll;


### PR DESCRIPTION
Otherwise article text starts after `Linux,`:
https://dlang.org/articles/dll-windows.html

Also fix 2 typos.