### PR TITLE
Fix `FunctionLiteral` grammar

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2274,11 +2274,14 @@ $(H3 $(LNAME2 function_literals, Function Literals))
 
 $(GRAMMAR
 $(GNAME FunctionLiteral):
-    $(D function) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithAttributes)$(OPT) $(GLINK FunctionLiteralBody)
-    $(D delegate) $(GLINK RefOrAutoRef)$(OPT) $(GLINK2 type, Type)$(OPT) $(GLINK ParameterWithMemberAttributes)$(OPT) $(GLINK FunctionLiteralBody)
+    $(D function) $(GLINK RefOrAutoRef)$(OPT) $(GLINK BasicTypeWithSuffixes)$(OPT) $(GLINK ParameterWithAttributes)$(OPT) $(GLINK FunctionLiteralBody)
+    $(D delegate) $(GLINK RefOrAutoRef)$(OPT) $(GLINK BasicTypeWithSuffixes)$(OPT) $(GLINK ParameterWithMemberAttributes)$(OPT) $(GLINK FunctionLiteralBody)
     $(GLINK RefOrAutoRef)$(OPT) $(GLINK ParameterWithMemberAttributes) $(GLINK FunctionLiteralBody)
     $(GLINK2 statement, BlockStatement)
     $(IDENTIFIER) $(D =>) $(GLINK AssignExpression)
+
+$(GNAME BasicTypeWithSuffixes):
+    $(GLINK2 type, BasicType) $(GLINK2 type, TypeSuffixes)$(OPT)
 
 $(GNAME ParameterWithAttributes):
     $(GLINK2 function, Parameters) $(GLINK2 function, FunctionAttributes)$(OPT)


### PR DESCRIPTION
In the function literal grammar, it says that after the `function`/`delegate` keyword and optionally `ref` or `auto ref`, there can follow a general [*`Type`*](https://dlang.org/spec/type.html#Type):
<pre>
<i>FunctionLiteral</i>:
    function <i>RefOrAutoRef</i>? <i>Type</i>? <i>ParameterWithAttributes</i>? <i>FunctionLiteralBody</i>
    delegate <i>RefOrAutoRef</i>? <i>Type</i>? <i>ParameterWithMemberAttributes</i>? <i>FunctionLiteralBody</i>
    …
</pre>

The compiler does not support general *`Type`*, which is <code>*TypeCtors*? *BasicType* *TypeSuffixes*?</code>, but only <code>*BasicType* *TypeSuffixes*?</code>.