### PR TITLE
[spec] Improve opCast & `opCast!bool` docs

### DIFF
--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -281,6 +281,8 @@ assert(b);
 //b = s; // error
 ---
 )
+    $(P If the return type of `opCast` differs from the *type* parameter of
+        the `cast`, then the result is implicitly converted to *type*.)
 
 $(H3 $(LNAME2 boolean_operators, Boolean Operations))
 

--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -265,12 +265,29 @@ $(H2 $(LEGACY_LNAME2 Cast, cast, Cast Operator Overloading))
         expression, except in the case of boolean operations (see next
         section).)
 
+$(SPEC_RUNNABLE_EXAMPLE_RUN
+---
+struct S
+{
+    void* mem;
+
+    bool opCast(T)()
+    if (is(T == bool)) => mem !is null;
+}
+
+S s = S(new int);
+auto b = cast(bool) s;
+assert(b);
+//b = s; // error
+---
+)
+
 $(H3 $(LNAME2 boolean_operators, Boolean Operations))
 
-        $(P Notably absent from the list of overloaded unary operators is the !
+        $(P Notably absent from the list of overloaded unary operators is the `!`
         logical negation operator. More obscurely absent is a unary operator
-        to convert to a bool result.
-        Instead, these are covered by a rewrite to:
+        to convert to a `bool` result.
+        Instead, for structs these are covered by a rewrite to:
         )
 ---
 opCast!(bool)(e)
@@ -283,10 +300,15 @@ if (e)   =>  if (e.opCast!(bool))
 if (!e)  =>  if (!e.opCast!(bool))
 ---
 
-        $(P etc., whenever a bool result is expected. This only happens, however, for
-        instances of structs. Class references are converted to bool by checking to
+        $(P and similarly for `assert(e)` and
+        $(DDSUBLINK spec/expression, logical_expressions, logical operators) used
+        on the struct instance.)
+
+        $(P This only happens, however, for
+        instances of structs. Class references are converted to `bool` by checking to
         see if the class reference is null or not.
         )
+
 
 $(H2 $(LEGACY_LNAME2 Binary, binary, Binary Operator Overloading))
 

--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -300,7 +300,7 @@ if (e)   =>  if (e.opCast!(bool))
 if (!e)  =>  if (!e.opCast!(bool))
 ---
 
-        $(P and similarly for `assert(e)` and
+        $(P and similarly for other boolean conditional expressions and
         $(DDSUBLINK spec/expression, logical_expressions, logical operators) used
         on the struct instance.)
 


### PR DESCRIPTION
Add runnable example.
Clarify when implicit cast to bool happens. This does *not* happen whenever a bool type is expected.
Mention result of `opCast` is implicitly converted to the `cast` type.