### PR TITLE
entry draft for a possible new header for platform compiler support

### DIFF
--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -42,6 +42,8 @@ $(H2 $(LNAME2 general_idea, The General Idea))
     $(LI matching C++ virtual function table layout for single inheritance)
     )
 
+$(H2 LNAME2 platform-compiler support, Platform-Compiler Support)
+
 $(H2 $(LNAME2 global-functions, Global Functions))
 
     $(P C++ global functions, including those in namespaces, can be declared

--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -42,7 +42,11 @@ $(H2 $(LNAME2 general_idea, The General Idea))
     $(LI matching C++ virtual function table layout for single inheritance)
     )
 
-$(H2 LNAME2 platform-compiler support, Platform-Compiler Support)
+$(H2 $(LNAME2 platform-compiler-support, Platform-Compiler Support))
+
+    $(P When building on windows, you should preferrably link your D code to MSVC compiled binaries.
+    You can link to both gcc and clang compiled binaries on linux.
+    On macOS, you should preferrably link to clang compiled binaries.)
 
 $(H2 $(LNAME2 global-functions, Global Functions))
 


### PR DESCRIPTION
This PR is to propose an addition for Platform compiler support header to `cpp_interface.dd` file being the interfacing to C++ reference page. Might be verbose but I think it's needed especially for beginners. I remember nearly giving up when I started fresh with C++ interop because I was running my C++ code with g++ on windows and being linked to my D code compiled with DMD. It was a next level headache being a beginner.
so it can just be a simple instruction to let users know that the following documentation works with this compiler1-compiler2 pair on platform A. Ditto for platform B and platform C.

@Geod24 
 