### PR TITLE
[spec/traits] Improve getOverloads docs

### DIFF
--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -1426,13 +1426,13 @@ void main()
 
 $(H3 $(GNAME getOverloads))
 
-        $(P The first argument is an aggregate (e.g. struct/class/module).
-        The second argument is a `string` that matches the name of
-        the member(s) to return.
-        The third argument is a `bool`, and is optional.  If `true`, the
-        result will also include template overloads.
-        The result is a symbol sequence of all the overloads of the supplied name.
-        )
+        * The first argument is an aggregate type or instance, or a module.
+        * The second argument is a `string` that matches the name of
+          the member(s) to return.
+        * The third argument is a `bool`, and is optional.  If `true`, the
+          result will also include template overloads.
+        * The result is a $(DDSUBLINK spec/template, homogeneous_sequences, symbol sequence)
+          of all the overloads of the supplied name.
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
@@ -1440,8 +1440,6 @@ import std.stdio;
 
 class D
 {
-    this() { }
-    ~this() { }
     void foo() { }
     int foo(int) { return 2; }
     void bar(T)() { return T.init; }
@@ -1452,18 +1450,24 @@ void main()
 {
     D d = new D();
 
-    foreach (t; __traits(getOverloads, D, "foo"))
-        writeln(typeid(typeof(t)));
+    alias fooOverloads = __traits(getOverloads, D, "foo");
+    foreach (o; fooOverloads)
+        writeln(typeid(typeof(o)));
 
-    alias b = typeof(__traits(getOverloads, D, "foo"));
-    foreach (t; b)
-        writeln(typeid(t));
+    // typeof on a symbol sequence gives a type sequence
+    foreach (T; typeof(fooOverloads))
+        writeln(typeid(T));
 
-    auto i = __traits(getOverloads, d, "foo")[1](1);
-    writeln(i);
+    // calls d.foo(3)
+    auto i = __traits(getOverloads, d, "foo")[1](3);
+    assert(i == 2);
 
-    foreach (t; __traits(getOverloads, D, "bar", true))
-        writeln(t.stringof);
+    // pass true to include templates
+    // calls std.stdio.writeln(i)
+    __traits(getOverloads, std.stdio, "writeln", true)[0](i);
+
+    foreach (o; __traits(getOverloads, D, "bar", true))
+        writeln(o.stringof);
 }
 ---
 )
@@ -1471,10 +1475,10 @@ void main()
         Prints:
 
 $(CONSOLE
-void()
-int()
-void()
-int()
+void function()
+int function(int)
+void function()
+int function(int)
 2
 bar(T)()
 bar(int n)


### PR DESCRIPTION
Use list, add link.
Mention it works on an aggregate type or instance.
Remove unneeded ctor, dtor.
Tweak example, use `fooOverloads` alias.
Add comments.
Add example of `getOverloads` on a module.
Fix `writeln` `typeid` method output.