### PR TITLE
[spec] Improve built-in property docs (part 2)

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -171,6 +171,19 @@ $(H3 $(LNAME2 field_properties, Field Properties))
 
 $(H2 $(LNAME2 class_properties, Class Properties))
 
+$(TABLE2 Class Instance Properties,
+$(THEAD Property, Description)
+$(TROW $(DDSUBLINK spec/property, classinfo, $(D .classinfo)),
+    Information about the dynamic type of the class.)
+$(TROW $(RELATIVE_LINK2 outer-property, `.outer`), $(ARGS For
+        a nested class instance, provides either the parent class instance,
+        or the parent function's context pointer when there is no parent
+        class.))
+$(TROW $(D .tupleof), See below.)
+)
+
+$(H3 $(LNAME2 tupleof, `.tupleof`))
+
         $(P The $(D .tupleof) property is an
         $(DDSUBLINK spec/template, homogeneous_sequences, lvalue sequence)
         of all the non-static fields in the class, excluding the hidden fields and
@@ -207,11 +220,6 @@ void main()
 )
 
 $(H3 $(LNAME2 hidden-fields, Accessing Hidden Fields))
-
-        $(P The $(RELATIVE_LINK2 outer-property, `.outer` property) for
-        a nested class instance provides either the parent class instance,
-        or the parent function's context pointer when there is no parent
-        class.)
 
         $(P The properties $(D .__vptr) and $(D .__monitor) give access
         to the class object's vtbl[] and monitor, respectively, but

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -161,13 +161,6 @@ void foo(B b)
         without the subclasses needing to recompile or relink.
         )
 
-$(H3 $(LNAME2 field_properties, Field Properties))
-
-        $(P The $(D .offsetof) property gives the offset in bytes of the field
-        from the beginning of the class instantiation.
-        `.offsetof` is not available for fields of `extern(Objective-C)` classes
-        due to their fields having a dynamic offset.
-        )
 
 $(H2 $(LNAME2 class_properties, Class Properties))
 
@@ -225,6 +218,16 @@ $(H3 $(LNAME2 hidden-fields, Accessing Hidden Fields))
         to the class object's vtbl[] and monitor, respectively, but
         should not be used in user code.
         )
+
+$(H3 $(LNAME2 field_properties, Field Properties))
+
+        $(P The $(D .offsetof) property gives the offset in bytes of the field
+        from the beginning of the class instantiation.
+        )
+        $(NOTE `.offsetof` is not available for fields of `extern(Objective-C)` classes
+        due to their fields having a dynamic offset.
+        )
+
 
 $(H2 $(LNAME2 member-functions, Member Functions (a.k.a. Methods)))
 

--- a/spec/property.dd
+++ b/spec/property.dd
@@ -63,12 +63,13 @@ $(TROW $(D (2.5F).nan),        yields the floating point NaN value)
 
 $(BR)
 
-$(TABLE2 Properties for Class Types,
-$(THEAD Property, Description)
-$(TROW $(RELATIVE_LINK2 classinfo, $(D .classinfo)), Information about the dynamic type of the class)
-)
-
-        $(P See also: $(DDSUBLINK spec/enum, enum_properties, Enum Properties).)
+        $(P See also:)
+        * $(DDSUBLINK spec/arrays, array-properties, Array Properties)
+        * $(DDSUBLINK spec/class, class_properties, Class Properties)
+        * $(DDSUBLINK spec/hash-map, properties, Associative Array Properties)
+        * $(DDSUBLINK spec/enum, enum_properties, Enum Properties)
+        * $(DDSUBLINK spec/struct, struct_properties, Struct Properties)
+        * $(DDSUBLINK spec/simd, properties, Vector Properties)
 
 
 $(H2 $(LNAME2 init, .init Property))

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -601,9 +601,8 @@ assert(u.c == false); // no overlap
 
 $(H2 $(LNAME2 struct_properties, Struct Properties))
 
-$(TABLE2 Struct Properties,
+$(TABLE2 Struct Type Properties,
 $(THEAD Name, Description)
-$(TROW $(D .sizeof), Size in bytes of struct)
 $(TROW $(D .alignof), Size boundary struct needs to be aligned on)
 )
 
@@ -613,7 +612,7 @@ $(TABLE2 Struct Instance Properties,
 $(THEAD Name, Description)
 $(TROW $(D .tupleof), An $(DDSUBLINK spec/template, homogeneous_sequences, lvalue sequence)
     of all struct fields - see
-    $(DDSUBLINK spec/class, class_properties, Class Properties) for a class-based example.)
+    $(DDSUBLINK spec/class, tupleof, here) for a class-based example.)
 )
 
 $(H3 $(LNAME2 struct_field_properties, Struct Field Properties))

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -978,7 +978,7 @@ $(H4 $(LNAME2 lvalue-sequences, Lvalue Sequences))
         )
 
     $(UL
-        $(LI `.tupleof` can be $(DDSUBLINK spec/class, class_properties, used on a class)
+        $(LI `.tupleof` can be $(DDSUBLINK spec/class, tupleof, used on a class)
             or struct instance to obtain an lvalue sequence of its fields.)
         $(LI `.tupleof` can be $(DDSUBLINK spec/arrays, array-properties, used on a static array)
             instance to obtain an lvalue sequence of its elements.)


### PR DESCRIPTION
Move class table to class.dd.
Add subheading for tupleof, update links.
Add links to other properties.
struct.dd: Remove struct sizeof as sizeof is for all types, no need to list here as well.