### PR TITLE
These grammar sections are informative

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -3084,7 +3084,7 @@ void foo()
 
 $(H4 $(LNAME2 is-parameter-list, Parameter List Forms))
 
-$(GRAMMAR
+$(GRAMMAR_INFORMATIVE
 $(D is $(LPAREN)) $(I Type) $(D :) $(I TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))
 $(D is $(LPAREN)) $(I Type) $(D ==) $(I TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))
 $(D is $(LPAREN)) $(I Type) $(I Identifier) $(D :) $(I TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1844,7 +1844,7 @@ $(H3 $(LNAME2 null, null))
 
 $(H3 $(LNAME2 string_literals, String Literals))
 
-$(GRAMMAR
+$(GRAMMAR_INFORMATIVE
 $(GNAME StringLiteral):
     $(GLINK_LEX WysiwygString)
     $(GLINK_LEX AlternateWysiwygString)

--- a/spec/importc.dd
+++ b/spec/importc.dd
@@ -328,7 +328,7 @@ $(H2 $(LNAME2 implementation, Implementation))
 
     $(P This is described in C11 7.6.1)
 
-$(GRAMMAR
+$(GRAMMAR_INFORMATIVE
 #pragma STDC FENV_ACCESS on-off-switch
 
 on-off-switch:


### PR DESCRIPTION
In "Parameter List Forms", there is only part of a rule relevant for its particular subsection, the full rule is above at the primary section header.
The importc "FENV_ACCESS" grammar section is describing C11 grammar, not D grammar.
The expression "StringLiteral" grammar section is a redeclaration of "StringLiteral" which occurred previously in the lexer section, which seems to be the primary source.

* assuming I understand `$(GRAMMAR_INFORMATIVE` correctly