### PR TITLE
[spec] Improve string literal docs

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1846,7 +1846,9 @@ $(H3 $(LEGACY_LNAME2 StringLiteral, string_literals, String Literals))
 
     $(P See $(GLINK_LEX StringLiteral) grammar.)
 
-    $(P String literals are read-only. They can implicitly convert to any
+    $(P String literals are read-only.
+        A string literal without a $(DDSUBLINK spec/lex, string_postfix, StringPostfix)
+        can implicitly convert to any
         of the following types, which have equal weight:
     )
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1747,7 +1747,7 @@ $(GNAME PrimaryExpression):
     $(GLINK_LEX IntegerLiteral)
     $(GLINK_LEX FloatLiteral)
     $(LEGACY_LNAME2 CharacterLiteral)$(LEGACY_LNAME2 character-literal)$(GLINK_LEX CharacterLiteral)
-    $(GLINK_LEX StringLiteral)
+    $(RELATIVE_LINK2 string_literals, *StringLiteral*)
     $(GLINK ArrayLiteral)
     $(GLINK AssocArrayLiteral)
     $(GLINK FunctionLiteral)
@@ -1842,19 +1842,12 @@ $(H3 $(LNAME2 null, null))
         but no longer exact.
     )
 
-$(H3 $(LNAME2 string_literals, String Literals))
+$(H3 $(LEGACY_LNAME2 StringLiteral, string_literals, String Literals))
 
-$(GRAMMAR_INFORMATIVE
-$(GNAME StringLiteral):
-    $(GLINK_LEX WysiwygString)
-    $(GLINK_LEX AlternateWysiwygString)
-    $(GLINK_LEX DoubleQuotedString)
-    $(GLINK_LEX DelimitedString)
-    $(GLINK_LEX TokenString)
-)
+    $(P See $(GLINK_LEX StringLiteral) grammar.)
 
-    $(P String literals can implicitly convert to any
-        of the following types, they have equal weight:
+    $(P String literals are read-only. They can implicitly convert to any
+        of the following types, which have equal weight:
     )
 
     $(TABLE
@@ -1866,10 +1859,13 @@ $(GNAME StringLiteral):
         $(TROW $(D immutable(dchar)[]))
     )
 
+    $(UNDEFINED_BEHAVIOR writing to a string literal. This is not allowed in `@safe` code.)
+
     $(P By default, a string literal is typed as a dynamic array, but the element
         count is known at compile time. So all string literals can be
-        implicitly converted to static array types.)
+        implicitly converted to an immutable static array lvalue.)
 
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
         -------------
         void foo(char[2] a)
         {
@@ -1883,22 +1879,29 @@ $(GNAME StringLiteral):
 
         void main()
         {
+            foo("bc");
+            bar("bc");
+            baz("bc"); // OK, see below
+
             string str = "abc";
             foo(str[1 .. 3]);
             bar(str[1 .. 3]);
-          //baz(str[1 .. 3]); // cannot match length
+            //baz(str[1 .. 3]); // cannot match length
         }
         -------------
+        )
+    $(P See $(RELATIVE_LINK2 slice_to_static_array, Slice Conversion to Static Array).)
 
-    $(P String literals have a 0 appended to them, which makes
-        them easy to pass to C or C++ functions expecting a $(CODE const char*)
-        string.
-        The 0 is not included in the $(CODE .length) property of the
-        string literal.
+    $(P String literals have a `'\0'` appended to them, which makes
+        them easy to pass to C or C++ functions expecting a null-terminated
+        $(CODE const char*) string.
+        The `'\0'` is not included in the $(CODE .length) property of the
+        string literal, but it can be used in a conversion to a static array
+        when necessary.
     )
 
-    $(P Concatenation of string literals requires the use of the
-        `~` operator, and is resolved at compile time.
+    $(P Concatenation of string literals requires the use of
+        $(RELATIVE_LINK2 cat_expressions, the `~` operator), and is resolved at compile time.
         C style implicit concatenation without an intervening operator is
         error prone and not supported in D.)
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1865,41 +1865,38 @@ $(H3 $(LEGACY_LNAME2 StringLiteral, string_literals, String Literals))
 
     $(P By default, a string literal is typed as a dynamic array, but the element
         count is known at compile time. So all string literals can be
-        implicitly converted to an immutable static array lvalue.)
+        implicitly converted to an immutable static array:)
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
         -------------
         void foo(char[2] a)
         {
-            assert(a == "bc");
+            assert(a[0] == 'b');
         }
         void bar(ref const char[2] a)
         {
             assert(a == "bc");
         }
-        void baz(const char[3] a) {}
 
         void main()
         {
             foo("bc");
-            bar("bc");
-            baz("bc"); // OK, see below
-
-            string str = "abc";
-            foo(str[1 .. 3]);
-            bar(str[1 .. 3]);
-            //baz(str[1 .. 3]); // cannot match length
+            foo("b"); // OK
+            //foo("bcd"); // error, too many chars
+            bar("bc"); // OK, same length
+            //bar("b"); // error, lengths must match
         }
         -------------
         )
-    $(P See $(RELATIVE_LINK2 slice_to_static_array, Slice Conversion to Static Array).)
+    $(P A string literal converts to a static array rvalue of the same or longer length.
+        Any extra elements are padded with zeros. A string literal
+        can also convert to a static array lvalue of the same length.)
 
     $(P String literals have a `'\0'` appended to them, which makes
         them easy to pass to C or C++ functions expecting a null-terminated
         $(CODE const char*) string.
         The `'\0'` is not included in the $(CODE .length) property of the
-        string literal, but it can be used in a conversion to a static array
-        when necessary.
+        string literal.
     )
 
     $(P Concatenation of string literals requires the use of

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -301,10 +301,6 @@ string, a delimited string, or a token string.
 $(P In all string literal forms, an $(GLINK EndOfLine) is regarded as a single
 $(D \n) character.)
 
-$(P String literals are read only.)
-
-$(UNDEFINED_BEHAVIOR writing to a string literal. This is not allowed in `@safe` code.)
-
 $(GRAMMAR_LEX
 $(GNAME EscapeSequence):
     $(B \\')

--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -289,45 +289,16 @@ $(GNAME StringLiteral):
     $(GLINK WysiwygString)
     $(GLINK AlternateWysiwygString)
     $(GLINK DoubleQuotedString)
-
     $(GLINK DelimitedString)
     $(GLINK TokenString)
 )
 $(P
-A string literal is either a double quoted string, a wysiwyg quoted
+A string literal is either a wysiwyg quoted string, a double quoted
 string, a delimited string, or a token string.
 )
 
 $(P In all string literal forms, an $(GLINK EndOfLine) is regarded as a single
 $(D \n) character.)
-
-$(GRAMMAR_LEX
-$(GNAME EscapeSequence):
-    $(B \\')
-    $(B \\")
-    $(B \\?)
-    $(B \\\\)
-    $(B \0)
-    $(B \a)
-    $(B \b)
-    $(B \f)
-    $(B \n)
-    $(B \r)
-    $(B \t)
-    $(B \v)
-    $(B \x) $(GLINK HexDigit) $(GLINK HexDigit)
-    $(B \\) $(GLINK OctalDigit)
-    $(B \\) $(GLINK OctalDigit) $(GLINK OctalDigit)
-    $(B \\) $(GLINK OctalDigit) $(GLINK OctalDigit) $(GLINK OctalDigit)
-    $(B \u) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit)
-    $(B \U) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit)
-    $(B \\) $(GLINK2 entity, NamedCharacterEntity)
-
-$(GNAME StringPostfix):
-    $(B c)
-    $(B w)
-    $(B d)
-)
 
 $(H3 $(LNAME2 wysiwyg, Wysiwyg Strings))
 $(GRAMMAR_LEX
@@ -522,6 +493,13 @@ $(GNAME TokenStringToken):
 
 $(H3 $(LNAME2 string_postfix, String Postfix))
 
+$(GRAMMAR_LEX
+$(GNAME StringPostfix):
+    $(B c)
+    $(B w)
+    $(B d)
+)
+
         $(P The optional $(I StringPostfix) character gives a specific type
         to the string, rather than it being inferred from the context.
         The types corresponding to the postfix characters are:
@@ -547,7 +525,28 @@ $(H3 $(LNAME2 string_postfix, String Postfix))
 
 $(H2 $(LNAME2 escape_sequences, Escape Sequences))
 
-    $(P The escape sequences listed in $(GLINK EscapeSequence) are:)
+$(GRAMMAR_LEX
+$(GNAME EscapeSequence):
+    $(B \\')
+    $(B \\")
+    $(B \\?)
+    $(B \\\\)
+    $(B \0)
+    $(B \a)
+    $(B \b)
+    $(B \f)
+    $(B \n)
+    $(B \r)
+    $(B \t)
+    $(B \v)
+    $(B \x) $(GLINK HexDigit) $(GLINK HexDigit)
+    $(B \\) $(GLINK OctalDigit)
+    $(B \\) $(GLINK OctalDigit) $(GLINK OctalDigit)
+    $(B \\) $(GLINK OctalDigit) $(GLINK OctalDigit) $(GLINK OctalDigit)
+    $(B \u) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit)
+    $(B \U) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit) $(GLINK HexDigit)
+    $(B \\) $(GLINK2 entity, NamedCharacterEntity)
+)
 
     $(LONGTABLE_2COLS 0.8, Escape Sequences,
     $(THEAD Sequence, Meaning),


### PR DESCRIPTION
Link to lex _StringLiteral_ rather than repeating grammar. 
Move semantic sentences about string literals being read-only to expression.dd.
Document that StringPostfix disables implicit conversions.
Document that a string literal can convert to a static array rvalue of same or longer length or lvalue of equal length.
~~Document that the null byte can be used to convert to a static array when necessary.~~

Move EscapeSequence and StringPostfix grammar to their subheadings. 