### PR TITLE
Allow underscores at more positions in grammar for numbers

### DIFF
--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -672,9 +672,7 @@ $(GNAME DecimalDigitsUS):
     $(GLINK DecimalDigitUS) $(GSELF DecimalDigitsUS)
 
 $(GNAME DecimalDigitsNoSingleUS):
-    $(GLINK DecimalDigit)
-    $(GLINK DecimalDigit) $(GLINK DecimalDigitsUS)
-    $(GLINK DecimalDigitsUS) $(GLINK DecimalDigit)
+    $(GLINK DecimalDigitsUS)$(OPT) $(GLINK DecimalDigit) $(GLINK DecimalDigitsUS)$(OPT)
 
 $(GNAME DecimalDigitsNoStartingUS):
     $(GLINK DecimalDigit)
@@ -689,10 +687,7 @@ $(GNAME DecimalDigitUS):
     $(B _)
 
 $(GNAME BinaryDigitsNoSingleUS):
-    $(GLINK BinaryDigit)
-    $(GLINK BinaryDigit) $(GLINK BinaryDigitsUS)
-    $(GLINK BinaryDigitsUS) $(GLINK BinaryDigit)
-    $(GLINK BinaryDigitsUS) $(GLINK BinaryDigit) $(GLINK BinaryDigitsUS)
+    $(GLINK BinaryDigitsUS)$(OPT) $(GLINK BinaryDigit) $(GLINK BinaryDigitsUS)$(OPT)
 
 $(GNAME BinaryDigitsUS):
     $(GLINK BinaryDigitUS)
@@ -725,9 +720,7 @@ $(GNAME HexDigitsUS):
     $(GLINK HexDigitUS) $(GSELF HexDigitsUS)
 
 $(GNAME HexDigitsNoSingleUS):
-    $(GLINK HexDigit)
-    $(GLINK HexDigit) $(GLINK HexDigitsUS)
-    $(GLINK HexDigitsUS) $(GLINK HexDigit)
+    $(GLINK HexDigitsUS)$(OPT) $(GLINK HexDigit) $(GLINK HexDigitsUS)$(OPT)
 
 $(GNAME HexDigitsNoStartingUS):
     $(GLINK HexDigit)


### PR DESCRIPTION
DecimalDigitsNoSingleUS and HexDigitsNoSingleUS previously did not accept underscores at the start and end at the same time, but DMD allows this. For example the hex literal `0x_1_` and the floating point literals `0_1_.0`, `1e_1_` and `0x_1_p_1_` are accepted by DMD, but were not allowed by the grammar. BinaryDigitsNoSingleUS was already correct.

The grammar is also simplified by using optional parts instead of multiple rules.