### PR TITLE
Rename FunctionLiteralBody2 to FunctionLiteralBody

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2255,9 +2255,9 @@ $(H3 $(LNAME2 function_literals, Function Literals))
 
 $(GRAMMAR
 $(GNAME FunctionLiteral):
-    $(D function) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithAttributes)$(OPT) $(GLINK FunctionLiteralBody2)
-    $(D delegate) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithMemberAttributes)$(OPT) $(GLINK FunctionLiteralBody2)
-    $(GLINK RefOrAutoRef)$(OPT) $(GLINK ParameterWithMemberAttributes) $(GLINK FunctionLiteralBody2)
+    $(D function) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithAttributes)$(OPT) $(GLINK FunctionLiteralBody)
+    $(D delegate) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithMemberAttributes)$(OPT) $(GLINK FunctionLiteralBody)
+    $(GLINK RefOrAutoRef)$(OPT) $(GLINK ParameterWithMemberAttributes) $(GLINK FunctionLiteralBody)
     $(GLINK2 statement, BlockStatement)
     $(IDENTIFIER) $(D =>) $(GLINK AssignExpression)
 
@@ -2267,7 +2267,7 @@ $(GNAME ParameterWithAttributes):
 $(GNAME ParameterWithMemberAttributes):
     $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT)
 
-$(GNAME FunctionLiteralBody2):
+$(GNAME FunctionLiteralBody):
     $(D =>) $(GLINK AssignExpression)
     $(GLINK2 function, SpecifiedFunctionBody)
 
@@ -2313,7 +2313,7 @@ $(GNAME RefOrAutoRef):
         }
         -------------
 
-    $(P A delegate is necessary if the $(I FunctionLiteralBody2) accesses any non-static
+    $(P A delegate is necessary if the $(I FunctionLiteralBody) accesses any non-static
         local variables in enclosing functions.)
 
         -------------


### PR DESCRIPTION
There is no `FunctionLiteralBody1` or `FunctionLiteralBody`, appending 2 is confusing.