### PR TITLE
[spec/arrays] Improve vector operations docs

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -463,9 +463,9 @@ a ~= b; // a becomes the concatenation of a and b
         setting dynamic array length) for details.
         )
 
-$(H2 $(LNAME2 array-operations, Array Operations))
+$(H2 $(LNAME2 array-operations, Vector Operations))
 
-        $(P Many array operations, also known as vector operations,
+        $(P Many array operations
         can be expressed at a high level rather than as a loop.
         For example, the loop:
         )
@@ -490,16 +490,35 @@ a[] = b[] + 4;
 
         $(P A vector operation is indicated by the slice operator appearing
         as the left-hand side of an assignment or an op-assignment expression.
-        The right-hand side can be an expression consisting either of an array
-        slice of the same length and type as the left-hand side or a scalar expression
-        of the element type of the left-hand side, in any combination.
-        )
+        The right-hand side can be certain combinations of:)
 
+        * An array $(GLINK2 expression, SliceExpression) of the same length
+          and type as the left-hand side
+        * A scalar expression of the same element type as the left-hand side
+
+        $(P The following operations are supported:)
+
+        * Unary: `-`, `~`
+        * Add: `+`, `-`
+        * Mul: `*`, `/`, `%`,
+        * Bitwise: `^`, `&`, `|`
+        * Pow: `^^`
+
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 ---
-T[] a, b, c;
-...
-a[] -= (b[] + 4) * c[];
+int[3] a = 0;
+int[] b = [1, 2, 3];
+
+a[] += 10 - (b[] ^^ 2);
+assert(a == [9, 6, 1]);
 ---
+)
+
+        $(NOTE In particular, an expression using
+        $(GLINK2 expression, ConditionalExpression),
+        $(DDSUBLINK spec/expression, logical_expressions, logical expressions),
+        $(GLINK2 expression, CmpExpression),
+        concatenation `~` or a function call is *not* a vector op.)
 
         $(P The slice on the left and any slices on the right must not overlap.
         All operands are evaluated exactly once, even if the array slice
@@ -511,7 +530,7 @@ a[] -= (b[] + 4) * c[];
         An application must not depend on this order.
         )
 
-        $(P Implementation note: Many vector operations are expected
+        $(P $(B Implementation Note:) Many vector operations are expected
         to take advantage of any vector math instructions available on
         the target computer.
         )


### PR DESCRIPTION
Change title to Vector Operations, array operations is not precise enough IMO and hard to google for.
Define which operations are supported. These were found from code in `expressionsem.d`:
```d
            // Look for valid array operations
            if (exp.memset != MemorySet.blockAssign &&
                exp.e1.op == EXP.slice &&
                (isUnaArrayOp(exp.e2.op) || isBinArrayOp(exp.e2.op)))
```
(Those predicates are in `arrayop.d`).

Rewrite example & make runnable.
Add a note warning about invalid expressions for vector op.

Fixes Issue 5636 - Array ops use lexicographic comparison instead of vector-style element-wise.