### PR TITLE
[spec/statement] ForeachRangeStatement variable cannot be `ref`

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1207,7 +1207,9 @@ $(GNAME ForeachRangeStatement):
         The $(I ScopeStatement) is then executed $(I n) times, where $(I n)
         is the result of $(I UprExpression) `-` $(I LwrExpression).
         If $(I UprExpression) is less than or equal to $(I LwrExpression),
-        the $(I ScopeStatement) is not executed.)
+        the $(I ScopeStatement) is not executed.
+        $(I ForeachType) cannot be declared with `ref`.
+        )
 
         $(P
         If $(I Foreach) is $(D foreach), then the variable is set to


### PR DESCRIPTION
For https://github.com/dlang/dmd/pull/16381.