### PR TITLE
Document deprecation of 'is' for static arrays

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -688,6 +688,10 @@ $(GNAME IdentityExpression):
     ---
     )
 
+    $(DDOC_DEPRECATED Use of `is` to compare static arrays by address and
+    length is deprecated. To do so, use the slice operator and compare slices
+    of the arrays instead; for example, `a1[] is a2[]`.)
+
     $(P For other operand types, identity is defined as being the same
         as equality.
     )


### PR DESCRIPTION
This was deprecated in DMD 2.072.0, but the corresponding spec PR was never merged.

See https://github.com/dlang/dmd/pull/6089