### PR TITLE
listanchors.js: Match both dlang.org and docarchives.dlang.io in version selector

### DIFF
--- a/js/listanchors.js
+++ b/js/listanchors.js
@@ -66,45 +66,43 @@ function addVersionSelector() {
       return {
         name: e,
         url: "https://docarchives.dlang.io/v" + e + ".0/" + currentRoot + ddocModuleURL,
-        selected: false,
       };
   });
 
-  var rootURL = location.href.split(/\/(phobos|library|spec)(-prerelease)?/)[0]
   var onlineVersions;
   if (isSpec) {
     onlineVersions = [{
       name: "master",
-      url: rootURL + "/spec/" + ddocModuleURL,
+      url: "https://dlang.org/spec/" + ddocModuleURL,
     }];
   } else {
     onlineVersions = [{
       name: "master",
-      url: rootURL + "/phobos-prerelease/" + ddocModuleURL,
+      url: "https://dlang.org/phobos-prerelease/" + ddocModuleURL,
     },{
       name: "master (ddox)",
-      url: rootURL + "/library-prerelease/" + ddoxModuleURL,
+      url: "https://dlang.org/library-prerelease/" + ddoxModuleURL,
     },{
       name: "stable",
-      url: rootURL + "/phobos/" + ddocModuleURL,
+      url: "https://dlang.org/phobos/" + ddocModuleURL,
     },{
       name: "stable (ddox)",
-      url: rootURL + "/library/" + ddoxModuleURL,
+      url: "https://dlang.org/library/" + ddoxModuleURL,
     }];
   }
 
   // set the current URL as selected
   var currentURL = location.href.split(/[#?]/)[0];
-  onlineVersions.forEach(function(v, i) {
-    onlineVersions[i].selected = v.url === currentURL;
+  var versions = onlineVersions.concat(archivedVersions);
+  versions.forEach(function(v, i) {
+    versions[i].selected = v.url === currentURL;
   });
   // Don't show the option chooser if the page hasn't been recognized
   // For example, Ddox symbol pages are currently not supported
-  if (onlineVersions.filter(function(v){return v.selected}).length === 0)
+  if (versions.filter(function(v){return v.selected}).length === 0)
     return;
 
   // build select box of all versions and append to current DOM
-  var versions = onlineVersions.concat(archivedVersions);
   var options = versions.map(function(e, i){
     return "<option value='" + i + "'" + (e.selected ? "selected" : "") + ">" + e.name + "</option>";
   });


### PR DESCRIPTION
Currently, when you view an archived version of dlang.org site via docarchives.dlang.io, you can (1) only go further back in time, and (2) the master/stable options only refer to the current archived version.

This change lays down the foundations to allow going both forwards and backwards between dlang versions, and the master/stable options now point at the main dlang.org site, so you can go from whatever archived version to mainline in one click.