### PR TITLE
scope does not affect operator overloading

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1295,6 +1295,8 @@ $(H2 $(LNAME2 function-overloading, Function Overloading))
 
         $(P Literals do not match $(CODE ref) or $(CODE out) parameters.)
 
+        $(P $(CODE scope) parameter storage class does not affect function overloading.)
+
         $(P If two or more functions have the same match level,
         then $(LNAME2 partial-ordering, $(I partial ordering))
         is used to disambiguate to find the best match.


### PR DESCRIPTION
This documents existing behavior. See https://issues.dlang.org/show_bug.cgi?id=23941 for discussion.