### PR TITLE
bump currentArchivedVersion to v2.106

### DIFF
--- a/js/listanchors.js
+++ b/js/listanchors.js
@@ -34,7 +34,7 @@ function addAnchors()
 function addVersionSelector() {
   // Latest version offered by the archive builds
   // This needs to be manually updated after new versions have been archived
-  var currentArchivedVersion = 99;
+  var currentArchivedVersion = 106;
   // build URLs for dlang.org: DDoc + Dox
   var ddocModuleURL = document.body.id.replace(/[.]/g, "_") + ".html";
   var ddoxModuleURL = document.body.id.replace(/[.]/g, "/") + ".html";


### PR DESCRIPTION
All archives up to 2.106.0 have been generated and uploaded.

https://docarchives.dlang.io/v2.106.0/
https://docarchives.dlang.io/v2.105.0/
https://docarchives.dlang.io/v2.104.0/
https://docarchives.dlang.io/v2.103.0/
https://docarchives.dlang.io/v2.102.0/
https://docarchives.dlang.io/v2.101.0/
https://docarchives.dlang.io/v2.100.0/