### PR TITLE
Add predefined version identifier for visionOS

### DIFF
--- a/spec/version.dd
+++ b/spec/version.dd
@@ -228,6 +228,7 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
         $(TROW $(ARGS $(D iOS)) , $(ARGS iOS))
         $(TROW $(ARGS $(D TVOS)) , $(ARGS tvOS))
         $(TROW $(ARGS $(D WatchOS)) , $(ARGS watchOS))
+        $(TROW $(ARGS $(D VisionOS)) , $(ARGS visionOS))
         $(TROW $(ARGS $(D FreeBSD)) , $(ARGS FreeBSD))
         $(TROW $(ARGS $(D OpenBSD)) , $(ARGS OpenBSD))
         $(TROW $(ARGS $(D NetBSD)) , $(ARGS NetBSD))


### PR DESCRIPTION
This is Apple's new operating system for their VR/AR device Vision Pro.

DMD PR: https://github.com/dlang/dmd/pull/15371.