### PR TITLE
[spec/memory-safety] Tweak system/safe/trusted docs

### DIFF
--- a/spec/memory-safe-d.dd
+++ b/spec/memory-safe-d.dd
@@ -33,19 +33,21 @@ $(H2 $(LNAME2 usage, Usage))
 
         $(P `@system` functions may perform any operation legal from the perspective of the language,
         including inherently memory unsafe operations such as pointer casts or pointer arithmetic.
-        However, compile-time known memory corrupting operations, such as indexing a static array
+        However, compile-time known memory-corrupting operations, such as indexing a static array
         out of bounds or returning a pointer to an expired stack frame, can still raise an error.
         `@system` functions may not be called directly from `@safe` functions.)
 
-        $(P `@trusted` functions have all the capabilities of `@system` functions but may be called from
-        `@safe` functions. For this reason they should be very limited in the scope of their use. Typical uses of
+        $(P `@trusted` functions must have a $(DDSUBLINK spec/function, safe-interfaces, safe interface),
+        as they can be called from `@safe` functions.
+        Internally they have all the capabilities of `@system` functions.
+        For this reason they should be very limited in the scope of their use. Typical uses of
         `@trusted` functions include wrapping system calls that take buffer pointer and length arguments separately so that
-        `@safe` functions may call them with arrays. `@trusted` functions must have a $(DDSUBLINK spec/function, safe-interfaces, safe interface).)
+        `@safe` functions may call them with arrays.)
 
         $(P `@safe` functions have a number of restrictions on what they may do and are intended to disallow operations that
         may cause memory corruption. See $(DDSUBLINK spec/function, safe-functions, `@safe` functions).)
 
-        $(P These attributes may be inferred when the compiler has the function body available, such as with templates.)
+        $(P The `@safe` attribute $(DDSUBLINK spec/function, function-attribute-inference, can be inferred) when the compiler has the function body available, such as with templates.)
 
         $(P Array bounds checks are necessary to enforce memory safety, so
         these are enabled (by default) for `@safe` code even in $(B -release) mode.


### PR DESCRIPTION
Emphasise that trusted functions have a safe interface - mention this first as people on the forum seem to have missed it sometimes.
Add link to attribute inference.