### PR TITLE
[spec/declaration] Improve docs

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -6,6 +6,9 @@ $(HEADERNAV_TOC)
 
 $(H2 $(LNAME2 grammar, Grammar))
 
+$(P *Declaration* can be used inside a function body for a $(GLINK2 statement, DeclarationStatement),
+as well as outside a function as it is included in $(GLINK2 module, DeclDef).)
+
 $(GRAMMAR
 $(GNAME Declaration):
     $(GLINK2 function, FuncDeclaration)
@@ -20,10 +23,9 @@ $(GNAME Declaration):
     $(GLINK2 version, StaticAssert)
     $(GLINK2 template, TemplateDeclaration)
     $(GLINK2 template-mixin, TemplateMixinDeclaration)
+    $(GLINK2 template-mixin, TemplateMixin)
 )
 
-$(P See also $(GLINK2 module, DeclDef).
-)
 
 $(H3 $(LNAME2 aggregates, Aggregates))
 

--- a/spec/module.dd
+++ b/spec/module.dd
@@ -30,8 +30,6 @@ $(GNAME DeclDef):
     $(GLINK2 version, ConditionalDeclaration)
     $(GLINK2 version, DebugSpecification)
     $(GLINK2 version, VersionSpecification)
-    $(GLINK2 version, StaticAssert)
-    $(GLINK2 template-mixin, TemplateMixin)
     $(GLINK MixinDeclaration)
     $(GLINK EmptyDeclaration)
 
@@ -629,11 +627,11 @@ $(P Each $(GLINK2 expression, AssignExpression) in the $(I ArgumentList) is
     evaluated at compile time, and the result must be representable
     as a string.
     The resulting strings are concatenated to form a string.
-    The text contents of the string must be compilable as a valid
+    The text contents of the string must be compilable as valid
     $(GLINK DeclDefs), and is compiled as such.)
 
-$(P The content of a mixin cannot be forward referenced by other DeclDefs of
-    the same scope because it is not yet pulled in the AST.)
+$(P The content of a mixin cannot be forward referenced by other *DeclDefs* of
+    the same scope because it is not yet pulled into the AST.)
 
 ---------
 class B : A {}      // Error: undefined identifier `A`
@@ -641,7 +639,7 @@ mixin ("class A {}");
 ---------
 
 $(P Forward references may only work in function bodies because they
-    are processed after the declarations)
+    are processed after the declarations:)
 
 ---------
 void v()

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -63,11 +63,8 @@ $(GNAME NonEmptyStatementNoCaseNoDefault):
     $(GLINK2 pragma, PragmaStatement)
     $(GLINK2 version, ConditionalStatement)
     $(GLINK2 version, StaticForeachStatement)
-    $(GLINK2 version, StaticAssert)
-    $(GLINK2 template-mixin, TemplateMixin)
     $(GLINK2 module, ImportDeclaration)
 )
-
 
         $(P Any ambiguities in the grammar between $(I Statement)s and
         $(GLINK2 declaration, Declaration)s are


### PR DESCRIPTION
Explain `Declaration` is the subset of `DeclDef` allowed inside a function body.
Move TemplateMixin from DeclDef and NonEmptyStatementNoCaseNoDefault to Declaration (which they each include).
Remove StaticAssert from DeclDef as it is already included by Declaration.