### PR TITLE
Replaced the link to obsolete oldDDerivations with link to dlang.nix

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -177,7 +177,7 @@ $(DOWNLOAD_OTHER $(GENTOO), $(LINK2 https://wiki.gentoo.org/wiki/Dlang, Gentoo),
 $(DOWNLOAD_OTHER $(HOMEBREW), $(LINK2 https://formulae.brew.sh/formula/dmd, Homebrew), $(CONSOLE brew install dmd))
 
 $(DOWNLOAD_OTHER $(NIX), $(LINK2 https://search.nixos.org/packages?show=dmd&query=dmd, Nix/NixOS), $(CONSOLE nix-env -iA nixpkgs.dmd)
-$(LINK2 https://github.com/dukc/oldDDerivations, derivations for building various versions yourself)
+$(LINK2 https://github.com/petarkirov/dlang.nix, derivations for various compiler versions)
 )
 
 $(DOWNLOAD_OTHER $(UBUNTU) $(DEBIAN), Ubuntu/Debian, $(LINK2 https://d-apt.sourceforge.net/, APT repository)


### PR DESCRIPTION
The present link points to my previous project that contains Nix derivations (package descriptions) for different compiler versions (as opposed to the official NixPkgs derivation which gets you what compiler version there happens to be).

However, since then I've joined @petarkirov in developing his project, that has all the same aims as mine and more along the way (such as dub and ldc support, separate binary and source derivations, and support for Nix flakes). I don't have any reason to maintain my old project anymore, so it's better for the link to point to our joint project instead.

I also chose to update the link description a bit. it's not so much about "building various versions yourself" anymore, since the joint project supports cached builds for anyone using Nix flakes.