### PR TITLE
Update cent/ucent deprecated docs

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -380,14 +380,15 @@ $(H4 Rationale)
 
 $(H3 $(DEPNAME 128-bit integer types))
     $(P D currently reserves the `cent` and `ucent` keywords for future use as
-        128-bit integral types, but the use of will result in a compile-time error.
+        128-bit integral types. Using them will result in a compile-time error.
+    )
         ---
         cent a = 18446744073709551616L;
         ucent b = 36893488147419103232UL;
         ---
-    )
+
 $(H4 Corrective Action)
-    $(P Use the library types in $(COREFILEREF int128).
+    $(P Use the library types in $(MREF std, int128) or $(COREFILEREF int128).
     )
 $(H4 Rationale)
     $(P These types are too specialized to be a part of the core language.

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -107,8 +107,8 @@ $(H2 $(LEGACY_LNAME2 Basic Data Types, basic-data-types, Basic Data Types))
     $(TROW $(D uint), $(D 0u), unsigned 32 bits)
     $(TROW $(D long), $(D 0L), signed 64 bits)
     $(TROW $(D ulong), $(D 0uL), unsigned 64 bits)
-    $(TROW $(D cent), $(D 0), signed 128 bits)
-    $(TROW $(D ucent), $(D 0u), unsigned 128 bits)
+    $(TROW $(GDEPRECATED $(D cent)), $(D 0), signed 128 bits)
+    $(TROW $(GDEPRECATED $(D ucent)), $(D 0u), unsigned 128 bits)
     $(TROW $(D float), $(D float.nan), 32 bit floating point)
     $(TROW $(D double), $(D double.nan), 64 bit floating point)
     $(TROW $(D real), $(D real.nan), largest floating point size available)
@@ -129,6 +129,9 @@ $(H2 $(LEGACY_LNAME2 Basic Data Types, basic-data-types, Basic Data Types))
     of the `double` type. On x86 CPUs it is often implemented as the 80 bit Extended Real
     type supported by the x86 FPU.
     )
+
+    $(NOTE 128-bit integer types `cent` and `ucent`
+    $(DDSUBLINK deprecate, 128-bit integer types, have been deprecated).)
 
     $(P NOTE: Complex and imaginary types `ifloat`, `idouble`, `ireal`, `cfloat`, `cdouble`,
     and `creal` have been deprecated in favor of `std.complex.Complex`.)


### PR DESCRIPTION
Also list `std.int128`.
~~Add `TROW_DEPRECATED1` macro (the `<del>` tag of `GDEPRECATED` doesn't work outside of `<td>`).~~
Mark cent/ucent as deprecated in basic types & add note under table.