### PR TITLE
[deprecate] Hex strings are no longer deprecated

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -11,7 +11,7 @@ $(SPEC_S Deprecated Features,
     $(TABLE2 Deprecated Features,
         $(THEAD Feature,                                                          Spec,  Dep,    Error,  Gone)
         $(TROW $(DEPLINK Throwing from contracts of nothrow functions),           &nbsp;, 2.101, 2.111, &nbsp;)
-        $(TROW $(DEPLINK Hexstring literals),                                     2.079, 2.079, 2.086, &nbsp;)
+        $(TROW $(COMMENT DEPLINK Hexstring literals),                             2.079,  2.079, 2.086, &nbsp;)
         $(TROW $(DEPLINK Class allocators and deallocators),                      &nbsp;, 2.080, 2.087, 2.100 )
         $(TROW $(DEPLINK Implicit comparison of different enums),                 2.075,  2.075, 2.081, &nbsp;)
         $(TROW $(DEPLINK Implicit string concatenation),                          2.072,  2.072, 2.081, &nbsp;)
@@ -49,7 +49,7 @@ $(SPEC_S Deprecated Features,
         $(TROW $(DEPLINK .offset property),                                       ?,     0.107,  2.061,  2.067 )
         $(TROW $(DEPLINK .size property),                                         ?,     0.107,  0.107,  2.061 )
         $(TROW $(DEPLINK .typeinfo property),                                     ?,     0.093,  2.061,  2.067 )
-        $(TROW $(DEPLINK unannotated asm blocks),                                 &nbsp;, &nbsp, &nbsp;, 2.100 )
+        $(TROW $(DEPLINK unannotated asm blocks),                                 &nbsp;, &nbsp, 2.100,  (never) )
     )
 
     $(DL
@@ -99,6 +99,7 @@ $(H4 Rationale)
         would break the guarantees of the $(D nothrow) attribute.
     )
 
+$(COMMENT
 $(H3 $(DEPNAME Hexstring literals))
     $(P Hexstring literals can be used to enter literals in base 16.
         ---
@@ -115,6 +116,7 @@ $(H4 Corrective Action)
 $(H4 Rationale)
     $(P Hexstrings are used so seldom that they don't warrant a language feature.
     )
+)
 
 $(H3 $(DEPNAME Class allocators and deallocators))
     $(P D classes can have members customizing the (de)allocation strategy.


### PR DESCRIPTION
I'm not sure when they were undeprecated. _Edit_: https://github.com/dlang/dmd/pull/15393, so probably 2.106, though they're not mentioned in the changelog.

E.g. they're mentioned in this changelog:
https://dlang.org/changelog/2.108.0.html#dmd.hexstring-cast

Also fix `asm` attribute error column.