### PR TITLE
Remove redundant grammar rules with semicolons

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -760,7 +760,6 @@ $(H2 $(LNAME2 static-constructor, Static Constructors))
 
 $(GRAMMAR
 $(GNAME StaticConstructor):
-    $(D static this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(D ;)
     $(D static this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
 )
 
@@ -855,7 +854,6 @@ $(H2 $(LNAME2 static-destructor, Static Destructors))
 
 $(GRAMMAR
 $(GNAME StaticDestructor):
-    $(D static ~ this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(D ;)
     $(D static ~ this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
 )
 
@@ -903,7 +901,6 @@ $(H2 $(LNAME2 shared_static_constructors, Shared Static Constructors))
 
 $(GRAMMAR
 $(GNAME SharedStaticConstructor):
-    $(D shared static this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(D ;)
     $(D shared static this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
 )
 
@@ -915,7 +912,6 @@ $(H2 $(LNAME2 shared_static_destructors, Shared Static Destructors))
 
 $(GRAMMAR
 $(GNAME SharedStaticDestructor):
-    $(D shared static ~ this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(D ;)
     $(D shared static ~ this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
 )
 

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -1320,7 +1320,6 @@ $(H2 $(LEGACY_LNAME2 StructPostblit, struct-postblit, Struct Postblits))
 
 $(GRAMMAR
 $(GNAME Postblit):
-    $(D this $(LPAREN) this $(RPAREN)) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(D ;)
     $(D this $(LPAREN) this $(RPAREN)) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
 )
 

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -1473,7 +1473,6 @@ $(H2 $(LNAME2 template_ctors, Template Constructors))
 
 $(GRAMMAR
 $(GNAME ConstructorTemplate):
-    $(D this) $(GLINK TemplateParameters) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(D :)
     $(D this) $(GLINK TemplateParameters) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(GLINK2 function, FunctionBody)
 )
 


### PR DESCRIPTION
FunctionBody already has MissingFunctionBody, which allows a single semicolon. ConstructorTemplate also used a colon instead of a semicolon.