### PR TITLE
Add PANEL macro to visually group certain paragraphs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2157,3 +2157,13 @@ dt.d_decl:hover .decl_anchor {
     margin-bottom: 1em;
     padding-top: 0.5em;
 }
+
+/* Group related info together */
+.panel
+{
+    padding: 0.3em 0.6em;
+    border-radius: 5px;
+    background-color: #F5F5F5;
+    border: 1px solid #E6E6E6;
+}
+

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -337,6 +337,8 @@ $(DIVID tools, $(DIV,
 ))
 _=
 
+_=Group related info together
+PANEL=$(DIVC panel, $0)
 PC=$(TC p, $1, $+)
 _=
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2421,6 +2421,7 @@ $(GNAME AssertArguments):
     $(UNDEFINED_BEHAVIOR Once in an $(I Invalid State) the behavior of the continuing execution
     of the program is undefined.)
 
+    $(PANEL
     $(IMPLEMENTATION_DEFINED Whether the first $(I AssertExpression) is evaluated
     or not (at runtime) is typically set with a compiler switch. If it is not evaluated,
     any side effects specified by the $(I AssertExpression) may not occur.
@@ -2435,7 +2436,7 @@ $(GNAME AssertArguments):
     )
     )
 
-    $(NOTE $(D AssertError) is the default for $(B dmd), with an optional
+    $(NOTE Throwing $(D AssertError) is the default for $(B dmd), with an optional
     $(DDSUBLINK dmd, switch-checkaction, $(B -checkaction=context))
     switch to show certain sub-expressions used in the first *AssertExpression*
     in the error message:)
@@ -2444,7 +2445,8 @@ $(GNAME AssertArguments):
     auto x = 4;
     assert(x < 3);
     ---
-    $(P When in use, the above will throw an `AssertError` with a message `4 >= 3`.)
+    When in use, the above will throw an `AssertError` with a message `4 >= 3`.
+    )
 
     $(BEST_PRACTICE
     $(OL


### PR DESCRIPTION
I copied the CSS property values from already used values. The `border-radius` being 5px rather than 4px is copied from the `message-box` style. (I think the 4px value is for smaller items like buttons).

Use it for `AssertExpression` docs to group several 'implementation defined' paragraphs and an example together.
https://dlang.org/spec/expression.html#AssertExpression

![image](https://github.com/dlang/dlang.org/assets/1107820/d5157cd1-388b-4977-8684-ae397e37c499)

