### PR TITLE
Remove dub.selections.json left-overs wrt. removed dmd dependency

### DIFF
--- a/ddoc/dub.selections.json
+++ b/ddoc/dub.selections.json
@@ -1,7 +1,6 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"dmd": {"path":"../../dmd"},
 		"libdparse": "0.15.4",
 		"stdx-allocator": "2.77.5"
 	}

--- a/dpl-docs/dub.selections.json
+++ b/dpl-docs/dub.selections.json
@@ -6,7 +6,6 @@
 		"ddoc_preprocessor": {"path":"../ddoc"},
 		"ddox": "0.16.15",
 		"diet-ng": "1.7.2",
-		"dmd": {"path":"../../dmd"},
 		"eventcore": "0.9.7",
 		"hyphenate": "1.1.2",
 		"libasync": "0.8.6",


### PR DESCRIPTION
Just to fix dub warnings like

```
Selected package dmd >=0.0.0 @../../dmd doesn't exist. Using latest matching version instead.
```