### PR TITLE
Update importc.dd

### DIFF
--- a/spec/importc.dd
+++ b/spec/importc.dd
@@ -109,7 +109,7 @@ $(H2 $(LNAME2 command-line, Invoking ImportC))
     )
 
     $(P will compile `hello.c` with ImportC and link it to create the executable
-    file `hello` (`hello.exe` on Windows) which can be run
+    file `hello` (`hello.exe` on Windows)
     )
 
     $(BEST_PRACTICE explicitly use a `.i` or `.c` extension when


### PR DESCRIPTION
1. This is inaccurate to pretend that the result of compiling hello.c can be run while the content that hello.c file is not specified.
2. That is already suggested with "to create the executable"