### PR TITLE
[spec] Document unsafe bool operations

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1350,6 +1350,9 @@ $(H4 $(LNAME2 cast_array, Arrays))
             ---
         )
 
+    $(IMPLEMENTATION_DEFINED Casting a non-literal array to `bool[]` when any
+        element has a byte representation $(DDSUBLINK spec/type, bool, other than 0 or 1).)
+
     $(DDOC_SEE_ALSO $(RELATIVE_LINK2 cast_array_literal, Casting array literals).)
 
 $(H4 $(LNAME2 cast_static_array, Static Arrays))

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1350,7 +1350,7 @@ $(H4 $(LNAME2 cast_array, Arrays))
             ---
         )
 
-    $(IMPLEMENTATION_DEFINED Casting a non-literal array to `bool[]` when any
+    $(UNDEFINED_BEHAVIOR Casting a non-literal array to `bool[]` when any
         element has a byte representation $(DDSUBLINK spec/type, bool, other than 0 or 1).)
 
     $(DDOC_SEE_ALSO $(RELATIVE_LINK2 cast_array_literal, Casting array literals).)

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -548,7 +548,7 @@ values `false` and `true`, respectively. Casting an expression to `bool` means
 testing for `0` or `!=0` for arithmetic types, and `null` or `!=null` for
 pointers or references.)
 
-$(IMPLEMENTATION_DEFINED)
+$(UNDEFINED_BEHAVIOR)
 * Interpreting a value with a byte representation
   other than 0 or 1 as `bool` (e.g. an overlapped union field).
 * Reading a `void`-initialized `bool`.

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -545,7 +545,7 @@ $(P A `bool` value can be implicitly converted to any integral type, with
 
 $(P The numeric literals `0` and `1` can be implicitly converted to the `bool`
 values `false` and `true`, respectively. Casting an expression to `bool` means
-testing for `0` or `!=0` for arithmetic types, and `null` or `!=null` for
+testing `!=0` for arithmetic types, and `!=null` for
 pointers or references.)
 
 $(UNDEFINED_BEHAVIOR)
@@ -553,6 +553,17 @@ $(UNDEFINED_BEHAVIOR)
   other than 0 or 1 as `bool` (e.g. an overlapped union field).
 * Reading a `void`-initialized `bool`.
 
+$(SPEC_RUNNABLE_EXAMPLE_RUN
+---
+byte i = 2;
+bool b = cast(bool) i; // OK, same as `i != 0`
+assert(b);
+
+bool* p = cast(bool*) &i; // unsafe cast
+// `*p` holds 0x2, an invalid bool value
+// reading `*p` is undefined behavior
+---
+)
 
 $(H2 $(LNAME2 functions, Function Types))
 

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -548,6 +548,11 @@ values `false` and `true`, respectively. Casting an expression to `bool` means
 testing for `0` or `!=0` for arithmetic types, and `null` or `!=null` for
 pointers or references.)
 
+$(IMPLEMENTATION_DEFINED)
+* Interpreting a value with a byte representation
+  other than 0 or 1 as `bool` (e.g. an overlapped union field).
+* Reading a `void`-initialized `bool`.
+
 
 $(H2 $(LNAME2 functions, Function Types))
 


### PR DESCRIPTION
The following are implementation defined for bool:

* Casting runtime array to `bool[]`
* Reinterpreting a byte as bool (e.g. by union field)
* `void` initialization

Note: Only 0 or 1 are safe values:
https://dlang.org/spec/function.html#safe-values