### PR TITLE
Reorganize function parameter grammar

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -42,12 +42,13 @@ $(GNAME ParameterList):
     $(GLINK VariadicArgumentsAttributes)$(OPT) $(D ...)
 
 $(GNAME Parameter):
+    $(GLINK ParameterDeclaration)
+    $(GLINK ParameterDeclaration) $(D ...)
+    $(GLINK ParameterDeclaration) $(D =) $(ASSIGNEXPRESSION)
+
+$(GNAME ParameterDeclaration):
     $(GLINK ParameterAttributes)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator)
-    $(GLINK ParameterAttributes)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator) $(D ...)
-    $(GLINK ParameterAttributes)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator) $(D =) $(ASSIGNEXPRESSION)
     $(GLINK ParameterAttributes)$(OPT) $(GLINK2 type, Type)
-    $(GLINK ParameterAttributes)$(OPT) $(GLINK2 type, Type) $(D ...)
-    $(GLINK ParameterAttributes)$(OPT) $(GLINK2 type, Type) $(D =) $(ASSIGNEXPRESSION)
 
 $(GNAME ParameterAttributes):
     $(GLINK ParameterStorageClass)


### PR DESCRIPTION
Removes the duplication of *empty*/`...`/`=` *`AssignExpression`*
```diff
    Parameter:
-       ParameterAttributes? BasicType Declarator
-       ParameterAttributes? BasicType Declarator ...
-       ParameterAttributes? BasicType Declarator = AssignExpression
-       ParameterAttributes? Type
-       ParameterAttributes? Type ...
-       ParameterAttributes? Type = AssignExpression
+       ParameterDeclaration
+       ParameterDeclaration ...
+       ParameterDeclaration = AssignExpression
+
+   ParameterDeclaration:
+       ParameterAttributes? BasicType Declarator
+       ParameterAttributes? Type
```