### PR TITLE
Update expression.dd

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2240,8 +2240,8 @@ $(GNAME RefOrAutoRef):
         {
             int x;
             auto dg = delegate ref int() { return x; };
-            x = 3;
-            assert(dg() == 3);
+            dg() = 3;
+            assert(x == 3);
         }
         ---
         )


### PR DESCRIPTION
Change the example for "The use of `ref` declares that the return value is returned by reference" to actually show (and require) that the return value is by reference.