### PR TITLE
Improve template-comparison article

### DIFF
--- a/articles/template-comparison.dd
+++ b/articles/template-comparison.dd
@@ -83,8 +83,9 @@ T foo(T i)
 
         $(TR
             $(TD Parameterize any Declaration)
-            $(TD Yes, classes, functions, typedefs,
-            variables, enums, etc. can be parameterized,
+            $(TD Yes, classes, functions, any
+            $(DDSUBLINK spec/declaration, alias, alias),
+            variables, any enum, etc. can be parameterized,
             such as this variable:
 ---
 template Foo(T)
@@ -97,7 +98,9 @@ template Foo(T)
                 $(B$(U C++98))$(BR)
                 No, only classes and functions
                 $(BR)$(B$(U C++11))$(BR)
-                Yes:
+                `using` type aliases
+                $(BR)$(B$(U C++14))$(BR)
+                `constexpr` constant:
 $(CPPCODE2
 template&lt;class T&gt;
 constexpr T pi = T(3.1415926535897932385L);
@@ -133,7 +136,8 @@ MyFoo&lt;unsigned&gt; f;
 
         $(TR
             $(TD Sequence Constructors)
-            $(TD No)
+            $(TD No, use a
+                $(DDSUBLINK spec/function, typesafe_variadic_functions, variadic parameter) instead)
             $(TD
                 $(B$(U C++98))$(BR)
                 No
@@ -259,8 +263,8 @@ template&lt;class T, int maxLength&gt; class HashTable {
         )
 
         $(TR
-            $(TD Template Declarations (with no definition))
-            $(TD No)
+            $(TD Template Forward Declarations)
+            $(TD Not necessary)
             $(TD Yes:
 $(CPPCODE2
 template&lt;class T&gt;

--- a/articles/template-comparison.dd
+++ b/articles/template-comparison.dd
@@ -98,9 +98,14 @@ template Foo(T)
                 $(B$(U C++98))$(BR)
                 No, only classes and functions
                 $(BR)$(B$(U C++11))$(BR)
-                `using` type aliases
-                $(BR)$(B$(U C++14))$(BR)
-                `constexpr` constant:
+                Added `using` type aliases:
+$(CPPCODE2
+template&lt;class T&gt;
+using ptr = T*;
+ptr&lt;int&gt; p;
+)
+                $(B$(U C++14))$(BR)
+                Added `constexpr` constant:
 $(CPPCODE2
 template&lt;class T&gt;
 constexpr T pi = T(3.1415926535897932385L);

--- a/articles/template-comparison.dd
+++ b/articles/template-comparison.dd
@@ -391,7 +391,7 @@ void foo()
 
         $(TR
             $(TD Reference Parameters)
-            $(TD No, D does not have a general reference type)
+            $(TD No, but an alias parameter can be used instead (see below).)
             $(TD Yes:
 $(CPPCODE2
 template&lt;double& D&gt;

--- a/articles/template-comparison.dd
+++ b/articles/template-comparison.dd
@@ -305,6 +305,12 @@ return Foo<char, int>::foo('c', 3);
         )
 
         $(TR
+        $(TD Deducing `this` parameter type)
+        $(TD $(DDSUBLINK spec/template, template_this_parameter, Yes))
+        $(TD $(B$(U C++23))$(BR)Yes)
+        )
+
+        $(TR
         $(TD Compile time execution of functions)
         $(TD $(DDSUBLINK spec/function, interpretation, Yes):
 ---


### PR DESCRIPTION
C++ still cannot do an enum type template AFAIU.
It was actually C++14 (not 11) that introduced constexpr constant templates: https://en.cppreference.com/w/cpp/language/variable_template
C++11 introduced type alias templates: https://en.cppreference.com/w/cpp/language/type_alias 
Mention using a variadic constructor instead of sequence ctor.
Rename row to 'forward declarations' and say they're not necessary in D.
Add row for 'Deducing `this` parameter type'.
Mention using alias param instead of `T&` param.
