### PR TITLE
[spec/function] Improve safe cast rules

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -3795,14 +3795,24 @@ $(H3 $(LNAME2 safe-functions, Safe Functions))
         $(UL
         $(LI No casting from a pointer type `T` to any type `U` with pointers, except when:)
             * `T` implicitly converts to `U`
-            * `U` implements class or interface `T`
+            * `U` $(DDSUBLINK spec/expression, cast_class, implements) class or interface
+              `T`, and both types are `extern(D)`
             * `T.opCast!U` is `@safe`
-            * Both types $(DDSUBLINK spec/expression, cast_array, are dynamic arrays) and:
-                * Casting a source element to a target element type is `@safe`
+            * Both types $(DDSUBLINK spec/expression, cast_array, are dynamic arrays), or
+              both types $(DDSUBLINK spec/expression, cast_pointers, are raw pointers), and:
+                * The target element type is not a pointer type
+                * The target element type is not mutable when the source element type is a pointer type
+                * Either the target element type is a dynamic array, or the target element
+                  type is no larger than the source element type
+                * Any source element type modifiers implicitly convert to the target element type modifiers
+                * Neither element type is a function type
                 * The target element type is not mutable when the source type is `void[]`
-                * The target type is not `bool[]` unless the operand is a literal
+                * The target element type is not $(DDSUBLINK spec/type, bool, `bool`)
+                * The source element type is not `bool` when the target element type is mutable
+                * Neither element type is $(DDSUBLINK spec/struct, opaque_struct_unions, opaque).
         $(LI No casting from any non-pointer type to a pointer type.)
-        $(LI No pointer arithmetic (including pointer indexing & slicing).)
+        $(LI No $(DDSUBLINK spec/expression, pointer_arithmetic, pointer arithmetic)
+            (including pointer indexing & slicing).)
         $(LI Cannot access union fields that:)
             * Have pointers or references overlapping with other types
             * Have invariants overlapping with other types


### PR DESCRIPTION
Add links.
Casting pointer to pointer has the same rules as dynamic arrays.
Fix wrong item about casting dynamic arrays - it's not the same as casting element types. Add detail instead.
Above changes based on https://github.com/dlang/dmd/blob/master/compiler/src/dmd/safe.d#L213-L277.

Document https://github.com/dlang/dmd/pull/16622.