### PR TITLE
[trivial] [deprecate.dd] `asm @safe` is not allowed

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -1050,7 +1050,7 @@ $(H4 Corrective Action)
         ---
         void foo() @safe
         {
-            asm @safe { noop; }
+            asm @trusted { noop; }
         }
         ---
     )


### PR DESCRIPTION
As of https://github.com/dlang/dmd/pull/15192