### PR TITLE
[spec] Restore *ArrayInitializer*

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -1032,13 +1032,13 @@ $(GNAME ArrayElementInitializer):
     $(GLINK2 expression, AssignExpression) $(D :) $(GLINK2 declaration, NonVoidInitializer)
 )
 
-$(H4 $(LNAME2 static-init-static, Static Initialization of Statically Allocated Arrays))
-
-        $(P Static initalizations are supplied by a list of array
+        $(P An *ArrayInitializer* is a list of array
         element values enclosed in `[ ]`. The values can be optionally
         preceded by an index and a `:`.
         If an index is not supplied, it is set to the previous index
         plus 1, or 0 if it is the first value.
+        Any missing elements will be initialized to the default value
+        of the element type.
         )
 
 $(SPEC_RUNNABLE_EXAMPLE_RUN
@@ -1064,29 +1064,9 @@ assert(value == [5, 6, 2]);
 ---------
 )
 
-        $(P All elements of a static array can be initialized to a specific value with:)
-
-$(SPEC_RUNNABLE_EXAMPLE_RUN
----------
-int[4] a = 42; // set all elements of a to 42
-
-assert(a == [42, 42, 42, 42]);
----------
-)
-
-        $(P These arrays are statically allocated when they appear in global scope.
-        Otherwise, they need to be marked with $(D const) or $(D static)
-        storage classes to make them statically allocated arrays.)
-
-$(H4 $(LNAME2 index-initializers, Index Initializers))
-
-    $(P To initialize an element at a particular index, use the
-        *AssignExpression* `:` *NonVoidInitializer* syntax.
-        The *AssignExpression* must be known at compile-time.
-        Any missing elements will be initialized to the default value
-        of the element type.
-        Note that if the array type is not specified, the array initializer will
-        be parsed as an
+        $(P Any indices must be known at compile-time.
+        Note that if the array type is not specified and every element has an index,
+        it will be inferred as an
         $(DDSUBLINK spec/expression, associative_array_literals, associative array
         literal).)
 
@@ -1101,6 +1081,22 @@ $(H4 $(LNAME2 index-initializers, Index Initializers))
         //int[] e = [n:2]; // error, n not known at compile-time
         ---
         )
+
+$(H3 $(LNAME2 static-init-static, Static Initialization of Statically Allocated Arrays))
+
+        $(P All elements of a static array can be initialized to a specific value with:)
+
+$(SPEC_RUNNABLE_EXAMPLE_RUN
+---------
+int[4] a = 42; // set all elements of a to 42
+
+assert(a == [42, 42, 42, 42]);
+---------
+)
+
+        $(P These arrays are statically allocated when they appear in global scope.
+        Otherwise, they need to be marked with $(D const) or $(D static)
+        storage classes to make them statically allocated arrays.)
 
 
 $(H2 $(LNAME2 special-array, Special Array Types))
@@ -1332,7 +1328,7 @@ $(H3 $(LNAME2 void_arrays, Void Arrays))
     the exact type of the array elements are unimportant. The $(D .length) of a
     void array is the length of the data in bytes, rather than the number of
     elements in its original type. Array indices in slicing
-    operations are interpreted as byte indices.)
+    operations are interpreted as byte indices. A void array cannot be indexed.)
 
     $(P Arrays of any type can be implicitly converted to a (tail qualified) void array - the
     compiler inserts the appropriate calculations so that the $(D .length) of
@@ -1355,10 +1351,12 @@ void main()
     arr[0..4] = [5];               // Assign first 4 bytes to 1 int element
     assert(data1 == [5,2,3]);
 
+    arr ~= [6];                    // Append the 4 bytes of an int
     //data1 = arr;                 // Error: void[] does not implicitly
                                    // convert to int[].
     int[] data2 = cast(int[]) arr; // OK, can convert with explicit cast.
-    assert(data2 is data1);
+    assert(data2 is arr);          // both point to the same set of bytes
+    assert(data2 == [5,2,3,6]);
 }
 ---------
 )

--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -107,16 +107,22 @@ int[]* e;     // pointer to dynamic array of ints
 ---------
 )
 
-$(H2 $(LNAME2 literals, Array Literals))
+$(H2 $(LNAME2 literals, Array Initializers & Literals))
 
+    $(P An $(GLINK ArrayInitializer) initializes a dynamic or static array:)
 ---
 auto a1 = [1,2,3];  // type is int[], with elements 1, 2, and 3
 auto a2 = [1u,2,3]; // type is uint[], with elements 1u, 2u, and 3u
 int[2] a3 = [1,2];  // type is int[2], with elements 1, and 2
 ---
-    $(P `[]` is an empty array literal.)
 
-    $(P See $(DDSUBLINK spec/expression, array_literals, Array Literals).)
+    $(P An $(DDSUBLINK spec/expression, array_literals, array literal) is an expression:)
+---
+void f(int[] a);
+
+f([1, 2]); // pass 2 elements
+f([]); // pass an empty array
+---
 
 $(LEGACY_LNAME2 usage)
 $(H2 $(LNAME2 assignment, Array Assignment))
@@ -1010,8 +1016,23 @@ $(H3 $(LNAME2 void-initialization, Void Initialization))
         $(REF uninitializedArray, std,array).
         )
 
+$(H3 $(LNAME2 array-initializers, Array Initializers))
 
-$(H3 $(LNAME2 static-init-static, Static Initialization of Statically Allocated Arrays))
+$(GRAMMAR
+$(GNAME ArrayInitializer):
+    $(D [) $(I ArrayElementInitializers)$(OPT) $(D ])
+
+$(GNAME ArrayElementInitializers):
+    $(I ArrayElementInitializer)
+    $(I ArrayElementInitializer) $(D ,)
+    $(I ArrayElementInitializer) $(D ,) $(GSELF ArrayElementInitializers)
+
+$(GNAME ArrayElementInitializer):
+    $(GLINK2 declaration, NonVoidInitializer)
+    $(GLINK2 expression, AssignExpression) $(D :) $(GLINK2 declaration, NonVoidInitializer)
+)
+
+$(H4 $(LNAME2 static-init-static, Static Initialization of Statically Allocated Arrays))
 
         $(P Static initalizations are supplied by a list of array
         element values enclosed in `[ ]`. The values can be optionally
@@ -1056,6 +1077,30 @@ assert(a == [42, 42, 42, 42]);
         $(P These arrays are statically allocated when they appear in global scope.
         Otherwise, they need to be marked with $(D const) or $(D static)
         storage classes to make them statically allocated arrays.)
+
+$(H4 $(LNAME2 index-initializers, Index Initializers))
+
+    $(P To initialize an element at a particular index, use the
+        *AssignExpression* `:` *NonVoidInitializer* syntax.
+        The *AssignExpression* must be known at compile-time.
+        Any missing elements will be initialized to the default value
+        of the element type.
+        Note that if the array type is not specified, the array initializer will
+        be parsed as an
+        $(DDSUBLINK spec/expression, associative_array_literals, associative array
+        literal).)
+
+        $(SPEC_RUNNABLE_EXAMPLE_RUN
+        ---
+        int n = 4;
+        auto aa = [0:1, 3:n]; // associative array `int[int]`
+
+        int[] a = [1, 3:n, 5];
+        assert(a == [1, 0, 0, n, 5]);
+
+        //int[] e = [n:2]; // error, n not known at compile-time
+        ---
+        )
 
 
 $(H2 $(LNAME2 special-array, Special Array Types))

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -183,7 +183,13 @@ int x, *y;  // x is an int, y is a pointer to int
 int x[], y; // x is an array/pointer, y is an int
 )
 
-$(H2 $(LEGACY_LNAME2 initializers, initialization, Initialization))
+$(H2 $(LNAME2 initialization, Initialization))
+
+        $(P When no *Initializer* is given, a variable is set to the
+        $(DDSUBLINK spec/property, init, default `.init` value) for
+        its type.)
+
+$(H3 $(LNAME2 initializers, Initializers))
 
 $(GRAMMAR
 $(GNAME Initializer):
@@ -191,18 +197,24 @@ $(GNAME Initializer):
     $(GLINK NonVoidInitializer)
 
 $(GNAME NonVoidInitializer):
-    $(GLINK2 expression, AssignExpression)$(LEGACY_LNAME2 ExpInitializer)
-    $(GLINK2 expression, ArrayLiteral)$(LEGACY_LNAME2 ArrayInitializer)
+    $(GLINK2 arrays, ArrayInitializer)$(LEGACY_LNAME2 ArrayInitializer)
     $(GLINK2 struct, StructInitializer)$(LEGACY_LNAME2 StructInitializer)
+    $(GLINK2 expression, AssignExpression)$(LEGACY_LNAME2 ExpInitializer)
 )
 
-        $(P When no *Initializer* is given, a variable is set to the
-        $(DDSUBLINK spec/property, init, default `.init` value) for
-        its type.)
+        $(P A variable can be initialized with a $(I NonVoidInitializer).
+        An *ArrayInitializer* or *StructInitializer* takes precedence over
+        an expression initializer.)
 
-        $(P A variable can be initialized with a $(I NonVoidInitializer).)
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+---
+struct S { int i; }
 
-        $(P See also: $(DDSUBLINK spec/arrays, array-initialization, Array Initialization).)
+S s = {}; // struct initializer, not a function literal expression
+S[] a = [{2}]; // array initializer holding a struct initializer
+//a = [{2}]; // invalid array literal expression
+---
+)
 
 $(H3 $(LNAME2 void_init, Void Initialization))
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2101,16 +2101,7 @@ $(H3 $(LNAME2 array_literals, Array Literals))
 
 $(GRAMMAR
 $(GNAME ArrayLiteral):
-    $(D [) $(I ArrayMemberInitializations)$(OPT) $(D ])
-
-$(GNAME ArrayMemberInitializations):
-    $(I ArrayMemberInitialization)
-    $(I ArrayMemberInitialization) $(D ,)
-    $(I ArrayMemberInitialization) $(D ,) $(GSELF ArrayMemberInitializations)
-
-$(GNAME ArrayMemberInitialization):
-    $(GLINK2 declaration, NonVoidInitializer)
-    $(GLINK AssignExpression) $(D :) $(GLINK2 declaration, NonVoidInitializer)
+    $(D [) $(GLINK ArgumentList)$(OPT) $(D ])
 )
 
     $(P An array literal is a comma-separated list of expressions
@@ -2161,27 +2152,6 @@ $(GNAME ArrayMemberInitialization):
             return [1, 2, 3];
         }
         ---
-
-    $(P To initialize an element at a particular index, use the
-        *AssignExpression* `:` *NonVoidInitializer* syntax.
-        The *AssignExpression* must be known at compile-time.
-        Any missing elements will be initialized to the default value
-        of the element type.
-        Note that if the array type is not specified, the literal will
-        be parsed as an
-        $(RELATIVE_LINK2 associative_array_literals, associative array).)
-
-        $(SPEC_RUNNABLE_EXAMPLE_RUN
-        ---
-        int n = 4;
-        auto aa = [0:1, 3:n]; // associative array `int[int]`
-
-        int[] a = [1, 3:n, 5];
-        assert(a == [1, 0, 0, n, 5]);
-
-        //int[] e = [n:2]; // error, n not known at compile-time
-        ---
-        )
 
 $(H4 $(LNAME2 cast_array_literal, Casting))
 


### PR DESCRIPTION
It was merged with ArrayLiteral in #3215 - sorry.

Fixes Bugzilla 24634 - Parse error initializing array from expression with StructInitializer.

Add examples.
Move index initializer paragraph to arrays.dd, add subheading.
declaration.dd: Add initializers subheading, move paragraph about default init above it.