### PR TITLE
Allow the literal `0_` in the grammar

### DIFF
--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -638,9 +638,13 @@ $(GNAME IntegerSuffix):
     $(B UL)
 
 $(GNAME DecimalInteger):
-    $(B 0)
+    $(B 0) $(GLINK Underscores)$(OPT)
     $(GLINK NonZeroDigit)
     $(GLINK NonZeroDigit) $(GLINK DecimalDigitsUS)
+
+$(GNAME Underscores):
+    $(B _)
+    $(GLINK Underscores) $(B _)
 
 $(GNAME BinaryInteger):
     $(GLINK BinPrefix) $(GLINK BinaryDigitsNoSingleUS)


### PR DESCRIPTION
Decimal literals having exactly one zero and some underscores after it are accepted by DMD, but currently not allowed by the grammar. Previously they were allowed by the grammar as octal literals, but they have been removed.