### PR TITLE
[spec/legacy] Add old alias syntax and postblit

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -244,6 +244,8 @@ auto c = new C();  // c is a handle to an instance of class C
 
 $(H2 $(LNAME2 alias, Alias Declarations))
 
+    $(NOTE New code should use the *AliasAssignments* form only.)
+
 $(GRAMMAR
 $(GNAME AliasDeclaration):
     $(D alias) $(GLINK StorageClasses)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 type, TypeSuffixes)$(OPT) $(GLINK Identifiers) $(D ;)

--- a/spec/legacy.dd
+++ b/spec/legacy.dd
@@ -14,8 +14,12 @@ $(COMMENT
     )
 
     $(TABLE2 Legacy Features,
-        $(THEAD Feature)
-        $(TROW $(RELATIVE_LINK2 body, `body` keyword), usage of identifier $(TT body) as a keyword is obsolete - use $(TT do) instead)
+        $(THEAD Feature, Summary)
+        $(TROW $(RELATIVE_LINK2 body, `body` keyword), $(D body) after a contract statement -
+            use $(D do) instead)
+        $(TROW `alias` target first syntax, use `alias name = target` instead.)
+        $(TROW Struct/union postblit, use a $(DDSUBLINK spec/struct, struct-copy-constructor,
+            copy constructor) instead.)
     )
 
 $(H2 $(LNAME2 body, `body` keyword))


### PR DESCRIPTION
As of last month the `-wo` switch does nothing, but I think it's still valuable to explain which features shouldn't be used in new code. These can then become errors in future editions (and perhaps revive the `-wo` switch for warnings in an older edition).

Please let me know if there are any other obsolete features that should be listed here.