### PR TITLE
[spec/template] Tweak template value parameters

### DIFF
--- a/spec/template.dd
+++ b/spec/template.dd
@@ -525,23 +525,29 @@ $(GNAME TemplateValueParameterDefault):
 )
 
     $(P A template value parameter can take an argument of any expression which can
-        be statically evaluated at compile time.
-        Template value arguments can be integer values, floating point values,
-        nulls, string values, array literals of template value arguments,
-        associative array literals of template value arguments,
-        or struct literals of template value arguments.)
+        be statically evaluated at compile time:)
+
+        * `bool` values
+        * Character values
+        * Integer values
+        * Floating point values
+        * `null`
+        * String values
+        * Array literals of valid template value arguments
+        * Associative array literals of valid template value arguments
+        * Struct literals of valid template value arguments
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
         -----
         template foo(string s)
         {
-            string bar() { return s ~ " betty"; }
+            enum string bar = s ~ " betty";
         }
 
         void main()
         {
             import std.stdio;
-            writeln(foo!("hello").bar()); // prints: hello betty
+            writeln(foo!("hello").bar); // prints: hello betty
         }
         -----
         )

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -527,7 +527,7 @@ $(GNAME TemplateValueParameterDefault):
     $(P A template value parameter can take an argument of any expression which can
         be statically evaluated at compile time as one of the following:)
 
-        * A `bool`, character, integer or string value
+        * A `bool`, character, integer, floating point or string value
         * `null`
         * An array literal whose elements could be valid template value arguments
         * An associative array literal whose keys and values could each be valid

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -525,17 +525,14 @@ $(GNAME TemplateValueParameterDefault):
 )
 
     $(P A template value parameter can take an argument of any expression which can
-        be statically evaluated at compile time:)
+        be statically evaluated at compile time as one of the following:)
 
-        * `bool` values
-        * Character values
-        * Integer values
-        * Floating point values
+        * A `bool`, character, integer or string value
         * `null`
-        * String values
-        * Array literals of valid template value arguments
-        * Associative array literals of valid template value arguments
-        * Struct literals of valid template value arguments
+        * An array literal whose elements could be valid template value arguments
+        * An associative array literal whose keys and values could each be valid
+          template value arguments
+        * A struct literal whose arguments could be valid template value arguments
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
         -----


### PR DESCRIPTION
Use list of argument kinds, add booleans & characters. 
Use '*valid* template value arguments' for clarity. 
Tweak example to use enum instead of function.