### PR TITLE
Fix grammar for InterpolatedTokenStringTokens

### DIFF
--- a/spec/istring.dd
+++ b/spec/istring.dd
@@ -85,7 +85,7 @@ $(GNAME InterpolatedTokenLiteral):
     $(D iq{) $(GLINK InterpolatedTokenStringTokens)$(OPT) $(D })
 
 $(GNAME InterpolatedTokenStringTokens):
-    $(GLINK InterpolatedTokenStringTokenNoBraces)
+    $(GLINK InterpolatedTokenStringToken)
     $(GLINK InterpolatedTokenStringToken) $(GSELF InterpolatedTokenStringTokens)
 
 $(GNAME InterpolatedTokenStringToken):


### PR DESCRIPTION
InterpolatedTokenStringTokenNoBraces is not defined. Instead use InterpolatedTokenStringToken, so the string can also end with braces.