### PR TITLE
Update faq.dd to fix broken link to Kahan's paper on Java floats.

### DIFF
--- a/articles/faq.dd
+++ b/articles/faq.dd
@@ -360,7 +360,7 @@ $(ITEM real, What is the point of 80 bit reals?)
         to be done, especially when adding together large numbers of small
         real numbers. Prof. Kahan, who designed the Intel floating point
         unit, has an eloquent
-        <a href="http://http.cs.berkeley.edu/~wkahan/JAVAhurt.pdf">paper</a>
+        <a href="https://people.eecs.berkeley.edu/~wkahan/JAVAhurt.pdf">paper</a>
         on the subject.
 
 $(ITEM anonymous, How do I do anonymous struct/unions in D?)


### PR DESCRIPTION
Link was broken,  original link was old enough that redirect no longer applied.