### PR TITLE
[2.101 changelog] Fix `-preview=fixImmutableConv` entry

### DIFF
--- a/changelog/2.101.0.dd
+++ b/changelog/2.101.0.dd
@@ -20,7 +20,7 @@ $(LI $(RELATIVE_LINK2 dmd.deprecate_throwing_nothrow_contracts,Throwing from con
 $(LI $(RELATIVE_LINK2 dmd.deprecate_version_int,Using integers for `version` or `debug` conditions has been deprecated))
 $(LI $(RELATIVE_LINK2 dmd.dip1000_deprecation_warnings,Print deprecations for `scope` pointer errors))
 $(LI $(RELATIVE_LINK2 dmd.dtoh-improvements,Improvements for the C++ header generation))
-$(LI $(RELATIVE_LINK2 dmd.fix-immutable-conv,`-preview=fixImmmutableConv` has been added))
+$(LI $(RELATIVE_LINK2 dmd.fix-immutable-conv,`-preview=fixImmutableConv` has been added))
 $(LI $(RELATIVE_LINK2 dmd.fix22134,Returning a discarded void value from a function is now deprecated))
 $(LI $(RELATIVE_LINK2 dmd.importc_typeof,ImportC now recognizes the `typeof(...)` operator))
 $(LI $(RELATIVE_LINK2 dmd.markdown,Removed the `-transition=markdown` and `-revert=markdown` switches))
@@ -270,10 +270,10 @@ Note: The header generator is still considered experimental, so please submit
 )
 )
 
-$(LI $(LNAME2 dmd.fix-immutable-conv,`-preview=fixImmmutableConv` has been added)
+$(LI $(LNAME2 dmd.fix-immutable-conv,`-preview=fixImmutableConv` has been added)
 $(CHANGELOG_SOURCE_FILE dmd, changelog/dmd.fix-immutable-conv.dd)
 $(P
-The compiler allows implicitly converting a return value with indirections to immutable if it determines the result must be unique.
+The compiler allows implicitly converting a return value with indirections to immutable if it determines the result is unique.
 Formerly, this check would inspect the types of the indirections, and forget to take into account conversions, such as `int[]` to `void[]`:
 )
 
@@ -296,7 +296,7 @@ void main()
 $(P
 This was filed as [issue 15660](https://issues.dlang.org/show_bug.cgi?id=15660), which has been fixed some time ago by making the check more strict: the called function must be strongly pure.
 However, to avoid breaking code, the fix was only active with the `-preview=dip1000` switch.
-Since it is unrelated to dip1000 (which is about `scope` pointers), the fix has been moved to a new `-preview=fixImmmutableConv` switch.
+Since it is unrelated to dip1000 (which is about `scope` pointers), the fix has been moved to a new `-preview=fixImmutableConv` switch.
 )
 )
 


### PR DESCRIPTION
Fix typo so google finds searches for it.