### PR TITLE
Rename FunctionLiteralBody2 to FunctionLiteralBody

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1729,7 +1729,8 @@ $(H3 $(LEGACY_LNAME2 slice_operations, slice_expressions, Slice Operations))
 $(GRAMMAR
 $(GNAME SliceOperation):
     $(D [ ])
-    $(D [) $(GLINK Slice) $(D ,)$(OPT) $(D ])
+    $(D [) $(GLINK Slice) $(D ])
+    $(D [) $(GLINK Slice) $(D ,) $(D ])
 
 $(GNAME Slice):
     $(GLINK AssignExpression)
@@ -2271,9 +2272,9 @@ $(H3 $(LNAME2 function_literals, Function Literals))
 
 $(GRAMMAR
 $(GNAME FunctionLiteral):
-    $(D function) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithAttributes)$(OPT) $(GLINK FunctionLiteralBody2)
-    $(D delegate) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithMemberAttributes)$(OPT) $(GLINK FunctionLiteralBody2)
-    $(GLINK RefOrAutoRef)$(OPT) $(GLINK ParameterWithMemberAttributes) $(GLINK FunctionLiteralBody2)
+    $(D function) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithAttributes)$(OPT) $(GLINK FunctionLiteralBody)
+    $(D delegate) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithMemberAttributes)$(OPT) $(GLINK FunctionLiteralBody)
+    $(GLINK RefOrAutoRef)$(OPT) $(GLINK ParameterWithMemberAttributes) $(GLINK FunctionLiteralBody)
     $(GLINK2 statement, BlockStatement)
     $(IDENTIFIER) $(D =>) $(GLINK AssignExpression)
 
@@ -2283,7 +2284,7 @@ $(GNAME ParameterWithAttributes):
 $(GNAME ParameterWithMemberAttributes):
     $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT)
 
-$(GNAME FunctionLiteralBody2):
+$(GNAME FunctionLiteralBody):
     $(D =>) $(GLINK AssignExpression)
     $(GLINK2 function, SpecifiedFunctionBody)
 
@@ -2329,7 +2330,7 @@ $(GNAME RefOrAutoRef):
         }
         -------------
 
-    $(P A delegate is necessary if the $(I FunctionLiteralBody2) accesses any non-static
+    $(P A delegate is necessary if the $(I FunctionLiteralBody) accesses any non-static
         local variables in enclosing functions.)
 
         -------------
@@ -2612,8 +2613,10 @@ $(GNAME AssertExpression):
     $(D assert $(LPAREN)) $(GLINK AssertArguments) $(D $(RPAREN))
 
 $(GNAME AssertArguments):
-    $(GLINK AssignExpression) $(D ,)$(OPT)
-    $(GLINK AssignExpression) $(D ,) $(GLINK AssignExpression) $(D ,)$(OPT)
+    $(GLINK AssignExpression)
+    $(GLINK AssignExpression) $(D ,)
+    $(GLINK AssignExpression) $(D ,) $(GLINK AssignExpression)
+    $(GLINK AssignExpression) $(D ,) $(GLINK AssignExpression) $(D ,)
 )
 
     $(P The first $(I AssignExpression) is evaluated and


### PR DESCRIPTION
There is no `FunctionLiteralBody1` or `FunctionLiteralBody`, appending 2 is confusing.