### PR TITLE
Clarify capacity documentation

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -652,7 +652,7 @@ Returns an array literal with each element of the literal being the $(D .init) p
         which is 8 in 32-bit builds and 16 on 64-bit builds.))
         $(TROW $(D .length), Get/set number of elements in the
         array. It is of type $(D size_t).)
-        $(TROW $(D .capacity), Returns the number of elements that can be appended to the array without reallocating.
+        $(TROW $(D .capacity), Returns the length an array can grow to without reallocating.
             See $(RELATIVE_LINK2 capacity-reserve, here) for details.)
         $(TROW $(D .ptr), Returns a pointer to the first element of the array.)
         $(TROW $(D .dup), Create a dynamic array of the same size and copy the contents of the array into it. The copy will have any immutability or const stripped. If this conversion is invalid the call will not compile.)


### PR DESCRIPTION
The current description is wrong. Capacity includes the existing elements, so for instance if an int[] is length 3 and has capacity 5, appending 5 elements will reallocate, because it would set the length to 8 which is greater than the capacity of 5.