### PR TITLE
[spec] Remove @ from keyword attribute

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -590,7 +590,7 @@ $(H3 $(LNAME2 gshared, $(D __gshared) Attribute))
 
         $(P $(D __gshared) is disallowed in `@safe` code.)
 
-$(H3 $(LNAME2 synchronized, $(D @synchronized) Attribute))
+$(H3 $(LNAME2 synchronized, $(D synchronized) Attribute))
 
         $(P See $(DDSUBLINK spec/class, synchronized-classes, Synchronized Classes).)
 


### PR DESCRIPTION
The spec has a heading for a '@synchronized Attribute'. No other part of the spec prefixes this keyword with an at-sign, and according to DMD on run.dlang.io:
```d
@synchronized class Test{}
//onlineapp.d(3): Error: `synchronized` is a keyword, not an `@` attribute
```