### PR TITLE
Fix path for querying druntime contributions

### DIFF
--- a/js/show_contributors.js
+++ b/js/show_contributors.js
@@ -29,8 +29,8 @@ $(document).ready(function()
     var repo;
     if (modulePath.indexOf("core") == 0 || modulePath.indexOf("object") == 0)
     {
-        repo = "druntime";
-        modulePath = "src/" + modulePath;
+        repo = "dmd";
+        modulePath = "druntime/src/" + modulePath;
     }
     else if (modulePath.indexOf("std") == 0 || modulePath.indexOf("etc") == 0)
     {


### PR DESCRIPTION
Druntime now lives in the dmd repository.

We want it to query for example
https://contribs.dlang.io/contributors/file/dlang/dmd?file=druntime/src/object.d
and not
https://contribs.dlang.io/contributors/file/dlang/druntime?file=src/object.d
(which returns an empty list)