### PR TITLE
[spec/expression] Tweak lvalue section

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -51,31 +51,33 @@ $(H3 $(LNAME2 .define-lvalue, Lvalue))
 $(P The following expressions, and no others, are called *lvalue expressions* or *lvalues*:)
 $(OL
 $(LI $(RELATIVE_LINK2 this, `this`) inside `struct` and `union` member functions;)
-$(LI a variable, function name, or invocation of a function that returns by reference;)
-$(LI the result of the `.` $(GLINK PostfixExpression) or
+$(LI a variable, function name, or invocation of a function that
+$(DDSUBLINK spec/function, ref-functions, returns by reference);)
+$(LI the result of the `.` $(GLINK PostfixExpression) and
 $(DDSUBLINK spec/module, module_scope_operators, Module Scope Operator)
 when the rightmost side of the dot is a variable,
 field (direct or `static`), function name, or invocation of a function that returns by reference;)
 $(LI the result of the following expressions:
 $(UL
-$(LI built-in unary operators `+` (when applied to an lvalue), `*`, `++` (prefix only), `--` (prefix only);)
-$(LI built-in indexing operator `[]` (but not the slicing operator);)
-$(LI built-in assignment binary operators, i.e. `=`, `+=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `~=`,
+$(LI built-in $(RELATIVE_LINK2 unary-expression, unary operators) `+` (when applied to an lvalue), `*`, `++` (prefix only), `--` (prefix only);)
+$(LI built-in $(RELATIVE_LINK2 index_expressions, indexing operator) `[]` (but not the slicing operator);)
+$(LI built-in $(RELATIVE_LINK2 assign_expressions, assignment operators), i.e. `=`, `+=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `~=`,
 `<<=`, `>>=`, `>>>=`, and `^^=`;)
+$(LI $(DDLINK spec/operatoroverloading, Operator Overloading, user-defined operators)
+if and only if the function called as a result of lowering returns
+by reference;)
 $(LI the $(GLINK ConditionalExpression) operator $(I e) `?` $(I e$(SUBSCRIPT 1)) `:` $(I e$(SUBSCRIPT 2)) under the following
 circumstances:)
 $(OL
     $(LI $(I e$(SUBSCRIPT 1)) and $(I e$(SUBSCRIPT 2)) are lvalues of the same type; OR)
     $(LI One of $(I e$(SUBSCRIPT 1)) and $(I e$(SUBSCRIPT 2)) is an lvalue of type `T` and the other has
-    and `alias this` converting it to `ref T`;))
-$(LI $(DDLINK spec/operatoroverloading, Operator Overloading, user-defined operators)
-if and only if the function called as a result of lowering returns
-by reference;)
+    an `alias this` which converts it to an lvalue of `T`;))
 $(LI $(RELATIVE_LINK2 mixin_expressions, `mixin` expressions) if and only if the
 compilation of the expression resulting from compiling
 the argument(s) to `mixin` is an lvalue;)
-$(LI `cast(U)` expressions applied to lvalues of type `T` when `T*` is implicitly convertible to `U*`;)
-$(LI `cast()` and `cast(`$(I qualifier list)`)` when applied to an lvalue.)
+$(LI $(RELATIVE_LINK2 cast_expressions, `cast(U)` expressions) applied to lvalues
+of type `T` when `T*` is implicitly convertible to `U*`;)
+$(LI $(RELATIVE_LINK2 cast_qualifier, `cast(`$(I TypeCtors)$(OPT)`)`) when applied to an lvalue.)
 )))
 
 $(H3 $(LNAME2 .define-rvalue, Rvalue))


### PR DESCRIPTION
Add links.
`.` PostfixExpression *and* Module Scope Operator (using `or` it can read like the latter is an alternative name).
Move operator overloading below built-in operators. 
Fix conditional typo and allow field alias this to be an lvalue too. 
Use *TypeCtors* for CastQual.