### PR TITLE
Allow `ref` and `auto ref` in `IfCondition` declarations

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -241,6 +241,8 @@ $(GNAME IfCondition):
     $(EXPRESSION)
     $(D auto) $(GLINK_LEX Identifier) $(D =) $(EXPRESSION)
     $(D scope) $(GLINK_LEX Identifier) $(D =) $(EXPRESSION)
+    $(D ref) $(GLINK_LEX Identifier) $(D =) $(EXPRESSION)
+    $(D auto ref) $(GLINK_LEX Identifier) $(D =) $(EXPRESSION)
     $(GLINK2 type, TypeCtors) $(GLINK_LEX Identifier) $(D =) $(EXPRESSION)
     $(GLINK2 type, TypeCtors)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator) $(D =) $(EXPRESSION)
 

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -239,12 +239,18 @@ $(GNAME IfStatement):
 
 $(GNAME IfCondition):
     $(EXPRESSION)
-    $(D auto) $(GLINK_LEX Identifier) $(D =) $(EXPRESSION)
-    $(D scope) $(GLINK_LEX Identifier) $(D =) $(EXPRESSION)
-    $(D ref) $(GLINK_LEX Identifier) $(D =) $(EXPRESSION)
-    $(D auto ref) $(GLINK_LEX Identifier) $(D =) $(EXPRESSION)
-    $(GLINK2 type, TypeCtors) $(GLINK_LEX Identifier) $(D =) $(EXPRESSION)
-    $(GLINK2 type, TypeCtors)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator) $(D =) $(EXPRESSION)
+    $(GLINK IfConditionStorageClasses) $(GLINK_LEX Identifier) $(D =) $(EXPRESSION)
+    $(GLINK IfConditionStorageClasses)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator) $(D =) $(EXPRESSION)
+
+$(GNAME IfConditionStorageClasses):
+    $(GLINK IfConditionStorageClass)
+    $(GLINK IfConditionStorageClass) $(GLINK IfConditionStorageClasses)
+
+$(GNAME IfConditionStorageClass):
+    $(D scope)
+    $(D auto)
+    $(D ref)
+    $(GLINK2 type, TypeCtor)
 
 $(GNAME ThenStatement):
     $(PSSCOPE)
@@ -262,6 +268,9 @@ $(GNAME ElseStatement):
 
         $(P The $(I ElseStatement) is associated with the innermost `if`
         statement which does not already have an associated $(I ElseStatement).)
+
+        $(P If both, `auto` and `ref` are present, the variable is a reference
+        if and only if the *Expression* is an lvalue.)
 
 $(H3 $(LNAME2 boolean-conditions, Boolean Conversion))
 


### PR DESCRIPTION
As [DIP 1046](https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1046.md) *(`ref` For Variable Declarations)* has been accepted, probably, `ref` (and `auto ref`) should be allowed for the condition in `if`, `while`, and `switch` statements:

```d
int** pptr = …;
if (ref int* ptr = *pptr) …;
```
Of course, the condition tests whether the variable (`ptr` in the example) is `true`-like, not whether the reference is a non-null reference. In the example, it tests `ptr !is null`, and **not** `&ptr !is null` (or, equivalently, `pptr !is null`).

```d
if (auto ref x = mystery()) …;
```
Especially in template contexts, `auto ref` could be used to make `x` be a `ref` if `mystery()` returns by reference, but a value otherwise.