### PR TITLE
[spec] Avoid using 'you'

### DIFF
--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -44,9 +44,9 @@ $(H2 $(LNAME2 general_idea, The General Idea))
 
 $(H2 $(LNAME2 platform-compiler-support, Platform-Compiler Support))
 
-    $(P When building on windows, you should preferrably link your D code to MSVC compiled binaries.
-    You can link to both gcc and clang compiled binaries on linux.
-    On macOS, you should preferrably link to clang compiled binaries.)
+    * On Windows, prefer linking D code to MSVC compiled binaries.
+    * On Linux, linking to both GCC and Clang compiled binaries is supported.
+    * On MacOS, prefer linking to Clang compiled binaries.
 
 $(H2 $(LNAME2 global-functions, Global Functions))
 

--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -13,7 +13,8 @@ $(HEADERNAV_TOC)
         and function call/return sequences.
         )
 
-        $(P The $(DDLINK spec/importc, ImportC, ImportC) compiler extention lets you import or compile `.c` files directly. )
+        $(P The $(DDLINK spec/importc, ImportC, ImportC) compiler extension allows
+        importing or compiling `.c` files directly. )
 
         $(P Bindings for popular C libraries can be found in the
             $(LINK2 https://dlang.org/phobos/index.html, standard library) and


### PR DESCRIPTION
Also fix 'preferrably', 'extention' typos.