### PR TITLE
[spec/struct] Document pointer to struct dot operator

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1613,6 +1613,8 @@ $(TABLE
         * Access a $(DDLINK spec/property, Properties, property) of a type or expression.
         * Access a member of a module, package, aggregate type or instance, enum
           or template instance.
+        * Dereference a $(DDSUBLINK spec/struct, struct-pointer, pointer to a struct/union)
+          instance and access a member of it.
         * Call a free function using $(DDSUBLINK spec/function, pseudo-member, UFCS).
     )
     $(TROW `.` *NewExpression*, Instantiate a $(DDSUBLINK spec/class, nested-explicit,

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -59,12 +59,19 @@ void main()
 ---
 )
 
-    $(P For local variables, a struct instance is allocated on the stack
-    by default. To allocate on the heap, use `new`:)
+    $(P For local variables, a struct/union instance is allocated on the stack
+    by default. To allocate on the heap, use $(DDSUBLINK spec/expression, new_expressions,
+    `new`), which gives a pointer.)
+
+    $(PANEL
+    A $(LNAME2 struct-pointer, pointer to a struct) or union is automatically
+    dereferenced when using the `.` operator to access members.
     ---
     S* p = new S;
-    assert(p.i == 0);
+    assert(p.i == 0); // `p.i` is the same as `(*p).i`
     ---
+    $(NOTE There is no `->` operator as in C.)
+    )
 
     $(P A struct can contain multiple fields which are stored sequentially.
     Conversely, multiple fields in a union use overlapping storage.)


### PR DESCRIPTION
List pointer as a valid left operand of dot expression. 
[struct.dd] Add panel explaining access of a member of a struct pointer.