### PR TITLE
Move the base of {Index,Slice}Expression into PostfixExpression

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -204,7 +204,7 @@ assert(b[1] == 2);
 ---------
 )
 
-    $(P See also $(GLINK2 expression, IndexExpression).)
+    $(P See also $(GLINK2 expression, IndexOperation).)
 
 $(H3 $(LNAME2 pointer-arithmetic, Pointer Arithmetic))
 
@@ -284,7 +284,7 @@ writeln(b[7]);      // 10
 ---------
 )
 
-    $(P See also $(GLINK2 expression, SliceExpression).)
+    $(P See also $(GLINK2 expression, SliceOperation).)
 
 
 $(H2 $(LNAME2 array-length, Array Length))
@@ -502,7 +502,7 @@ a[] = b[] + 4;
         as the left-hand side of an assignment or an op-assignment expression.
         The right-hand side can be certain combinations of:)
 
-        * An array $(GLINK2 expression, SliceExpression) of the same length
+        * An array $(GLINK2 expression, SliceOperation) of the same length
           and type as the left-hand side
         * A scalar expression of the same element type as the left-hand side
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -905,7 +905,7 @@ assert(a[2] == 4);
 ---
 )
 
-    $(P $(GLINK IndexExpression) can also be used with a pointer and has
+    $(P $(GLINK IndexOperation) can also be used with a pointer and has
     the same behaviour as adding an integer, then dereferencing the result.)
 
     $(P If the second operand is a pointer, and the first is an integral type,
@@ -1531,8 +1531,8 @@ $(GNAME PostfixExpression):
     $(GSELF PostfixExpression) $(D --)
     $(GSELF PostfixExpression) $(D $(LPAREN)) $(GLINK NamedArgumentList)$(OPT) $(D $(RPAREN))
     $(GLINK2 type, TypeCtors)$(OPT) $(GLINK2 type, BasicType) $(D $(LPAREN)) $(GLINK NamedArgumentList)$(OPT) $(D $(RPAREN))
-    $(GLINK IndexExpression)
-    $(GLINK SliceExpression)
+    $(GSELF PostfixExpression) $(GLINK IndexOperation)
+    $(GSELF PostfixExpression) $(GLINK SliceOperation)
 )
 
 $(TABLE
@@ -1546,8 +1546,8 @@ $(TABLE
     )
     $(TROW `++`, Increment after use - see $(RELATIVE_LINK2 order-of-evaluation, order of evaluation))
     $(TROW `--`, Decrement after use)
-    $(TROW *IndexExpression*, Select a single element)
-    $(TROW *SliceExpression*, Select a series of elements)
+    $(TROW *IndexOperation*, Select a single element)
+    $(TROW *SliceOperation*, Select a series of elements)
 )
 
 $(H3 $(LNAME2 argument-list, Postfix Argument Lists))
@@ -1592,15 +1592,21 @@ S s = S(1, 2);
     Uniform construction syntax for built-in scalar types))
 
 
-$(H2 $(LNAME2 index_expressions, Index Expressions))
+$(H3 $(LNAME2 index_operations, Index Operations))
 
 $(GRAMMAR
-$(GNAME IndexExpression):
-    $(GLINK PostfixExpression) $(D [) $(GLINK ArgumentList) $(D ])
+$(GNAME IndexOperation):
+    $(D [) $(GLINK ArgumentList) $(D ])
 )
 
-    $(P $(I PostfixExpression) is evaluated.
-        If $(I PostfixExpression) is an expression of static or
+    $(P The base $(I PostfixExpression) is evaluated.
+        The special variable `$` is declared and set to be the number
+        of elements in the base $(I PostfixExpression) (when available).
+        A new declaration scope is created for the evaluation of the
+        $(I ArgumentList) and `$` appears in that scope only.
+    )
+
+    $(P If the $(I PostfixExpression) is an expression of static or
         dynamic array type, the result of the indexing is an lvalue
         of the *i*th element in the array, where `i` is an integer
         evaluated from $(I ArgumentList).
@@ -1608,31 +1614,25 @@ $(GNAME IndexExpression):
         `*(p + i)` (see $(RELATIVE_LINK2 pointer_arithmetic, Pointer Arithmetic)).
     )
 
-    $(P If $(I PostfixExpression) is a $(DDSUBLINK spec/template, variadic-templates, $(I ValueSeq))
+    $(P If the base $(I PostfixExpression) is a $(DDSUBLINK spec/template, variadic-templates, $(I ValueSeq))
         then the $(I ArgumentList) must consist of only one argument,
         and that must be statically evaluatable to an integral constant.
         That integral constant $(I n) then selects the $(I n)th
         expression in the $(I ValueSeq), which is the result
-        of the $(I IndexExpression).
+        of the $(I IndexOperation).
         It is an error if $(I n) is out of bounds of the $(I ValueSeq).
-    )
-
-    $(P The special variable `$` is declared and set to be the number
-        of elements in the $(I PostfixExpression) (when available).
-        A new declaration scope is created for the evaluation of the
-        $(I ArgumentList) and `$` appears in that scope only.
     )
 
     $(P The index operator can be $(DDSUBLINK spec/operatoroverloading, array, overloaded).
         Using multiple indices in *ArgumentList* is only supported for operator
         overloading.)
 
-$(H2 $(LNAME2 slice_expressions, Slice Expressions))
+$(H3 $(LNAME2 slice_operations, Slice Operations))
 
 $(GRAMMAR
-$(GNAME SliceExpression):
-    $(GLINK PostfixExpression) $(D [ ])
-    $(GLINK PostfixExpression) $(D [) $(GLINK Slice) $(D ,)$(OPT) $(D ])
+$(GNAME SliceOperation):
+    $(D [ ])
+    $(D [) $(GLINK Slice) $(D ,)$(OPT) $(D ])
 
 $(GNAME Slice):
     $(GLINK AssignExpression)
@@ -1641,21 +1641,28 @@ $(GNAME Slice):
     $(GLINK AssignExpression) $(D ..) $(GLINK AssignExpression) $(D ,) $(GSELF Slice)
 )
 
-    $(P $(I PostfixExpression) is evaluated.
-        If $(I PostfixExpression) is a static or dynamic
+    $(P The base $(I PostfixExpression) is evaluated.
+        The special variable `$` is declared and set to be the number
+        of elements in the $(I PostfixExpression) (when available).
+        A new declaration scope is created for the evaluation of the
+        $(I AssignExpression)`..`$(I AssignExpression) and `$` appears in
+        that scope only.
+    )
+
+    $(P If the base $(I PostfixExpression) is a static or dynamic
         array `a`, the result of the slice is a dynamic array
         referencing elements `a[i]` to `a[j-1]` inclusive, where `i`
         and `j` are integers evaluated from the first and second $(I
         AssignExpression) respectively.
     )
 
-    $(P If $(I PostfixExpression) is a pointer `p`, the result
+    $(P If the base $(I PostfixExpression) is a pointer `p`, the result
         will be a dynamic array referencing elements from `p[i]` to `p[j-1]`
         inclusive, where `i` and `j` are integers evaluated from the
         first and second $(I AssignExpression) respectively.
     )
 
-    $(P If $(I PostfixExpression) is a $(DDSUBLINK spec/template, variadic-templates, $(I ValueSeq)), then
+    $(P If the base $(I PostfixExpression) is a $(DDSUBLINK spec/template, variadic-templates, $(I ValueSeq)), then
         the result of the slice is a new $(I ValueSeq) formed
         from the upper and lower bounds, which must statically evaluate
         to integral constants.
@@ -1669,24 +1676,17 @@ $(GNAME Slice):
         The result of the expression is a slice of the elements in $(I PostfixExpression).
     )
 
-    $(P The special variable `$` is declared and set to be the number
-        of elements in the $(I PostfixExpression) (when available).
-        A new declaration scope is created for the evaluation of the
-        $(I AssignExpression)`..`$(I AssignExpression) and `$` appears in
-        that scope only.
-    )
-
-    $(P If the $(D [ ]) form is used, the slice is of all the elements in $(I PostfixExpression).
-        The expression cannot be a pointer.
+    $(P If the $(D [ ]) form is used, the slice is of all the elements in the base $(I PostfixExpression).
+        The base expression cannot be a pointer.
     )
 
     $(P The slice operator can be $(DDSUBLINK spec/operatoroverloading, slice, overloaded).
         Using more than one *Slice* is only supported for operator
         overloading.)
 
-    $(P A $(I SliceExpression) is not a modifiable lvalue.)
+    $(P A $(I SliceOperation) is not a modifiable lvalue.)
 
-$(H3 $(LNAME2 slice_to_static_array, Slice Conversion to Static Array))
+$(H4 $(LNAME2 slice_to_static_array, Slice Conversion to Static Array))
 
     $(P If the slice bounds can be known at compile time, the slice expression
     may be implicitly convertible to a static array lvalue. For example:)
@@ -1785,7 +1785,7 @@ $(GNAME PrimaryExpression):
     $(RELATIVE_LINK2 null, $(D null))
     $(LEGACY_LNAME2 true_false)$(DDSUBLINK spec/type, bool, `true`)
     $(DDSUBLINK spec/type, bool, `false`)
-    $(RELATIVE_LINK2 IndexExpression, `$`)
+    $(RELATIVE_LINK2 IndexOperation, `$`)
     $(GLINK_LEX IntegerLiteral)
     $(GLINK_LEX FloatLiteral)
     $(LEGACY_LNAME2 CharacterLiteral)$(LEGACY_LNAME2 character-literal)$(GLINK_LEX CharacterLiteral)

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1592,7 +1592,7 @@ S s = S(1, 2);
     Uniform construction syntax for built-in scalar types))
 
 
-$(H3 $(LNAME2 index_operations, Index Operations))
+$(H3 $(LEGACY_LNAME2 index_operations, index_expressions, Index Operations))
 
 $(GRAMMAR
 $(GNAME IndexOperation):
@@ -1627,7 +1627,7 @@ $(GNAME IndexOperation):
         Using multiple indices in *ArgumentList* is only supported for operator
         overloading.)
 
-$(H3 $(LNAME2 slice_operations, Slice Operations))
+$(H3 $(LEGACY_LNAME2 slice_operations, slice_expressions, Slice Operations))
 
 $(GRAMMAR
 $(GNAME SliceOperation):

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -3679,7 +3679,7 @@ $(H2 $(LNAME2 nogc-functions, No-GC Functions))
         $(LI $(DDSUBLINK spec/expression, CatExpression, array concatenation))
         $(LI $(DDSUBLINK spec/expression, simple_assignment_expressions, array appending))
         $(LI $(DDSUBLINK spec/expression, AssocArrayLiteral, constructing an associative array))
-        $(LI $(DDSUBLINK spec/expression, IndexExpression, indexing) an associative array
+        $(LI $(DDSUBLINK spec/expression, IndexOperation, indexing) an associative array
             $(NOTE because it may throw $(D RangeError) if the specified key is not present))
         $(LI $(DDSUBLINK spec/expression, NewExpression, allocating an object with `new`) on the heap
             $(NOTE `new` declarations of $(D class types) in function scopes are compatible with

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -950,10 +950,10 @@ $(H4 $(LNAME2 seq-ops, Sequence Operations))
     $(LI The number of elements in an $(I AliasSeq) can be retrieved with
         the $(D .length) property.)
     $(LI The $(I n)th element can be retrieved by
-        $(DDSUBLINK spec/expression, index_expressions, indexing) an
+        $(DDSUBLINK spec/expression, index_operations, indexing) an
         $(I AliasSeq) with `Seq[n]`. Indexes must be known at compile-time.
         The result is an lvalue when the element is a variable.)
-    $(LI $(DDSUBLINK spec/expression, slice_expressions, Slicing)
+    $(LI $(DDSUBLINK spec/expression, slice_operations, Slicing)
         produces a new sequence with a subset of the elements of the original sequence.)
     )
 


### PR DESCRIPTION
Them being independent expressions in the grammar made PostfixExpression non-trivially left recursive.

A more direct representation of the parser would be to combine indexing and slicing, but I assume the separation was deliberate for reader clarity.