### PR TITLE
Consistently use `extern(X)`

### DIFF
--- a/htod.dd
+++ b/htod.dd
@@ -121,7 +121,7 @@ $(P Produces the file test.d:)
 /* Converted to D from test.h by htod */
 module test;
 //C     unsigned u;
-extern (C):
+extern(C):
 uint u;
 //C     #define MYINT int
 //C     void bar(int x, long y, long long z);

--- a/spec/abi.dd
+++ b/spec/abi.dd
@@ -708,10 +708,10 @@ $(GNAME TypeTuple):
 
 $(H2 $(LNAME2 function_calling_conventions, Function Calling Conventions))
 
-        $(P The $(D extern (C)) and $(D extern (D)) calling convention matches the C
+        $(P The $(D extern(C)) and $(D extern(D)) calling convention matches the C
         calling convention
         used by the supported C compiler on the host system.
-        Except that the extern (D) calling convention for Windows x86 is described here.
+        Except that the extern(D) calling convention for Windows x86 is described here.
         )
 
 $(H3 $(LNAME2 register_conventions, Register Conventions))

--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -125,7 +125,7 @@ $(GNAME NamespaceList):
         )
 
 ---------------
-extern (C):
+extern(C):
     int foo(); // call foo() with C conventions
 ---------------
         Note that `extern(C)` can be provided for all types of
@@ -139,13 +139,13 @@ extern (C):
         $(P D conventions are:)
 
 ---------------
-extern (D):
+extern(D):
 ---------------
 
         $(P Windows API conventions are:)
 
 ---------------
-extern (Windows):
+extern(Windows):
     void *VirtualAlloc(
         void *lpAddress,
         uint dwSize,
@@ -169,7 +169,7 @@ $(H3 C++ $(LNAME2 namespace, Namespaces))
         )
 
         ---
-        extern (C++, N) { void foo(); }
+        extern(C++, N) { void foo(); }
         ---
 
         $(P refers to the C++ declaration:)
@@ -187,8 +187,8 @@ $(H3 C++ $(LNAME2 namespace, Namespaces))
 
         $(SPEC_RUNNABLE_EXAMPLE_COMPILE
         ---
-        extern (C++, N) { void foo(); void bar(); }
-        extern (C++, M) { void foo(); }
+        extern(C++, N) { void foo(); void bar(); }
+        extern(C++, M) { void foo(); }
 
         void main()
         {
@@ -202,7 +202,7 @@ $(H3 C++ $(LNAME2 namespace, Namespaces))
         $(P Multiple dotted identifiers in the $(I QualifiedIdentifier) create nested namespaces:)
 
         ---
-        extern (C++, N.M) { extern (C++) { extern (C++, R) { void foo(); } } }
+        extern(C++, N.M) { extern(C++) { extern(C++, R) { void foo(); } } }
         N.M.R.foo();
         ---
 

--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -77,13 +77,13 @@ int foo(int i, int j, int k)
     )
 
 ------
-extern (C++) int foo(int i, int j, int k);
+extern(C++) int foo(int i, int j, int k);
 ------
 
     $(P and then it can be called within the D code:)
 
 ------
-extern (C++) int foo(int i, int j, int k);
+extern(C++) int foo(int i, int j, int k);
 
 void main()
 {
@@ -131,7 +131,7 @@ $(H3 $(LNAME2 calling_global_d_functions_from_cpp, Calling Global D Functions Fr
 ---
 import std.stdio;
 
-extern (C++) int foo(int i, int j, int k)
+extern(C++) int foo(int i, int j, int k)
 {
     writefln("i = %s", i);
     writefln("j = %s", j);
@@ -139,7 +139,7 @@ extern (C++) int foo(int i, int j, int k)
     return 1;
 }
 
-extern (C++) void bar();
+extern(C++) void bar();
 
 void main()
 {
@@ -172,11 +172,11 @@ $(H2 $(LNAME2 cpp-namespaces, C++ Namespaces))
 
         $(P C++ symbols that reside in namespaces can be
         accessed from D. A $(LINK2 attribute.html#namespace, namespace)
-        can be added to the `extern (C++)`
+        can be added to the `extern(C++)`
         $(LINK2 attribute.html#linkage, LinkageAttribute):
     )
 ------
-extern (C++, N) int foo(int i, int j, int k);
+extern(C++, N) int foo(int i, int j, int k);
 
 void main()
 {
@@ -189,13 +189,13 @@ void main()
 
 ---
 module ns;
-extern (C++, `ns`)
+extern(C++, `ns`)
 {
     int foo() { return 1; }
 }
 ---
     $(P Any expression that resolves to either a tuple of strings or an empty tuple is accepted.
-      When the expression resolves to an empty tuple, it is equivalent to `extern (C++)`)
+      When the expression resolves to an empty tuple, it is equivalent to `extern(C++)`)
 ---
 extern(C++, (expression))
 {
@@ -213,12 +213,12 @@ ns/
 
 $(P File `ns/a.d`:)
 ---
-module a; extern (C++, `ns`) { int foo() { return 1; } }
+module a; extern(C++, `ns`) { int foo() { return 1; } }
 ---
 
 $(P File `ns/b.d`:)
 ---
-module b; extern (C++, `ns`) { int bar() { return 2; } }
+module b; extern(C++, `ns`) { int bar() { return 2; } }
 ---
 
 $(P File `ns/package.d`:)
@@ -233,7 +233,7 @@ import ns;
 static assert(foo() == 1 && bar() == 2);
 ---
 
-$(P Note that the `extern (C++, `ns`)` linkage attribute affects only the ABI (name mangling and calling convention) of
+$(P Note that the `extern(C++, `ns`)` linkage attribute affects only the ABI (name mangling and calling convention) of
   these declarations. Importing them follows the usual
   $(LINK2 spec/module.html, D module import semantics).)
 
@@ -241,10 +241,10 @@ $(P Alternatively, the non-string form can be used to introduce a scope. Note th
     enclosing module already provides a scope for the symbols declared in the namespace.
     This form does not allow closing and reopening the same namespace with in the same module. That is:)
 ---
-module a; extern (C++, ns1) { int foo() { return 1; } }
+module a; extern(C++, ns1) { int foo() { return 1; } }
 ---
 ---
-module b; extern (C++, ns1) { int bar() { return 2; } }
+module b; extern(C++, ns1) { int bar() { return 2; } }
 ---
 ---
 import a, b;
@@ -252,15 +252,15 @@ static assert(foo() == 1 && bar() == 2);
 ---
    $(P works, but:)
 ---
-extern (C++, ns1) { int foo() { return 1; } }
-extern (C++, ns1) { int bar() { return 2; } }
+extern(C++, ns1) { int foo() { return 1; } }
+extern(C++, ns1) { int bar() { return 2; } }
 ---
    $(P does not. Additionally, aliases can be used to avoid collision of symbols:)
 ---
-module a; extern (C++, ns) { int foo() { return 1; } }
+module a; extern(C++, ns) { int foo() { return 1; } }
 ---
 ---
-module b; extern (C++, ns) { int bar() { return 2; } }
+module b; extern(C++, ns) { int bar() { return 2; } }
 ---
 ---
 module ns;
@@ -275,16 +275,16 @@ static assert(foo() == 1 && bar() == 2);
 
 $(H2 $(LNAME2 classes, Classes))
 
-    $(P C++ classes can be declared in D by using the $(CODE extern (C++))
+    $(P C++ classes can be declared in D by using the $(CODE extern(C++))
     attribute on $(CODE class), $(CODE struct) and $(CODE interface)
-    declarations. $(CODE extern (C++)) interfaces have the same restrictions as
+    declarations. $(CODE extern(C++)) interfaces have the same restrictions as
     D interfaces, which means that Multiple Inheritance is supported to the
     extent that only one base class can have member fields.)
 
-    $(P $(CODE extern (C++)) structs do not support virtual functions but can
+    $(P $(CODE extern(C++)) structs do not support virtual functions but can
     be used to map C++ value types.)
 
-    $(P Unlike classes and interfaces with D linkage, $(CODE extern (C++))
+    $(P Unlike classes and interfaces with D linkage, $(CODE extern(C++))
     classes and interfaces are not rooted in $(CODE Object) and cannot be used
     with $(CODE typeid).)
 
@@ -300,7 +300,7 @@ $(H2 $(LNAME2 classes, Classes))
     $(P $(CODE extern(C++, class)) and $(CODE extern(C++, struct)) can be combined
     with C++ namespaces:)
 ---
-extern (C++, struct) extern (C++, foo)
+extern(C++, struct) extern(C++, foo)
 class Bar
 {
 }
@@ -423,16 +423,16 @@ $(H3 $(LNAME2 using_d_classes_from_cpp, Using D Classes From C++))
     $(P Given D code like:)
 
 ---
-extern (C++) int callE(E);
+extern(C++) int callE(E);
 
-extern (C++) interface E
+extern(C++) interface E
 {
     int bar(int i, int j, int k);
 }
 
 class F : E
 {
-    extern (C++) int bar(int i, int j, int k)
+    extern(C++) int bar(int i, int j, int k)
     {
         import std.stdio : writefln;
         writefln("i = %s", i);
@@ -546,7 +546,7 @@ struct Derived
 $(H2 $(LNAME2 cpp-templates, C++ Templates))
 
     $(P C++ function and type templates can be bound by using the
-    $(CODE extern (C++)) attribute on a function or type template declaration.)
+    $(CODE extern(C++)) attribute on a function or type template declaration.)
 
     $(P Note that all instantiations used in D code must be provided by linking
     to C++ object code or shared libraries containing the instantiations.)
@@ -667,7 +667,7 @@ C
 $(H2 $(LNAME2 function-overloading, Function Overloading))
 
     $(P C++ and D follow different rules for function overloading.
-    D source code, even when calling $(CODE extern (C++)) functions,
+    D source code, even when calling $(CODE extern(C++)) functions,
     will still follow D overloading rules.
     )
 
@@ -810,17 +810,17 @@ $(H2 $(LNAME2 data-type-compatibility, Data Type Compatibility))
     )
 
     $(TROW
-    $(ARGS $(CODE extern (C++)) $(B struct)),
+    $(ARGS $(CODE extern(C++)) $(B struct)),
     $(ARGS $(B struct) or $(B class))
     )
 
     $(TROW
-    $(ARGS $(CODE extern (C++)) $(B class)),
+    $(ARGS $(CODE extern(C++)) $(B class)),
     $(ARGS $(B struct) or $(B class))
     )
 
     $(TROW
-    $(ARGS $(CODE extern (C++)) $(B interface)),
+    $(ARGS $(CODE extern(C++)) $(B interface)),
     $(ARGS $(B struct) or $(B class) with no member fields)
     )
 
@@ -857,7 +857,7 @@ $(H2 $(LNAME2 data-type-compatibility, Data Type Compatibility))
 
     $(TROW
     $(ARGS $(I type)$(B [])),
-    $(ARGS no `extern (C++)` equivalent, $(RELATIVE_LINK2 dynamic-arrays, see below))
+    $(ARGS no `extern(C++)` equivalent, $(RELATIVE_LINK2 dynamic-arrays, see below))
     )
 
     $(TROW
@@ -881,11 +881,11 @@ $(H2 $(LNAME2 data-type-compatibility, Data Type Compatibility))
 
 $(H3 $(LNAME2 dynamic-arrays, Dynamic Arrays))
 
-    $(P These are not supported for `extern (C++)`. For `extern (C)`, they
+    $(P These are not supported for `extern(C++)`. For `extern(C)`, they
     are equivalent to a struct template. For example:)
 
 ---
-extern (C) const(char)[] slice;
+extern(C) const(char)[] slice;
 ---
 
     $(P `dmd -HC` generates the following C++ declaration:)

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -176,7 +176,7 @@ fun()(f1(), f3(f2()), f4());
     $(IMPLEMENTATION_DEFINED
     $(OL
     $(LI The order of evaluation of the operands of $(GLINK AssignExpression).)
-    $(LI The order of evaluation of function arguments for functions with linkage other than `extern (D)`.)
+    $(LI The order of evaluation of function arguments for functions with linkage other than `extern(D)`.)
     ))
 
     $(BEST_PRACTICE Even though the order of evaluation is well-defined, writing code that

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2136,7 +2136,7 @@ $(H4 $(LNAME2 c_style_variadic_functions, C-style Variadic Functions))
 
         $(P A C-style variadic function is declared with
         a parameter `...` as the last function parameter.
-        It has non-D linkage, such as $(D extern (C)).)
+        It has non-D linkage, such as $(D extern(C)).)
 
         $(P To access the variadic arguments,
         import the standard library
@@ -2146,7 +2146,7 @@ $(H4 $(LNAME2 c_style_variadic_functions, C-style Variadic Functions))
         ---
         import core.stdc.stdarg;
 
-        extern (C) void dry(int x, int y, ...); // C-style Variadic Function
+        extern(C) void dry(int x, int y, ...); // C-style Variadic Function
 
         void spin()
         {
@@ -2159,7 +2159,7 @@ $(H4 $(LNAME2 c_style_variadic_functions, C-style Variadic Functions))
         $(P There must be at least one non-variadic parameter declared.)
 
         ---
-        extern (C) int def(...); // error, must have at least one parameter
+        extern(C) int def(...); // error, must have at least one parameter
         ---
 
         $(P
@@ -2169,7 +2169,7 @@ $(H4 $(LNAME2 c_style_variadic_functions, C-style Variadic Functions))
         )
 
         ---
-        extern (C) int printf(const(char)*, ...);
+        extern(C) int printf(const(char)*, ...);
 
         void main()
         {
@@ -2187,7 +2187,7 @@ $(H4 $(LNAME2 c_style_variadic_functions, C-style Variadic Functions))
         }
 
         import core.stdc.stdarg;
-        extern (C) void rinse(int x, int y, ...)
+        extern(C) void rinse(int x, int y, ...)
         {
             va_list args;
             va_start(args, y); // y is the last named parameter
@@ -3469,7 +3469,7 @@ $(H2 $(LNAME2 main, $(D main()) Function))
 
         $(GRAMMAR
         $(GNAME CMainFunction):
-            $(D extern (C)) $(GLINK MainReturnDecl) $(D main$(LPAREN)$(GLINK CmainParameters)$(OPT)$(RPAREN)) $(GLINK2 statement, BlockStatement)
+            $(D extern(C)) $(GLINK MainReturnDecl) $(D main$(LPAREN)$(GLINK CmainParameters)$(OPT)$(RPAREN)) $(GLINK2 statement, BlockStatement)
 
         $(GNAME CmainParameters):
             $(D int) $(GLINK_LEX Identifier), $(D char**) $(GLINK_LEX Identifier)
@@ -3841,7 +3841,7 @@ $(H4 Safe External Functions)
         $(P External functions don't have a function body visible to the compiler:
         )
         ---
-        @safe extern (C) void play();
+        @safe extern(C) void play();
         ---
         and so safety cannot be verified automatically.
 
@@ -3916,7 +3916,7 @@ $(H3 $(LNAME2 system-functions, System Functions))
 
         $(P System functions can call safe and trusted functions.)
 
-        $(BEST_PRACTICE When in doubt, mark `extern (C)` and `extern (C++)` functions as
+        $(BEST_PRACTICE When in doubt, mark `extern(C)` and `extern(C++)` functions as
         `@system` when their implementations are not in D, as the D compiler will be
         unable to check them. Most of them are `@safe`, but will need to be manually
         checked.)
@@ -3953,7 +3953,7 @@ $(H3 $(LNAME2 safe-interfaces, Safe Interfaces))
             $(LI
                 C's `free` does not have a safe interface:
                 ---
-                extern (C) @system void free(void* ptr);
+                extern(C) @system void free(void* ptr);
                 ---
                 because `free(p)` invalidates `p`, making its value unsafe.
                 `free` can only be `@system`.
@@ -3961,8 +3961,8 @@ $(H3 $(LNAME2 safe-interfaces, Safe Interfaces))
             $(LI
                 C's `strlen` and `memcpy` do not have safe interfaces:
                 ---
-                extern (C) @system size_t strlen(char* s);
-                extern (C) @system void* memcpy(void* dst, void* src, size_t nbytes);
+                extern(C) @system size_t strlen(char* s);
+                extern(C) @system void* memcpy(void* dst, void* src, size_t nbytes);
                 ---
                 because they iterate pointers based on unverified assumptions
                 (`strlen` assumes that `s` is zero-terminated; `memcpy` assumes
@@ -3974,7 +3974,7 @@ $(H3 $(LNAME2 safe-interfaces, Safe Interfaces))
             $(LI
                 C's `malloc` does have a safe interface:
                 ---
-                extern (C) @trusted void* malloc(size_t sz);
+                extern(C) @trusted void* malloc(size_t sz);
                 ---
                 It does not exhibit undefined behavior for any input. It returns
                 either a valid pointer, which is safe, or `null` which is also

--- a/spec/garbage.dd
+++ b/spec/garbage.dd
@@ -543,7 +543,7 @@ $(H2 $(LNAME2 gc_registry, Adding your own Garbage Collector))
         D runtime initialization using `pragma(crt_constructor)`:)
         ---
         import core.gc.gcinterface, core.gc.registry;
-        extern (C) pragma(crt_constructor) void registerMyGC()
+        extern(C) pragma(crt_constructor) void registerMyGC()
         {
             registerGCFactory("mygc", &createMyGC);
         }
@@ -567,7 +567,7 @@ $(H2 $(LNAME2 gc_registry, Adding your own Garbage Collector))
         can be selected via the usual configuration options, e.g. by embedding
         `rt_options` into the binary:)
         ---
-        extern (C) __gshared string[] rt_options = ["gcopt=gc:mygc"];
+        extern(C) __gshared string[] rt_options = ["gcopt=gc:mygc"];
         ---
 
     $(P The standard GC implementation from a statically

--- a/spec/importc.dd
+++ b/spec/importc.dd
@@ -843,9 +843,9 @@ $(H2 $(LNAME2 d-side, ImportC from D's Point of View))
     of its path and extension. This is just like the default module name assigned
     to a D module that does not have a module declaration.)
 
-    $(H3 $(LNAME2 extern-C, `extern (C)`))
+    $(H3 $(LNAME2 extern-C, `extern(C)`))
 
-    $(P All C symbols are `extern (C)`.)
+    $(P All C symbols are `extern(C)`.)
 
     $(H3 $(LNAME2 enums, Enums))
 

--- a/spec/interface.dd
+++ b/spec/interface.dd
@@ -322,7 +322,7 @@ $(SECTION2 $(LEGACY_LNAME2 CPP-Interfaces, cpp-interfaces, C++ Interfaces),
     )
 
 ---
-extern (C++) interface Ifoo
+extern(C++) interface Ifoo
 {
     void foo();
     void bar();

--- a/spec/interfaceToC.dd
+++ b/spec/interfaceToC.dd
@@ -34,7 +34,7 @@ $(H2 $(LNAME2 calling_c_functions, Calling C Functions))
         )
 
 ------
-extern (C) int strcmp(const char* string1, const char* string2);
+extern(C) int strcmp(const char* string1, const char* string2);
 ------
 
         and then it can be called within D code in the obvious way:
@@ -64,7 +64,7 @@ int myDfunction(char[] s)
         $(LINK2 http://www.digitalmars.com/ctg/ctgLanguageImplementation.html#extended, extended type modifiers)
         in D. These are handled by
         $(LINK2 attribute.html#linkage, linkage attributes),
-        such as $(D extern (C)).)
+        such as $(D extern(C)).)
 
         $(LI There is no volatile type modifier in D. To declare a C function that uses
         volatile, just drop the keyword from the declaration.)
@@ -77,11 +77,11 @@ int myDfunction(char[] s)
 
         $(P C code can correspondingly call D functions, if the D functions
         use an attribute that is compatible with the C compiler, most likely
-        the extern (C):)
+        the extern(C):)
 
 ------
 // myfunc() can be called from any C function
-extern (C)
+extern(C)
 {
     void myfunc(int a, int b)
     {
@@ -206,7 +206,7 @@ $(H2 $(LNAME2 passing_d_array, Passing D Array Arguments to C Functions))
 
 $(CCODE void foo(int a[3]) { ... } // C code)
 ---
-extern (C)
+extern(C)
 {
     void foo(ref int[3] a); // D prototype
 }
@@ -402,7 +402,7 @@ $(H2 $(LEGACY_LNAME2 Using C Libraries, using-c-libraries, Using Existing C Libr
 $(H2 $(LEGACY_LNAME2 C Globals, c-globals, Accessing C Globals))
 
         $(P C globals can be accessed directly from D. C globals have the C naming
-        convention, and so must be in an $(D extern (C)) block.
+        convention, and so must be in an $(D extern(C)) block.
         Use the $(D extern) storage class to indicate that the global is allocated
         in the C code, not the D code.
         C globals default to being in global, not thread local, storage.
@@ -411,7 +411,7 @@ $(H2 $(LEGACY_LNAME2 C Globals, c-globals, Accessing C Globals))
         )
 
 ---
-extern (C) extern __gshared int x;
+extern(C) extern __gshared int x;
 ---
 
 $(SPEC_SUBNAV_PREV_NEXT ddoc, Embedded Documentation, cpp_interface, Interfacing to C++)

--- a/spec/objc_interface.dd
+++ b/spec/objc_interface.dd
@@ -22,7 +22,7 @@ $(HEADERNAV_TOC)
     ---
     import core.attribute : selector;
 
-    extern (Objective-C)
+    extern(Objective-C)
     extern class NSString
     {
         const(char)* UTF8String() @selector("UTF8String");
@@ -32,7 +32,7 @@ $(HEADERNAV_TOC)
     $(P
         All Objective-C classes that should be accessible from within D need to
         be declared with the $(LINK2 #objc-linkage, Objective-C linkage). If the
-        class is declared as `extern` (in addition to `extern (Objective-C)`) it
+        class is declared as `extern` (in addition to `extern(Objective-C)`) it
         is expected to be defined externally.
     )
 
@@ -48,7 +48,7 @@ $(HEADERNAV_TOC)
     ---
     import core.attribute : selector;
 
-    extern (Objective-C)
+    extern(Objective-C)
     extern class MTLRenderPipelineDescriptor : NSObject
     {
         NSString label() @selector("label");
@@ -70,14 +70,14 @@ $(HEADERNAV_TOC)
     import core.attribute : selector;
 
     // externally defined
-    extern (Objective-C)
+    extern(Objective-C)
     extern class NSObject
     {
         static NSObject alloc() @selector("alloc");
         NSObject init() @selector("init");
     }
 
-    extern (Objective-C)
+    extern(Objective-C)
     class Foo : NSObject
     {
         override static Foo alloc() @selector("alloc");
@@ -113,14 +113,14 @@ $(HEADERNAV_TOC)
     import core.attribute : selector;
     import core.stdc.stdio : printf;
 
-    extern (Objective-C)
+    extern(Objective-C)
     interface Foo
     {
         static void foo() @selector("foo");
         void bar() @selector("bar");
     }
 
-    extern (Objective-C)
+    extern(Objective-C)
     class Bar : Foo
     {
         static void foo() @selector("foo")
@@ -162,16 +162,16 @@ $(HEADERNAV_TOC)
     struct objc_selector;
     alias SEL = objc_selector*;
 
-    extern (C) SEL sel_registerName(in char* str);
+    extern(C) SEL sel_registerName(in char* str);
 
-    extern (Objective-C)
+    extern(Objective-C)
     extern class NSObject
     {
         static NSObject alloc() @selector("alloc");
         NSObject init() @selector("init");
     }
 
-    extern (Objective-C)
+    extern(Objective-C)
     interface Foo
     {
         bool respondsToSelector(SEL sel) @selector("respondsToSelector:");
@@ -181,7 +181,7 @@ $(HEADERNAV_TOC)
         @optional void bar() @selector("bar");
     }
 
-    extern (Objective-C)
+    extern(Objective-C)
     class Bar : NSObject, Foo
     {
         override static Bar alloc() @selector("alloc");
@@ -224,14 +224,14 @@ $(HEADERNAV_TOC)
     import core.attribute : selector;
 
     // externally defined
-    extern (Objective-C)
+    extern(Objective-C)
     extern class NSObject
     {
         static NSObject alloc() @selector("alloc");
         NSObject init() @selector("init");
     }
 
-    extern (Objective-C)
+    extern(Objective-C)
     class Foo : NSObject
     {
         int bar_;
@@ -303,7 +303,7 @@ $(HEADERNAV_TOC)
     ---
     import core.attribute : selector;
 
-    extern (Objective-C)
+    extern(Objective-C)
     extern class NSString
     {
         NSString initWith(in char*) @selector("initWithUTF8String:");
@@ -398,14 +398,14 @@ $(HEADERNAV_TOC)
     $(SECTION2 $(LNAME2 objc-linkage, Objective-C Linkage))
 
     $(P
-        Objective-C linkage is achieved by attaching the `extern (Objective-C)`
+        Objective-C linkage is achieved by attaching the `extern(Objective-C)`
         attribute to a class. Example:
     )
 
     ---
     import core.attribute : selector;
 
-    extern (Objective-C)
+    extern(Objective-C)
     extern class NSObject
     {
         NSObject init() @selector("init");
@@ -413,7 +413,7 @@ $(HEADERNAV_TOC)
     ---
 
     $(P
-        All methods inside a class declared as `extern (Objective-C)` will
+        All methods inside a class declared as `extern(Objective-C)` will
         get implicit Objective-C linkage.
     )
 
@@ -498,7 +498,7 @@ $(HEADERNAV_TOC)
     ---
     import core.attribute : selector;
 
-    extern (Objective-C)
+    extern(Objective-C)
     extern class NSString
     {
         static NSString alloc() @selector("alloc");
@@ -519,7 +519,7 @@ $(HEADERNAV_TOC)
     )
 
     ---
-    extern (C) void NSLog(NSString, ...);
+    extern(C) void NSLog(NSString, ...);
     ---
 
     $(P
@@ -566,7 +566,7 @@ $(HEADERNAV_TOC)
 
     import core.attribute : selector;
 
-    extern (Objective-C)
+    extern(Objective-C)
     extern class NSString
     {
         static NSString alloc() @selector("alloc");
@@ -574,7 +574,7 @@ $(HEADERNAV_TOC)
         void release() @selector("release");
     }
 
-    extern (C) void NSLog(NSString, ...);
+    extern(C) void NSLog(NSString, ...);
 
     void main()
     {

--- a/spec/pragma.dd
+++ b/spec/pragma.dd
@@ -89,7 +89,7 @@ $(H3 $(LNAME2 crtctor, $(D pragma crt_constructor)))
     $(P The function must:)
 
     $(OL
-        $(LI be `extern (C)`)
+        $(LI be `extern(C)`)
         $(LI not have any parameters)
         $(LI not be a non-static member function)
         $(LI be a function definition, not a declaration (i.e. it must have a function body))
@@ -339,7 +339,7 @@ $(H3 $(LNAME2 msg, $(D pragma msg)))
 $(H3 $(LNAME2 printf, $(D pragma printf)))
 
     $(P `pragma(printf)` specifies that a function declaration is a printf-like function, meaning
-    it is an `extern (C)` or `extern (C++)` function with a `format` parameter accepting a
+    it is an `extern(C)` or `extern(C++)` function with a `format` parameter accepting a
     pointer to a 0-terminated `char` string conforming to the C99 Standard 7.19.6.1, immediately followed
     by either a `...` variadic argument list or a parameter of type `va_list` as the last parameter.
     )
@@ -413,7 +413,7 @@ $(H3 $(LNAME2 printf, $(D pragma printf)))
 $(H3 $(LNAME2 scanf, $(D pragma scanf)))
 
     $(P `pragma(scanf)` specifies that a function declaration is a scanf-like function, meaning
-    it is an `extern (C)` or `extern (C++)` function with a `format` parameter accepting a
+    it is an `extern(C)` or `extern(C++)` function with a `format` parameter accepting a
     pointer to a 0-terminated `char` string conforming to the C99 Standard 7.19.6.2, immediately followed
     by either a `...` variadic argument list or a parameter of type `va_list` as the last parameter.
     )

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -192,7 +192,7 @@ $(H2 $(LNAME2 struct_layout, Struct Layout))
     $(UNDEFINED_BEHAVIOR
     $(OL
     $(LI The padding data can be accessed, but its contents are undefined.)
-    $(LI Do not pass or return structs with no fields of non-zero size to `extern (C)` functions.
+    $(LI Do not pass or return structs with no fields of non-zero size to `extern(C)` functions.
     According to C11 6.7.2.1p8 this is undefined behavior.)
     ))
 

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -925,7 +925,7 @@ $(SECTION3 $(GNAME getFunctionVariadicStyle),
         $(THEAD result, kind, access, example)
         $(TROW $(D "none"), not a variadic function, $(NBSP), $(D void foo();))
         $(TROW $(D "argptr"), D style variadic function, $(D _argptr) and $(D _arguments), $(D void bar(...)))
-        $(TROW $(D "stdarg"), C style variadic function, $(LINK2 $(ROOT_DIR)phobos/core_stdc_stdarg.html, $(D core.stdc.stdarg)), $(D extern (C) void abc(int, ...)))
+        $(TROW $(D "stdarg"), C style variadic function, $(LINK2 $(ROOT_DIR)phobos/core_stdc_stdarg.html, $(D core.stdc.stdarg)), $(D extern(C) void abc(int, ...)))
         $(TROW $(D "typesafe"), typesafe variadic function, array on stack, $(D void def(int[] ...)))
     )
 
@@ -1370,15 +1370,15 @@ $(H3 $(GNAME getLinkage))
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
-extern (C) int fooc();
+extern(C) int fooc();
 alias aliasc = fooc;
 
 static assert(__traits(getLinkage, fooc) == "C");
 static assert(__traits(getLinkage, aliasc) == "C");
 
-extern (C++) struct FooCPPStruct {}
-extern (C++) class FooCPPClass {}
-extern (C++) interface FooCPPInterface {}
+extern(C++) struct FooCPPStruct {}
+extern(C++) class FooCPPClass {}
+extern(C++) interface FooCPPInterface {}
 
 static assert(__traits(getLinkage, FooCPPStruct) == "C++");
 static assert(__traits(getLinkage, FooCPPClass) == "C++");


### PR DESCRIPTION
Linkage is not a control-flow statement (such as `if` or `while`) and as with `assert`, `pragma` and many others, no space should be used between the keyword and the opening parenthesis.