### PR TITLE
ddoc_preprocessor: Don't depend on entire DMD frontend, only include single `dmd.cli` module

### DIFF
--- a/ddoc/dub.sdl
+++ b/ddoc/dub.sdl
@@ -1,8 +1,10 @@
 name "ddoc_preprocessor"
 description "Preprocesses source code before running Ddoc over it"
 dependency "libdparse" version="~>0.15.1"
-dependency "dmd" path="../../dmd"
-versions "DdocOptions"
+# we only need an isolated single module from DMD
+sourceFiles "../../dmd/compiler/src/dmd/cli.d"
+importPaths "source" "../../dmd/compiler/src"
+versions "DdocOptions" # for dmd.cli
 buildRequirements "disallowDeprecations"
 configuration "executable" {
 	versions "IsExecutable"


### PR DESCRIPTION
We only need a single module, and it's totally isolated too - for now.

Besides somewhat speeding up the ddoc_preprocessor tool build, the main advantage is that we lift the dependency on DMD's `dub.sdl`. The build is currently using a stable dub v1.17, and this limits what we can do with DMD's dub.sdl, such as requiring newer dub versions, what I'd need in https://github.com/dlang/dmd/pull/16756.