### PR TITLE
[articles/template-comparison] Fix missing arguments to ERROR macro

### DIFF
--- a/articles/template-comparison.dd
+++ b/articles/template-comparison.dd
@@ -483,7 +483,7 @@ $(CPPCODE2
 template &lt;const char*&gt;
 struct S {};
 
-S&lt;"Foo"&gt; foo1; $(ERROR A string literal argument is still illegal)
+S&lt;"Foo"&gt; foo1; // $(ERROR A string literal argument is still illegal)
 const char foo_str[] = "foo";
 S&lt;foo_str&gt; foo2; // Literal types are allowed, including arrays.
 )
@@ -946,7 +946,7 @@ Macros:
         NO1=<td class="compNo"><a href="$1">No</a></td>
         D_CODE = <pre class="d_code2">$0</pre>
         CPPCODE2 = <pre class="cppcode2">$0</pre>
-        ERROR = $(RED $(B error))
+        ERROR = $(RED $(B error) $0)
         SUBNAV=$(SUBNAV_ARTICLES)
 META_KEYWORDS=D Programming Language, template metaprogramming,
 variadic templates, type deduction, dependent base class

--- a/articles/template-comparison.dd
+++ b/articles/template-comparison.dd
@@ -466,7 +466,7 @@ void foo()
             $(TD String Parameters)
             $(TD Yes:
 ---
-void foo(char[] format)(int i)
+void foo(string format)(int i)
 {
     writefln(format, i);
 }
@@ -480,7 +480,7 @@ foo!("i = %s")(3);
                 $(BR)$(B$(U C++17))$(BR)
                 Only indirectly:
 $(CPPCODE2
-template &lt;const char*&gt;
+template &lt;const char *str&gt;
 struct S {};
 
 S&lt;"Foo"&gt; foo1; // $(ERROR A string literal argument is still illegal)


### PR DESCRIPTION
Besides the line tweaked in the diff below, arguments are used on line 246 and 250. Without this they are silently thrown away.