### PR TITLE
Condition → Conditional; IfCondition → Condition

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -234,10 +234,10 @@ $(P If statements provide simple conditional execution of statements.)
 
 $(GRAMMAR
 $(GNAME IfStatement):
-    $(D if $(LPAREN)) $(GLINK IfCondition) $(D $(RPAREN)) $(GLINK ThenStatement)
-    $(D if $(LPAREN)) $(GLINK IfCondition) $(D $(RPAREN)) $(GLINK ThenStatement) $(D else) $(GLINK ElseStatement)
+    $(D if $(LPAREN)) $(GLINK Condition) $(D $(RPAREN)) $(GLINK ThenStatement)
+    $(D if $(LPAREN)) $(GLINK Condition) $(D $(RPAREN)) $(GLINK ThenStatement) $(D else) $(GLINK ElseStatement)
 
-$(GNAME IfCondition):
+$(GNAME Condition):
     $(EXPRESSION)
     $(D auto) $(GLINK_LEX Identifier) $(D =) $(EXPRESSION)
     $(D scope) $(GLINK_LEX Identifier) $(D =) $(EXPRESSION)
@@ -283,7 +283,7 @@ $(H3 $(LNAME2 boolean-conditions, Boolean Conversion))
 $(H3 $(LNAME2 condition-variables, Condition Variables))
 
         $(P
-        When an $(I Identifier) form of *IfCondition* is used, a
+        When a variable declaration form of *Condition* is used, a
         variable is declared with that name and initialized to the
         value of the *Expression*.
         )
@@ -325,12 +325,12 @@ $(H2 $(LEGACY_LNAME2 WhileStatement, while-statement, While Statement))
 
 $(GRAMMAR
 $(GNAME WhileStatement):
-    $(D while $(LPAREN)) $(GLINK IfCondition) $(D $(RPAREN)) $(PSSCOPE)
+    $(D while $(LPAREN)) $(GLINK Condition) $(D $(RPAREN)) $(PSSCOPE)
 )
 
 $(P A $(I While Statement) implements a simple loop.)
 
-$(P If the $(I IfCondition) is an *Expression*, it is evaluated and must have a type
+$(P If the $(I Condition) is an *Expression*, it is evaluated and must have a type
 that can be $(DDSUBLINK spec/statement, boolean-conditions, converted to a boolean).
 If it's `true` the *ScopeStatement* is executed.
 After the *ScopeStatement* is executed, the *Expression* is evaluated again, and
@@ -361,7 +361,7 @@ initialized to the end of the *ScopeStatement*.)
 
 $(P A $(GLINK BreakStatement) will exit the loop.)
 
-$(P A $(GLINK ContinueStatement) will transfer directly to evaluating $(I IfCondition) again.)
+$(P A $(GLINK ContinueStatement) will transfer directly to evaluating $(I Condition) again.)
 
 $(H2 $(LEGACY_LNAME2 DoStatement, do-statement, Do Statement))
 
@@ -1284,7 +1284,7 @@ $(H2 $(LEGACY_LNAME2 SwitchStatement, switch-statement, Switch Statement))
 
 $(GRAMMAR
 $(GNAME SwitchStatement):
-    $(D switch $(LPAREN)) $(GLINK IfCondition) $(D $(RPAREN)) $(PSSCOPE)
+    $(D switch $(LPAREN)) $(GLINK Condition) $(D $(RPAREN)) $(PSSCOPE)
 
 $(GNAME CaseStatement):
     $(D case) $(GLINK2 expression, ArgumentList) $(D :) $(PSSEMI_PSCURLYSCOPE_LIST)$(OPT)
@@ -1305,7 +1305,7 @@ $(GNAME StatementNoCaseNoDefault):
     $(GLINK ScopeBlockStatement)
 )
 
-        $(P The *Expression* from the $(I IfCondition) is evaluated.
+        $(P The *Expression* from the $(I Condition) is evaluated.
         If the type of the *Expression* is an `enum`, it is
         (recursively) converted to its $(GLINK2 enum, EnumBaseType).
         Then, if the type is an integral, the *Expression* undergoes
@@ -1506,7 +1506,7 @@ $(H2 $(LEGACY_LNAME2 FinalSwitchStatement, final-switch-statement, Final Switch 
 
 $(GRAMMAR
 $(GNAME FinalSwitchStatement):
-    $(D final switch $(LPAREN)) $(GLINK IfCondition) $(D $(RPAREN)) $(PSSCOPE)
+    $(D final switch $(LPAREN)) $(GLINK Condition) $(D $(RPAREN)) $(PSSCOPE)
 )
 
         $(P A final switch statement is just like a switch statement,

--- a/spec/version.dd
+++ b/spec/version.dd
@@ -10,17 +10,17 @@ $(HEADERNAV_TOC)
 
 $(GRAMMAR
 $(GNAME ConditionalDeclaration):
-    $(GLINK Condition) $(GLINK2 attribute, DeclarationBlock)
-    $(GLINK Condition) $(GLINK2 attribute, DeclarationBlock) $(D else) $(GLINK2 attribute, DeclarationBlock)
-    $(GLINK Condition) $(D :) $(GLINK2 module, DeclDefs)$(OPT)
-    $(GLINK Condition) $(GLINK2 attribute, DeclarationBlock) $(D else) $(D :) $(GLINK2 module, DeclDefs)$(OPT)
+    $(GLINK Conditional) $(GLINK2 attribute, DeclarationBlock)
+    $(GLINK Conditional) $(GLINK2 attribute, DeclarationBlock) $(D else) $(GLINK2 attribute, DeclarationBlock)
+    $(GLINK Conditional) $(D :) $(GLINK2 module, DeclDefs)$(OPT)
+    $(GLINK Conditional) $(GLINK2 attribute, DeclarationBlock) $(D else) $(D :) $(GLINK2 module, DeclDefs)$(OPT)
 
 $(GNAME ConditionalStatement):
-    $(GLINK Condition) $(GLINK2 statement, NoScopeNonEmptyStatement)
-    $(GLINK Condition) $(GLINK2 statement, NoScopeNonEmptyStatement) $(D else) $(GLINK2 statement, NoScopeNonEmptyStatement)
+    $(GLINK Conditional) $(GLINK2 statement, NoScopeNonEmptyStatement)
+    $(GLINK Conditional) $(GLINK2 statement, NoScopeNonEmptyStatement) $(D else) $(GLINK2 statement, NoScopeNonEmptyStatement)
 )
 
-        $(P If the $(GLINK Condition) is satisfied, then the following
+        $(P If the $(GLINK Conditional) is satisfied, then the following
         $(I DeclarationBlock) or $(I Statement) is compiled in.
         If it is not satisfied, the $(I DeclarationBlock) or $(I Statement)
         after the optional $(CODE else) is compiled in.
@@ -44,20 +44,20 @@ $(GNAME ConditionalStatement):
         compilation that are errors.
         )
 
-        $(P $(I Condition) comes in the following forms:
+        $(P $(I Conditional) comes in the following forms:
         )
 
 $(GRAMMAR
-$(GNAME Condition):
-    $(GLINK VersionCondition)
-    $(GLINK DebugCondition)
-    $(GLINK StaticIfCondition)
+$(GNAME Conditional):
+    $(GLINK VersionConditional)
+    $(GLINK DebugConditional)
+    $(GLINK StaticIfConditional)
 )
 
-$(H2 $(LNAME2 version, Version Condition))
+$(H2 $(LNAME2 version, Version Conditional))
 
 $(GRAMMAR
-$(GNAME VersionCondition):
+$(GNAME VersionConditional):
     $(D version $(LPAREN)) $(GLINK_LEX Identifier) $(D $(RPAREN))
     $(D version $(LPAREN)) $(D unittest) $(D $(RPAREN))
     $(D version $(LPAREN)) $(D assert) $(D $(RPAREN))
@@ -67,7 +67,7 @@ $(GNAME VersionCondition):
         with a single source file.
         )
 
-        $(P The $(I VersionCondition) is satisfied if $(I Identifier)
+        $(P The $(I VersionConditional) is satisfied if $(I Identifier)
         matches a $(I version identifier).
         )
 
@@ -405,10 +405,10 @@ version(DigitalMars_funky_extension)
         )
 
 
-$(H2 $(LNAME2 debug, Debug Condition))
+$(H2 $(LNAME2 debug, Debug Conditional))
 
 $(GRAMMAR
-$(GNAME DebugCondition):
+$(GNAME DebugConditional):
     $(D debug)
     $(D debug $(LPAREN)) $(GLINK_LEX Identifier) $(D $(RPAREN))
 )
@@ -442,7 +442,7 @@ debug:
 
 $(H3 $(LNAME2 DebugStatement, Debug Statement))
 
-        $(P A $(GLINK ConditionalStatement) that has a $(GLINK DebugCondition) is called
+        $(P A $(GLINK ConditionalStatement) that has a $(GLINK DebugConditional) is called
         a $(I DebugStatement). $(I DebugStatements) have relaxed semantic checks in that
         `pure`, `@nogc`, `nothrow` and `@safe` checks are not done.
         Neither do $(I DebugStatements) influence the inference of `pure`, `@nogc`, `nothrow`
@@ -497,10 +497,10 @@ debug(identifier) { } // add in debug code if debug keyword is identifier
         and $(D -debug=)$(I identifier).
         )
 
-$(H2 $(LNAME2 staticif, Static If Condition))
+$(H2 $(LNAME2 staticif, Static If Conditional))
 
 $(GRAMMAR
-$(GNAME StaticIfCondition):
+$(GNAME StaticIfConditional):
     $(D static if $(LPAREN)) $(ASSIGNEXPRESSION) $(D $(RPAREN))
 )
 
@@ -514,7 +514,7 @@ $(GNAME StaticIfCondition):
         to a boolean type or if it cannot be evaluated at compile time.
         )
 
-        $(P $(I StaticIfCondition)s
+        $(P $(I StaticIfConditional)s
         can appear in module, class, template, struct, union, or function scope.
         In function scope, the symbols referred to in the
         $(ASSIGNEXPRESSION) can be any that can normally be referenced
@@ -562,7 +562,7 @@ Int!(17) c;  // error, static assert trips
 ------
 )
 
-        $(P A $(I StaticIfCondition) differs from an
+        $(P A $(I StaticIfConditional) differs from an
         $(I IfStatement) in the following ways:
         )
 


### PR DESCRIPTION
Using `IfCondition` in the grammar is misleading. It can be used for `if`, but also for `while` and `switch`. On the other hand, `Condition`, which refers to conditional compilation constructs, isn’t the stuff in parentheses of a `static if`, `debug` or `version`, but the whole `static if (…)` / `debug (…)` / `version (…)`; therefore, I replaced it with `Conditional`.