### PR TITLE
Expand & improve `comparison.dd`

### DIFF
--- a/comparison.dd
+++ b/comparison.dd
@@ -5,20 +5,22 @@ $(COMMUNITY D Concepts Overview,
 $(P Navigate D's implementation of a few key programming language concepts.)
 
 $(ITEMIZE
-        $(A spec/garbage.html, Garbage Collection),
+        $(A spec/garbage.html, Garbage Collection)
+        $(ITEMIZE
+            $(REF_ALTTEXT Manual invocation, GC.enable, core,memory),
+            $(A spec/function.html#nogc-functions, `@nogc` subset)
+        ),
         Functions
         $(ITEMIZE
-                $(A spec/type.html#delegates, Function Delegates),
                 $(A spec/function.html#function-overloading, Function Overloading),
-                $(A spec/function.html#parameters, `out` parameters for functions),
+                $(A spec/function.html#ref-params, `ref` and `out` function parameters),
+                $(A spec/type.html#delegates, Function Delegates),
                 $(A spec/function.html#nested, Nested functions),
                 $(A spec/expression.html#FunctionLiteral, Function literals),
                 $(A spec/function.html#closures, Closures),
                 $(A spec/function.html#variadic, Typesafe variadic arguments),
                 $(A lazy-evaluation.html, Lazy function argument evaluation),
-                $(A spec/function.html#interpretation, Compile time function evaluation),
-                $(A spec/function.html#pseudo-member, Uniform Function Call Syntax),
-                $(A spec/attribute.html#UserDefinedAttribute, User-Defined Attributes)
+                $(A spec/function.html#pseudo-member, Uniform Function Call Syntax)
         ),
         Arrays
         $(ITEMIZE
@@ -28,13 +30,12 @@ $(ITEMIZE
                 $(A spec/arrays.html#slicing, Array slicing),
                 $(A spec/arrays.html#bounds, Array bounds checking),
                 $(A spec/expression.html#ArrayLiteral, Array literals),
-                $(A spec/arrays.html#associative, Associative arrays),
                 $(A spec/statement.html#SwitchStatement, String switches),
-                $(A spec/declaration.html#alias, Aliases)
+                $(A spec/arrays.html#associative, Associative arrays)
         ),
         OOP
         $(ITEMIZE
-                Object Orientation,
+                $(A spec/class.html, Object Orientation),
                 $(A spec/interface.html, Interfaces),
                 Single inheritance of implementation/multiple inheritance of interfaces,
                 $(A spec/operatoroverloading.html, Operator overloading),
@@ -43,7 +44,7 @@ $(ITEMIZE
                 $(A spec/class.html#nested, Nested classes),
                 $(A spec/class.html#nested, Inner (adaptor) classes),
                 $(A spec/function.html, Covariant return types),
-                $(A spec/property.html#classproperties, Properties)
+                $(A spec/function.html#property-functions, Properties)
         ),
         Performance
         $(ITEMIZE
@@ -54,43 +55,76 @@ $(ITEMIZE
                 Independent of VM,
                 Direct native code gen
         ),
-        $(A spec/template.html, Generic Programming)
+        Generic Programming
         $(ITEMIZE
-                Class Templates,
+                $(A spec/declaration.html#AutoDeclaration, Implicit Type Inference),
+                $(A spec/statement.html#ForeachStatement, `foreach`),
+                $(MREF_ALTTEXT Ranges, std,range),
+                $(MREF_ALTTEXT Algorithms, std,algorithm),
+                $(A spec/declaration.html#alias, Aliases),
+                $(A spec/template.html, Templates)
+                $(ITEMIZE
+                $(A spec/template.html#aggregate_templates, Aggregate Templates),
                 $(A spec/template.html#function-templates, Function Templates),
-                Implicit Function Template Instantiation,
-                Partial and Explicit Specialization,
-                Value Template Parameters,
-                Template Template Parameters,
+                $(A spec/template.html#ifti, Implicit Function Template Instantiation),
+                $(A spec/template.html#parameters_specialization, Partial and Explicit Template Specialization),
+                $(A spec/template.html#template_value_parameter, Value Template Parameters),
+                $(A spec/template.html#aliasparameters, Alias Template Parameters),
                 $(A articles/variadic-function-templates.html, Variadic Template Parameters),
-                $(A concepts.html, Template Constraints),
+                $(A articles/constraints.html, Template Constraints)
+                )
+                $(A spec/expression.html#IsExpression, `is` expressions),
+                $(A spec/type.html#Typeof, `typeof`)
+        ),
+        Metaprogramming
+        $(ITEMIZE
+                $(A spec/function.html#interpretation, Compile Time Function Evaluation),
                 $(A spec/template-mixin.html, Template Mixins),
-                $(A spec/version.html#staticif, static if),
-                $(A spec/expression.html#IsExpression, expressions),
-                $(A spec/type.html#Typeof, typeof),
-                $(A spec/statement.html#ForeachStatement, foreach),
-                $(A spec/declaration.html#AutoDeclaration, Implicit Type Inference)
+                $(A articles/mixin.html, String Mixins),
+                $(A spec/version.html#staticif, `static if`),
+                $(A spec/version.html#staticforeach, `static foreach`)
         ),
         Reliability
         $(ITEMIZE
                 $(A spec/contracts.html, Contract Programming),
                 $(A spec/unittest.html, Unit testing),
+                $(A spec/const3.html, Immutable data),
                 $(A spec/module.html#staticorder, Static construction order),
-                $(A spec/statement.html#DeclarationStatement, Guaranteed initialization),
-                $(A https://wiki.dlang.org/Memory_Management#RAII_.28Resource_Acquisition_Is_Initialization.29, RAII (automatic destructors)),
+                $(A spec/declaration.html#initialization, Initialization by default),
+                $(A spec/glossary.html#raii, RAII (implicit destructor calls)),
                 $(A spec/statement.html#TryStatement, Exception handling),
                 $(A spec/statement.html#ScopeGuardStatement, Scope guards),
-                $(A spec/statement.html#TryStatement, try-catch-finally blocks),
+                $(A spec/statement.html#TryStatement, `try`-`catch`-`finally` blocks),
+                $(A articles/safed.html, Memory-safe subset)
+        ),
+        Concurrency & Parallelism
+        $(ITEMIZE
+                $(MREF_ALTTEXT Concurrency, std,concurrency),
+                $(MREF_ALTTEXT Fibers, core,thread,fiber),
+                $(REF parallel, std,parallelism),
+                $(A articles/migrate-to-shared.html, Thread Local Storage by default),
+                $(A spec/const3.html#shared, Shared data),
                 $(A spec/statement.html#SynchronizedStatement, Thread synchronization primitives)
+        ),
+        Types
+        $(ITEMIZE
+                $(A spec/struct.html, Structs and Unions),
+                $(A spec/enum.html, Enumerated types),
+                $(A spec/float.html, 80 bit floating point),
+                $(A phobos/std_complex.html, Complex and Imaginary),
+                $(A spec/type.html#pointers, Pointers),
+                $(REF_ALTTEXT Tuples, Tuple, std,typecons),
+                $(A spec/struct.html#alias-this, Alias This)
         ),
         Compatibility
         $(ITEMIZE
         C-like syntax,
-                $(A spec/enum.html, Enumerated types),
                 $(A spec/type.html, Support for all C types),
-                $(A spec/type.html, 80 bit floating point),
-                $(A phobos/std_complex.html, Complex and Imaginary),
+                $(A spec/statement.html#NonEmptyStatementNoCaseNoDefault,
+                    `if`, `while`, `do`, `for`, `switch`, `goto`),
                 $(A spec/attribute.html#linkage, Direct access to C),
+                $(A spec/importc.html, Import C code),
+                $(A spec/betterc.html, Better C subset),
                 Use existing debuggers,
                 $(A spec/attribute.html#align, Struct member alignment control),
                 Generates standard object files,
@@ -100,7 +134,10 @@ $(ITEMIZE
         $(ITEMIZE
                 $(A spec/version.html, Conditional compilation),
                 $(A spec/lex.html, Unicode source text),
-                $(A spec/ddoc.html, Documentation comments)
+                $(A spec/statement.html#with-statement, `with` statement),
+                $(A spec/attribute.html#UserDefinedAttribute, User-Defined Attributes),
+                $(A spec/ddoc.html, Documentation comments),
+                $(A spec/ddoc.html#using_ddoc_to_generate_examples, Documented unit tests)
         )
 )
 

--- a/comparison.dd
+++ b/comparison.dd
@@ -14,6 +14,7 @@ $(ITEMIZE
         $(ITEMIZE
                 $(A spec/function.html#function-overloading, Function Overloading),
                 $(A spec/function.html#ref-params, `ref` and `out` function parameters),
+                $(A spec/function.html#ref-functions, `ref` functions),
                 $(A spec/type.html#delegates, Function Delegates),
                 $(A spec/function.html#nested, Nested functions),
                 $(A spec/expression.html#FunctionLiteral, Function literals),
@@ -89,6 +90,7 @@ $(ITEMIZE
                 $(A spec/contracts.html, Contract Programming),
                 $(A spec/unittest.html, Unit testing),
                 $(A spec/const3.html, Immutable data),
+                $(A spec/function.html#pure-functions, Pure functions),
                 $(A spec/module.html#staticorder, Static construction order),
                 $(A spec/declaration.html#initialization, Initialization by default),
                 $(A spec/glossary.html#raii, RAII (implicit destructor calls)),

--- a/comparison.dd
+++ b/comparison.dd
@@ -31,7 +31,7 @@ $(ITEMIZE
                 $(A spec/arrays.html#slicing, Array slicing),
                 $(A spec/arrays.html#bounds, Array bounds checking),
                 $(A spec/expression.html#ArrayLiteral, Array literals),
-                $(A spec/statement.html#SwitchStatement, String switches),
+                $(A spec/statement.html#string-switch, String switches),
                 $(A spec/arrays.html#associative, Associative arrays)
         ),
         OOP
@@ -44,7 +44,7 @@ $(ITEMIZE
                 No built-in dynamic class loading,
                 $(A spec/class.html#nested, Nested classes),
                 $(A spec/class.html#nested, Inner (adaptor) classes),
-                $(A spec/function.html, Covariant return types),
+                $(A spec/function.html#covariance, Covariant return types),
                 $(A spec/function.html#property-functions, Properties)
         ),
         Performance


### PR DESCRIPTION
Add items:
* GC: manual invocation, `@nogc`
* Functions: `ref`

Reorder items a bit, indent some.

Move:
CTFE -> Metaprogramming
Aliases -> Generic
UDAs -> Other

Generic:
Add foreach, ranges, algorithms, aggregate templates. 
Rename Template Template parameters to alias parameters.

Change links:
Properties (more direct)
concepts (wrong) -> constraints
raii -> glossary more formal than wiki
80-bit -> vague type.html to float.html

Add links.

Add Metaprogramming group with string mixins and static foreach.

Reliability: immutable, @safe.

Add concurrency group: spawn, fibers, parallel, TLS, shared.

Add Types group with struct, union, pointers, tuples. Move enum, 80-bit, complex to Types.

Compat: C statements, importc, betterc.

Other: `with`, documented unittests.