### PR TITLE
Change spec for SwitchStatement to include changes introduced in dlang/dmd#15656

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1220,7 +1220,7 @@ $(H2 $(LEGACY_LNAME2 SwitchStatement, switch-statement, Switch Statement))
 
 $(GRAMMAR
 $(GNAME SwitchStatement):
-    $(D switch $(LPAREN)) $(EXPRESSION) $(D $(RPAREN)) $(PSSCOPE)
+    $(D switch $(LPAREN)) $(GLINK IfCondition) $(D $(RPAREN)) $(PSSCOPE)
 
 $(GNAME CaseStatement):
     $(D case) $(GLINK2 expression, ArgumentList) $(D :) $(PSSEMI_PSCURLYSCOPE_LIST)$(OPT)
@@ -1241,14 +1241,27 @@ $(GNAME StatementNoCaseNoDefault):
     $(GLINK ScopeBlockStatement)
 )
 
-        $(P $(I Expression) is evaluated.
-        If the type of $(I Expression) is an `enum`, it is
+        $(P If the $(I IfCondition) is an *Expression*, it is evaluated.
+        If the type of the *Expression* is an `enum`, it is
         (recursively) converted to its $(GLINK2 enum, EnumBaseType).
-        Then, if the type is an integral, $(I Expression) undergoes
+        Then, if the type is an integral, the *Expression* undergoes
         $(DDSUBLINK spec/type, integer-promotions, Integer Promotions).
-        Then, the type of $(I Expression) must be either an integral or
+        Then, the type of the *Expression* must be either an integral or
         a static or dynamic array of $(CODE char), $(CODE wchar), or $(CODE dchar).
         )
+
+        $(P If an $(D auto) $(I Identifier) is provided, it is declared and
+        initialized to the value and type of the *Expression*. Its scope
+        extends from when it is initialized to the end of the *ScopeStatement*.)
+
+        $(P If a $(I TypeCtors) $(I Identifier) is provided, it is declared
+        to be of the type specified by $(I TypeCtors) and is initialized with
+        the value of the *Expression*. Its scope extends from when it is
+        initialized to the end of the *ScopeStatement*.)
+
+        $(P If a $(I Declarator) is provided, it is declared and initialized
+        to the value of the *Expression*. Its scope extends from when it is
+        initialized to the end of the *ScopeStatement*.)
 
         $(P The resulting value is
         compared against each of the case expressions. If there is
@@ -1434,7 +1447,7 @@ $(H2 $(LEGACY_LNAME2 FinalSwitchStatement, final-switch-statement, Final Switch 
 
 $(GRAMMAR
 $(GNAME FinalSwitchStatement):
-    $(D final switch $(LPAREN)) $(EXPRESSION) $(D $(RPAREN)) $(PSSCOPE)
+    $(D final switch $(LPAREN)) $(GLINK IfCondition) $(D $(RPAREN)) $(PSSCOPE)
 )
 
         $(P A final switch statement is just like a switch statement,

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1241,7 +1241,7 @@ $(GNAME StatementNoCaseNoDefault):
     $(GLINK ScopeBlockStatement)
 )
 
-        $(P If the $(I IfCondition) is an *Expression*, it is evaluated.
+        $(P The *Expression* from the $(I IfCondition) is evaluated.
         If the type of the *Expression* is an `enum`, it is
         (recursively) converted to its $(GLINK2 enum, EnumBaseType).
         Then, if the type is an integral, the *Expression* undergoes
@@ -1250,18 +1250,13 @@ $(GNAME StatementNoCaseNoDefault):
         a static or dynamic array of $(CODE char), $(CODE wchar), or $(CODE dchar).
         )
 
-        $(P If an $(D auto) $(I Identifier) is provided, it is declared and
-        initialized to the value and type of the *Expression*. Its scope
+        $(P If an $(I Identifier) `=` prefix is provided, a variable is declared with that
+        name, initialized to the value and type of the *Expression*. Its scope
         extends from when it is initialized to the end of the *ScopeStatement*.)
 
-        $(P If a $(I TypeCtors) $(I Identifier) is provided, it is declared
-        to be of the type specified by $(I TypeCtors) and is initialized with
-        the value of the *Expression*. Its scope extends from when it is
-        initialized to the end of the *ScopeStatement*.)
-
-        $(P If a $(I Declarator) is provided, it is declared and initialized
-        to the value of the *Expression*. Its scope extends from when it is
-        initialized to the end of the *ScopeStatement*.)
+        $(P If $(I TypeCtors) and/or a specific type is provided for *Identifier*, those
+        are used for the variable declaration which is initialized by an implicit
+        conversion from the value of the *Expression*.)
 
         $(P The resulting value is
         compared against each of the case expressions. If there is


### PR DESCRIPTION
This PR changes the specs for SwitchStatement to include that the condition of a switch statement now can also be a declaration. See dlang/dmd#15656 for more infos.