### PR TITLE
[spec] Move enum to base type example to enum.dd

### DIFF
--- a/spec/enum.dd
+++ b/spec/enum.dd
@@ -75,10 +75,24 @@ $(H2 $(LNAME2 named_enums, Named Enums))
         *AssignExpression*. Otherwise, it defaults to
         type $(CODE int).)
 
-        * A named enum member can be
-          $(DDSUBLINK spec/type, implicit-conversions, implicitly cast to its $(I EnumBaseType)).
+        * A named enum member can be implicitly cast to its $(I EnumBaseType).
         * An $(I EnumBaseType) instance cannot be implicitly cast to a named enum type.
-        * A named enum member does not have an individual $(I Type).
+
+$(SPEC_RUNNABLE_EXAMPLE_FAIL
+-------------------
+int i;
+
+enum Foo { E }
+Foo f;
+i = f;           // OK
+f = i;           // error
+f = cast(Foo)i;  // OK
+f = 0;           // error
+f = Foo.E;       // OK
+-------------------
+)
+
+        $(P A named enum member does not have an individual $(I Type).)
 
         $(P The value of an $(GLINK EnumMember) is given by its *AssignExpression* if present.
         If there is no *AssignExpression* and it is the first $(I EnumMember),

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -226,23 +226,9 @@ $(H3 $(LEGACY_LNAME2 Implicit Conversions, implicit-conversions, Implicit Conver
     types as required. The rules for integers are detailed in the next sections.
     )
 
-    $(P An enum can be implicitly converted to its base
+    $(P An enum can be $(DDSUBLINK spec/enum, named_enums, implicitly converted) to its base
     type, but going the other way requires an explicit
-    conversion. For example:)
-
-$(SPEC_RUNNABLE_EXAMPLE_FAIL
--------------------
-int i;
-
-enum Foo { E }
-Foo f;
-i = f;           // OK
-f = i;           // error
-f = cast(Foo)i;  // OK
-f = 0;           // error
-f = Foo.E;       // OK
--------------------
-)
+    conversion.)
 
     $(UL
     $(LI All types implicitly convert to $(RELATIVE_LINK2 noreturn, `noreturn`).)


### PR DESCRIPTION
Link to it from type.dd instead.
Follow up to #3683.