### PR TITLE
Fix Grammar Page

### DIFF
--- a/spec/grammar.dd
+++ b/spec/grammar.dd
@@ -8,7 +8,7 @@ $(H2 Lexical Syntax)
 
     $(P Refer to the page for $(LINK2 lex.html, lexical syntax).)
 
-$(SUMMARY_GRAMMAR)
+$(GRAMMAR_SUMMARY)
 
 $(SPEC_SUBNAV_PREV_NEXT istring, Interpolation Expression Sequence, module, Modules)
 )
@@ -29,4 +29,4 @@ Macros:
         PSCURLYSCOPE=$(GLINK NonEmptyOrScopeBlockStatement)
         TRAITS_LINK2=$(LINK2 traits.html#$1, $(D $1))
         GLINK2=$(GLINK $2)
-        SUMMARY_GRAMMAR=$0
+        GRAMMAR_SUMMARY=$0


### PR DESCRIPTION
The second commit in #3860 ([GRAMMAR_SUMMARY → SUMMARY_GRAMMAR](https://github.com/dlang/dlang.org/pull/3860/commits/15d79f53c150249ec7bb404f91cee0114e7fbda3)) destroyed the [grammar.html](https://dlang.org/spec/grammar.html) page. This should fix it.