### PR TITLE
[spec] Add reserved version for Xtensa architecture

### DIFF
--- a/spec/version.dd
+++ b/spec/version.dd
@@ -306,6 +306,7 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
         $(TROW $(ARGS $(D SH)) , $(ARGS The SuperH architecture, 32-bit))
         $(TROW $(ARGS $(D WebAssembly)) , $(ARGS The WebAssembly virtual ISA $(LPAREN)instruction set architecture$(RPAREN), 32-bit))
         $(TROW $(ARGS $(D WASI)) , $(ARGS The WebAssembly System Interface))
+        $(TROW $(ARGS $(D Xtensa)) , $(ARGS The Xtensa Architecture, 32-bit))
         $(TROW $(ARGS $(D Alpha)) , $(ARGS The Alpha architecture))
         $(TROW $(ARGS $(D Alpha_SoftFloat)) , $(ARGS The Alpha soft float ABI))
         $(TROW $(ARGS $(D Alpha_HardFloat)) , $(ARGS The Alpha hard float ABI))


### PR DESCRIPTION
See also https://github.com/ldc-developers/ldc/issues/4725

cc @TurkeyMan is Xtensa ESP always 32-bit? What to do about Xtensa-S2/Xtensa-S3? I assume they will be specified in the target triple and any information they provide can be done through other means (e.g. `__traits(getTargetInfo)`)