### PR TITLE
[spec] Update function type grammar

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -261,7 +261,7 @@ $(GNAME AliasAssignments):
 $(GNAME AliasAssignment):
     $(GLINK_LEX Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK2 type, Type)
     $(GLINK_LEX Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK2 expression, FunctionLiteral)
-    $(GLINK_LEX Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT)
+    $(GLINK_LEX Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK2 type, Type) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT)
 )
 
     $(P An $(I AliasDeclaration) creates a symbol name that refers to a type or another symbol.

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -553,8 +553,8 @@ $(H2 $(LNAME2 functions, Function Types))
 
 $(P A function type has the form:)
 
-$(GRAMMAR
-$(GLINK TypeCtor)$(OPT) $(GLINK BasicType) $(GLINK2 function, Parameters) $(GLINK2 function, FunctionAttributes)$(OPT)
+$(GRAMMAR_INFORMATIVE
+$(GLINK2 declaration, StorageClasses)$(OPT) $(GLINK Type) $(GLINK2 function, Parameters) $(GLINK2 function, FunctionAttributes)$(OPT)
 )
 
 $(P A function type e.g. `int(int)` is only used for type tests.
@@ -563,7 +563,7 @@ A function type $(DDSUBLINK spec/declaration, alias-function, can be aliased).)
 $(P Instantiating a function type is illegal. Instead, a pointer to function
 or delegate can be used. Those have these type forms respectively:)
 
-$(GRAMMAR
+$(GRAMMAR_INFORMATIVE
 $(GLINK TypeCtor)$(OPT) $(GLINK BasicType) $(GLINK TypeSuffixes) `function` $(GLINK2 function, Parameters) $(GLINK2 function, FunctionAttributes)$(OPT)
 $(GLINK TypeCtor)$(OPT) $(GLINK BasicType) $(GLINK TypeSuffixes) `delegate` $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT)
 )


### PR DESCRIPTION
For https://github.com/dlang/dmd/pull/15805.

~~Remove now deprecated function type aliases with TypeCtor from example.~~