### PR TITLE
Regenerate contributors in 2.109 changelog

### DIFF
--- a/changelog/2.109.0.dd
+++ b/changelog/2.109.0.dd
@@ -7,7 +7,7 @@ $(VERSION Jun 01, 2024, =================================================,
 $(CHANGELOG_HEADER_STATISTICS
 $(VER) comes with 15 major changes and 26 fixed Bugzilla issues.
         A huge thanks goes to the
-        $(LINK2 #contributors, 44 contributors)
+        $(LINK2 #contributors, 39 contributors)
         who made $(VER) possible.)
 
 $(BUGSTITLE_TEXT_HEADER Compiler changes,
@@ -532,7 +532,7 @@ $(BUGSTITLE_BUGZILLA dlang.org enhancements,
 $(LI $(BUGZILLA 24488): contributor guide hard to find from home page)
 )
 )
-$(D_CONTRIBUTORS_HEADER 44)
+$(D_CONTRIBUTORS_HEADER 39)
 $(D_CONTRIBUTORS
     $(D_CONTRIBUTOR 0-v-0)
     $(D_CONTRIBUTOR Adam Wilson)
@@ -565,11 +565,6 @@ $(D_CONTRIBUTORS
     $(D_CONTRIBUTOR Paul Backus)
     $(D_CONTRIBUTOR Petar Kirov)
     $(D_CONTRIBUTOR Razvan Nitu)
-    $(D_CONTRIBUTOR richard (rikki) andrew cattermole)
-    $(D_CONTRIBUTOR Richard (Rikki) Andrew Cattermole)
-    $(D_CONTRIBUTOR richard (rikki) andrew cattermole)
-    $(D_CONTRIBUTOR Richard (Rikki) Andrew Cattermole)
-    $(D_CONTRIBUTOR richard (rikki) andrew cattermole)
     $(D_CONTRIBUTOR Richard (Rikki) Andrew Cattermole)
     $(D_CONTRIBUTOR shoo)
     $(D_CONTRIBUTOR Steven Schveighoffer)


### PR DESCRIPTION
Using updated git mailmap, in https://github.com/dlang/tools/pull/474
```
rdmd -version=Contributors_Lib changed v2.108.1..origin/stable \
    --version=2.109.0 --date="$DATE" --output=../dlang.org/changelog/2.109.0.dd
```
