### PR TITLE
[spec] Improve function type (alias) docs

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -433,11 +433,12 @@ assert(S.j == 4);
 
 $(H3 $(LNAME2 alias-function, Aliasing a Function Type))
 
-        $(P Function types can be aliased:)
+        $(P $(DDSUBLINK spec/type, functions, Function types) can be
+        aliased:)
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
-alias Fun = int(string p);
+alias Fun = int(string);
 int fun(string) {return 0;}
 static assert(is(typeof(fun) == Fun));
 
@@ -452,32 +453,43 @@ static assert(is(MemberFun1 == MemberFun2));
 
 $(SPEC_RUNNABLE_EXAMPLE_RUN
 -----------
+import std.stdio : writeln;
+
+void fun(int v = 6) {
+    writeln("v: ", v);
+}
+
+void main() {
+    fun();  // prints v: 6
+
+    alias Foo = void function(int=7);
+    Foo foo = &fun;
+    foo();  // prints v: 7
+    foo(8); // prints v: 8
+}
+-----------
+)
+$(SPEC_RUNNABLE_EXAMPLE_RUN
+-----------
 import std.stdio : writefln;
 
 void main() {
-    Foo foo = &foofoo;
-    foo();              // prints v: 6
-    foo(8);             // prints v: 8
-    Bar bar = &barbar;
+    fun(4);          // prints a: 4, b: 6, c: 7
+
+    Bar bar = &fun;
     //bar(4);           // compilation error, because the `Bar` alias
                         // requires an explicit 2nd argument
-    barbar(4);          // prints a: 4, b: 6, c: 7
     bar(4, 5);          // prints a: 4, b: 5, c: 9
     bar(4, 5, 6);       // prints a: 4, b: 5, c: 6
 
-    Baz baz = &barbar;
+    Baz baz = &fun;
     baz();              // prints a: 2, b: 3, c: 4
 }
 
-alias Foo = void function(int=6);
 alias Bar = void function(int, int, int=9);
 alias Baz = void function(int=2, int=3, int=4);
 
-void foofoo(int v = 6) {
-    writefln("v: %d", v);
-}
-
-void barbar(int a, int b = 6, int c = 7) {
+void fun(int a, int b = 6, int c = 7) {
     writefln("a: %d, b: %d, c: %d", a, b, c);
 }
 -----------

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -455,11 +455,13 @@ $(SPEC_RUNNABLE_EXAMPLE_RUN
 -----------
 import std.stdio : writeln;
 
-void fun(int v = 6) {
+void fun(int v = 6)
+{
     writeln("v: ", v);
 }
 
-void main() {
+void main()
+{
     fun();  // prints v: 6
 
     alias Foo = void function(int=7);
@@ -473,7 +475,8 @@ $(SPEC_RUNNABLE_EXAMPLE_RUN
 -----------
 import std.stdio : writefln;
 
-void main() {
+void main()
+{
     fun(4);          // prints a: 4, b: 6, c: 7
 
     Bar bar = &fun;
@@ -489,7 +492,8 @@ void main() {
 alias Bar = void function(int, int, int=9);
 alias Baz = void function(int=2, int=3, int=4);
 
-void fun(int a, int b = 6, int c = 7) {
+void fun(int a, int b = 6, int c = 7)
+{
     writefln("a: %d, b: %d, c: %d", a, b, c);
 }
 -----------

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -571,8 +571,9 @@ $(GLINK TypeCtor)$(OPT) $(GLINK BasicType) $(GLINK TypeSuffixes) `delegate` $(GL
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 void f(int);
-pragma(msg, typeof(f));  // void(int)
-pragma(msg, typeof(&f)); // void function(int)
+alias Fun = void(int);
+static assert(is(typeof(f) == Fun));
+static assert(is(Fun* == void function(int)));
 ---
 )
 

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -565,8 +565,8 @@ $(P Instantiating a function type is illegal. Instead, a pointer to function
 or delegate can be used. Those have these type forms respectively:)
 
 $(GRAMMAR_INFORMATIVE
-$(GLINK TypeCtor)$(OPT) $(GLINK BasicType) $(GLINK TypeSuffixes) `function` $(GLINK2 function, Parameters) $(GLINK2 function, FunctionAttributes)$(OPT)
-$(GLINK TypeCtor)$(OPT) $(GLINK BasicType) $(GLINK TypeSuffixes) `delegate` $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT)
+$(GLINK Type) `function` $(GLINK2 function, Parameters) $(GLINK2 function, FunctionAttributes)$(OPT)
+$(GLINK Type) `delegate` $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT)
 )
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -557,8 +557,9 @@ $(GRAMMAR_INFORMATIVE
 $(GLINK2 declaration, StorageClasses)$(OPT) $(GLINK Type) $(GLINK2 function, Parameters) $(GLINK2 function, FunctionAttributes)$(OPT)
 )
 
-$(P A function type e.g. `int(int)` is only used for type tests.
-A function type $(DDSUBLINK spec/declaration, alias-function, can be aliased).)
+$(P Function types are not included in the $(GLINK Type) grammar.
+A function type e.g. `int(int)` $(DDSUBLINK spec/declaration, alias-function, can be aliased).
+A function type is only used for type tests or as the target type of a pointer.)
 
 $(P Instantiating a function type is illegal. Instead, a pointer to function
 or delegate can be used. Those have these type forms respectively:)


### PR DESCRIPTION
Follow up to #3706.

Link to function types.
Split function pointer type alias example into 2, rename functions. 

Use `GRAMMAR_INFORMATIVE` for function (pointer) types as it's not supposed to be part of the official grammar (i.e. it shouldn't be in `spec/grammar.html`).
Function type grammar is not part of *Type*.
A function type can also be used to declare a pointer target type.
Simplify function pointer/delegate grammar with *Type* .
Show relation between function type and function pointer type.