### PR TITLE
Replace `GRAMMAR_INFORMATIVE` by `INFORMATIVE_GRAMMAR`

### DIFF
--- a/book/dlang.org.ddoc
+++ b/book/dlang.org.ddoc
@@ -184,7 +184,7 @@ GLOSSARY = $(HTTP dlang.org/spec/glossary.html#$0, $0)
 GLOSSARY2 = $(HTTP dlang.org/spec/glossary.html#$1, $2)
 GNAME=<a id="$0">$(SPANC gname, $0)</a>
 GRAMMAR=$(TC pre, bnf notranslate, $0)
-GRAMMAR_INFORMATIVE=$(GRAMMAR $0)
+INFORMATIVE_GRAMMAR=$(GRAMMAR $0)
 GRAMMAR_LEX=$(GRAMMAR $0)
 GREEN=$(SPANC green, $0)
 GSELF=$(I $0)

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -185,7 +185,7 @@ GLOSSARY = $(HTTP dlang.org/spec/glossary.html#$0, $0)
 GLOSSARY2 = $(HTTP dlang.org/spec/glossary.html#$1, $2)
 GNAME=<a id="$0">$(SPANC gname, $0)</a>
 GRAMMAR=$(TC pre, bnf notranslate, $0)
-GRAMMAR_INFORMATIVE=$(GRAMMAR $0)
+INFORMATIVE_GRAMMAR=$(GRAMMAR $0)
 GRAMMAR_LEX=$(GRAMMAR $0)
 GREEN=$(SPANC green, $0)
 GSELF=$(I $0)

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -1446,7 +1446,7 @@ $(GNAME AnonBaseClassList):
 
 which is equivalent to:
 
-$(GRAMMAR_INFORMATIVE
+$(INFORMATIVE_GRAMMAR
 $(D class) $(GLINK_LEX Identifier) $(D :) $(I AnonBaseClassList) $(I AggregateBody)
 // ...
 $(D new) $(I Identifier) $(I ConstructorArgs)

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -3293,7 +3293,7 @@ void foo()
 
 $(H4 $(LNAME2 is-parameter-list, Parameter List Forms))
 
-$(GRAMMAR_INFORMATIVE
+$(INFORMATIVE_GRAMMAR
 $(D is $(LPAREN)) $(I Type) $(D :) $(I TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))
 $(D is $(LPAREN)) $(I Type) $(D ==) $(I TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))
 $(D is $(LPAREN)) $(I Type) $(I Identifier) $(D :) $(I TypeSpecialization) $(D ,) $(GLINK2 template, TemplateParameterList) $(D $(RPAREN))

--- a/spec/grammar.dd
+++ b/spec/grammar.dd
@@ -8,7 +8,7 @@ $(H2 Lexical Syntax)
 
     $(P Refer to the page for $(LINK2 lex.html, lexical syntax).)
 
-$(GRAMMAR_SUMMARY)
+$(SUMMARY_GRAMMAR)
 
 $(SPEC_SUBNAV_PREV_NEXT istring, Interpolation Expression Sequence, module, Modules)
 )
@@ -29,4 +29,4 @@ Macros:
         PSCURLYSCOPE=$(GLINK NonEmptyOrScopeBlockStatement)
         TRAITS_LINK2=$(LINK2 traits.html#$1, $(D $1))
         GLINK2=$(GLINK $2)
-        GRAMMAR_SUMMARY=$0
+        SUMMARY_GRAMMAR=$0

--- a/spec/importc.dd
+++ b/spec/importc.dd
@@ -398,7 +398,7 @@ $(H2 $(LNAME2 implementation, Implementation))
 
     $(P This is described in C11 7.6.1)
 
-$(GRAMMAR_INFORMATIVE
+$(INFORMATIVE_GRAMMAR
 #pragma STDC FENV_ACCESS on-off-switch
 
 on-off-switch:

--- a/spec/simd.dd
+++ b/spec/simd.dd
@@ -55,7 +55,7 @@ import core.simd;
 
         $(P The types defined will all follow the naming convention:)
 
-$(GRAMMAR_INFORMATIVE
+$(INFORMATIVE_GRAMMAR
 $(I typeNN)
 )
         where $(I type) is the vector element type and $(I NN) is the number

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -597,7 +597,7 @@ $(H2 $(LNAME2 functions, Function Types))
 
 $(P A function type has the form:)
 
-$(GRAMMAR_INFORMATIVE
+$(INFORMATIVE_GRAMMAR
 $(GLINK2 declaration, StorageClasses)$(OPT) $(GLINK Type) $(GLINK2 function, Parameters) $(GLINK2 function, FunctionAttributes)$(OPT)
 )
 
@@ -608,7 +608,7 @@ A function type is only used for type tests or as the target type of a pointer.)
 $(P Instantiating a function type is illegal. Instead, a pointer to function
 or delegate can be used. Those have these type forms respectively:)
 
-$(GRAMMAR_INFORMATIVE
+$(INFORMATIVE_GRAMMAR
 $(GLINK Type) `function` $(GLINK2 function, Parameters) $(GLINK2 function, FunctionAttributes)$(OPT)
 $(GLINK Type) `delegate` $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT)
 )


### PR DESCRIPTION
Because `GRAMMAR_INFORMATIVE` starts with `GRAMMAR`, there are stray ones included in [the grammar spec](https://dlang.org/spec/grammar.html).