### PR TITLE
[spec] Fix missing legacy.html

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -11,7 +11,6 @@ $(SPEC_S Deprecated Features,
     $(TABLE2 Deprecated Features,
         $(THEAD Feature,                                                          Spec,  Dep,    Error,  Gone)
         $(TROW $(DEPLINK Throwing from contracts of nothrow functions),           &nbsp;, 2.101, 2.111, &nbsp;)
-        $(TROW $(DEPLINK body keyword),                                           2.075, 2.097, 2.097, 2.117)
         $(TROW $(DEPLINK Hexstring literals),                                     2.079, 2.079, 2.086, &nbsp;)
         $(TROW $(DEPLINK Class allocators and deallocators),                      &nbsp;, 2.080, 2.087, 2.100 )
         $(TROW $(DEPLINK Implicit comparison of different enums),                 2.075,  2.075, 2.081, &nbsp;)

--- a/posix.mak
+++ b/posix.mak
@@ -322,7 +322,7 @@ SPEC_ROOT=$(addprefix spec/, \
 	const3 function operatoroverloading template template-mixin contracts \
 	version traits errors unittest garbage float iasm ddoc \
 	interfaceToC cpp_interface objc_interface portability entity memory-safe-d \
-	abi simd betterc importc ob windows glossary)
+	abi simd betterc importc ob windows glossary legacy)
 SPEC_DD=$(addsuffix .dd,$(SPEC_ROOT))
 
 CHANGELOG_FILES:=$(basename $(subst _pre.dd,.dd,$(wildcard changelog/*.dd)))

--- a/spec/glossary.dd
+++ b/spec/glossary.dd
@@ -272,6 +272,7 @@ void test()
         `arg.funct()`.)
 )
 
+$(SPEC_SUBNAV_PREV_NEXT windows, Windows Programming, legacy, Legacy Code)
 )
 
 Macros:

--- a/spec/legacy.dd
+++ b/spec/legacy.dd
@@ -16,7 +16,7 @@ $(HEADERNAV_TOC)
         $(TROW $(RELATIVE_LINK2 body, `body` keyword), usage of identifier $(TT body) as a keyword is obsolete - use $(TT do) instead)
     )
 
-$(H3 $(LNAME2 body, `body` keyword))
+$(H2 $(LNAME2 body, `body` keyword))
     $(P `body` was a keyword used to specify a function/method's body after a contract statement:)
         ---
         class Foo
@@ -33,7 +33,7 @@ $(H3 $(LNAME2 body, `body` keyword))
         }
         ---
 
-$(H4 Corrective Action)
+$(H3 Corrective Action)
 
     $(P Use the `do` keyword instead (introduced in v2.075.0):)
         ---

--- a/spec/legacy.dd
+++ b/spec/legacy.dd
@@ -5,8 +5,10 @@ $(SPEC_S Legacy Code,
 $(HEADERNAV_TOC)
 
     $(P To maintain compatibility with older D code, many legacy features remain supported.
+$(COMMENT
     If the $(TT -wo) compiler command line switch is used, the compiler will give warning messages
     for each use of a legacy feature.
+)
     This page describes each legacy feature that is supported, with a suggestion of how to
     modernize the code.
     )

--- a/spec/legacy.dd
+++ b/spec/legacy.dd
@@ -13,10 +13,10 @@ $(HEADERNAV_TOC)
 
     $(TABLE2 Legacy Features,
         $(THEAD Feature)
-        $(TROW $(DEPLINK body keyword), usage of identifier $(TT body) as a keyword is obsolete use $(TT do) instead)
+        $(TROW $(RELATIVE_LINK2 body, `body` keyword), usage of identifier $(TT body) as a keyword is obsolete - use $(TT do) instead)
     )
 
-$(H3 $(DEPNAME body keyword))
+$(H3 $(LNAME2 body, `body` keyword))
     $(P `body` was a keyword used to specify a function/method's body after a contract statement:)
         ---
         class Foo
@@ -34,7 +34,8 @@ $(H3 $(DEPNAME body keyword))
         ---
 
 $(H4 Corrective Action)
-    $(P Use the `do` keyword instead (introduced v2.075.0):)
+
+    $(P Use the `do` keyword instead (introduced in v2.075.0):)
         ---
         void bar(int i)
         in { assert(i >= 42); }
@@ -51,12 +52,6 @@ $(H4 Corrective Action)
 $(SPEC_SUBNAV_PREV glossary, Glossary)
 )
 
-)
-
 Macros:
         CHAPTER=45
         TITLE=Legacy Code
-        DEPLINK=$(RELATIVE_LINK2 $0, $0)
-        DEPLINK2=$(LINK2 $1.html#$2, $2)
-        DEPNAME=$(LNAME2 $0, $0)
-    D=<span class="d_inlinecode">$0</span>

--- a/spec/legacy.dd
+++ b/spec/legacy.dd
@@ -11,15 +11,13 @@ $(HEADERNAV_TOC)
     modernize the code.
     )
 
-)
-
     $(TABLE2 Legacy Features,
         $(THEAD Feature)
         $(TROW $(DEPLINK body keyword), usage of identifier $(TT body) as a keyword is obsolete use $(TT do) instead)
     )
 
 $(H3 $(DEPNAME body keyword))
-    $(P `body` was a keyword used to specify a function/method's body in the presence of contracts
+    $(P `body` was a keyword used to specify a function/method's body after a contract statement:)
         ---
         class Foo
         {
@@ -34,22 +32,26 @@ $(H3 $(DEPNAME body keyword))
             void noBody() { /* No contracts, no body */ }
         }
         ---
-    )
+
 $(H4 Corrective Action)
-    $(P Use the `do` keyword instead (introduced v2.075.0)
+    $(P Use the `do` keyword instead (introduced v2.075.0):)
         ---
         void bar(int i)
         in { assert(i >= 42); }
         do { /* Look ma, no body! */ }
         ---
-    )
-$(H4 Rationale)
-    $(P The `body` keyword was only used for this single purpose.
+
+    $(RATIONALE The `body` keyword was only used for this single purpose.
         Since D grammar aims to be context free, this common word was reserved,
         which led to frequent trouble for people interfacing with other languages
         (e.g. javascript) or auto-generating code.
     )
 
+
+$(SPEC_SUBNAV_PREV glossary, Glossary)
+)
+
+)
 
 Macros:
         CHAPTER=45

--- a/spec/windows.dd
+++ b/spec/windows.dd
@@ -36,7 +36,7 @@ $(H3 $(LNAME2 omf-windows, Windows GUI Programs))
 
 $(H3 $(LNAME2 omf-dlls, DLLs))
 
-$(SPEC_SUBNAV_PREV ob, Live Functions)
+$(SPEC_SUBNAV_PREV_NEXT ob, Live Functions, glossary, Glossary)
 )
 
 Macros:


### PR DESCRIPTION
Also:
`-wo` does nothing after https://github.com/dlang/dmd/pull/15612, comment it out.
Remove non-standard macros.
Fix empty paragraphs.
Fix missing/wrong Previous/Next items.