### PR TITLE
[trivial] [spec] Use 'scope class instance` throughout

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -880,9 +880,9 @@ $(P
     In that case, they are inferred as $(DDSUBLINK spec/function, return-scope-parameters, Return Scope Parameters).
 )
 
-$(H3 $(LNAME2 scope-class-var, $(D scope) variables with `class` type))
+$(H3 $(LNAME2 scope-class-var, $(D scope) Class Instances))
 $(P
-        When used on variables with a `class` type, `scope` signifies the RAII
+        When used to allocate a class instance directly, a `scope` variable signifies the RAII
         (Resource Acquisition Is Initialization) protocol.
         This means that the destructor for an object is automatically called when the
         reference to it goes out of scope. The destructor is called even

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -482,7 +482,8 @@ $(H3 $(LNAME2 class-instantiation, Class Instantiation))
         A a = new A(3);
         ------
 
-        $(P A $(DDSUBLINK spec/attribute, scope-class-var, `scope` object) can be allocated on the stack.)
+        $(P A $(DDSUBLINK spec/attribute, scope-class-var, `scope` class instance)
+        is allocated on the stack.)
 
         $(P The following steps happen:)
 
@@ -704,7 +705,7 @@ $(GNAME Destructor):
 
         $(P The destructor function is called when the object
         is deleted by the garbage collector, or when a
-        $(DDSUBLINK spec/attribute, scope-class-var, `scope` object) goes out of scope.
+        $(DDSUBLINK spec/attribute, scope-class-var, `scope` class instance) goes out of scope.
         The syntax is:)
 
         ------
@@ -1024,7 +1025,7 @@ $(GNAME Invariant):
 
 $(H2 $(LNAME2 auto, Scope Classes))
 $(NOTE Scope classes have been $(DDSUBLINK deprecate, scope as a type constraint,  deprecated). See also
-$(DDSUBLINK spec/attribute, scope-class-var, `scope` objects).)
+$(DDSUBLINK spec/attribute, scope-class-var, `scope` class instances).)
 
         $(P A scope class is a class with the $(D scope) attribute, as in:)
 


### PR DESCRIPTION
Instead of 'scope object' or 'scope variable' because a reference can be `scope` without being stack allocated. The difference is the instance is *always* `scope`.