### PR TITLE
[spec] Add missing PragmaDeclaration to DeclDef

### DIFF
--- a/spec/module.dd
+++ b/spec/module.dd
@@ -27,6 +27,7 @@ $(GNAME DeclDef):
     $(GLINK2 class, StaticDestructor)
     $(GLINK2 class, SharedStaticConstructor)
     $(GLINK2 class, SharedStaticDestructor)
+    $(GLINK2 pragma, PragmaDeclaration)
     $(GLINK2 version, ConditionalDeclaration)
     $(GLINK2 version, DebugSpecification)
     $(GLINK2 version, VersionSpecification)


### PR DESCRIPTION
According to dmd parser this section is in DeclDef, so I added it there.