### PR TITLE
Use consistent order for qualifiers in conversion table

### DIFF
--- a/spec/const3.dd
+++ b/spec/const3.dd
@@ -714,16 +714,16 @@ $(GLOSSARY qualifier-convertible). The same information is shown below in tabula
 format:)
 
     $(TABLE_10 $(ARGS Implicit Conversion of Reference Types),
-    $(VERTROW from/to, $(I mutable), $(D const), $(D shared), $(D const shared), $(D inout), $(D const inout), $(D inout shared), $(D const inout shared), $(D immutable)),
+    $(VERTROW from/to, $(I mutable), $(D const), $(D shared), $(D inout), $(D const shared), $(D const inout), $(D inout shared), $(D const inout shared), $(D immutable)),
     $(TROW $(I mutable),            $(YES), $(YES), $(NO),  $(NO),  $(NO),  $(NO),  $(NO),  $(NO),  $(NO) )
     $(TROW $(D const),              $(NO),  $(YES), $(NO),  $(NO),  $(NO),  $(NO),  $(NO),  $(NO),  $(NO) )
+    $(TROW $(D shared),             $(NO),  $(NO),  $(YES), $(NO),  $(YES), $(NO),  $(NO),  $(NO),  $(NO) )
+    $(TROW $(D inout),              $(NO),  $(YES), $(NO),  $(YES), $(NO),  $(YES), $(NO),  $(NO),  $(NO) )
+    $(TROW $(D const shared),       $(NO),  $(NO),  $(NO),  $(NO),  $(YES), $(NO),  $(NO),  $(NO),  $(NO) )
     $(TROW $(D const inout),        $(NO),  $(YES), $(NO),  $(NO),  $(NO),  $(YES), $(NO),  $(NO),  $(NO) )
-    $(TROW $(D const shared),       $(NO),  $(NO),  $(NO),  $(YES), $(NO),  $(NO),  $(NO),  $(NO),  $(NO) )
-    $(TROW $(D const inout shared), $(NO),  $(NO),  $(NO),  $(YES), $(NO),  $(NO),  $(NO),  $(YES), $(NO) )
-    $(TROW $(D immutable),          $(NO),  $(YES), $(NO),  $(YES), $(NO),  $(YES), $(NO),  $(YES), $(YES))
-    $(TROW $(D inout),              $(NO),  $(YES), $(NO),  $(NO),  $(YES), $(YES), $(NO),  $(NO),  $(NO) )
-    $(TROW $(D shared),             $(NO),  $(NO),  $(YES), $(YES), $(NO),  $(NO),  $(NO),  $(NO),  $(NO) )
-    $(TROW $(D inout shared),       $(NO),  $(NO),  $(NO),  $(YES), $(NO),  $(NO),  $(YES), $(YES), $(NO) )
+    $(TROW $(D inout shared),       $(NO),  $(NO),  $(NO),  $(NO),  $(YES), $(NO),  $(YES), $(YES), $(NO) )
+    $(TROW $(D const inout shared), $(NO),  $(NO),  $(NO),  $(NO),  $(YES), $(NO),  $(NO),  $(YES), $(NO) )
+    $(TROW $(D immutable),          $(NO),  $(YES), $(NO),  $(NO),  $(YES), $(YES), $(NO),  $(YES), $(YES))
     )
 
 $(H3 $(LNAME2 unique-expressions, Unique Expressions))


### PR DESCRIPTION
The rows and columns now list qualifiers and qualifier combinations in the same order, and match the order used in the "Combining Qualifiers" section.