### PR TITLE
[spec/expression] Tweak `new` docs

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -1011,17 +1011,24 @@ $(H3 $(LNAME2 default-initialization, Default Initialization))
         )
 
 $(H3 $(LNAME2 length-initialization, Length Initialization))
+
         $(P The $(D new) expression can be used to allocate a dynamic array
         with a specified length by specifying its type and then using the
         `(size)` syntax:
         )
 
-$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 ---------
-int[] i = new int[](5); //i.length == 5
-int[][] j = new int[][](10, 5); //j.length == 10, j[0].length == 5
+int[] i = new int[](5);
+i = new int[5]; // same allocation, alternate syntax
+assert(i.length == 5);
+
+int[][] j = new int[][](10, 5);
+assert(j.length == 10);
+assert(j[0].length == 5);
 ---------
 )
+        $(P See $(GLINK2 expression, NewExpression) for details.)
 
 $(H3 $(LNAME2 void-initialization, Void Initialization))
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2858,11 +2858,20 @@ $(GNAME NewExpression):
     )
 
     $(P `new T` constructs an instance of type `T` and default-initializes it.
-        The result is:)
-    * `T` when `T` is a reference type (e.g. class, dynamic array,
-      $(DDSUBLINK spec/hash-map, construction_and_ref_semantic, associative array))
+        The result's type is:)
+    * `T` when `T` is a reference type (e.g. classes,
+      $(DDSUBLINK spec/hash-map, construction_and_ref_semantic, associative arrays))
     * `T*` when `T` is a value type (e.g. basic types, structs)
 
+    $(SPEC_RUNNABLE_EXAMPLE_RUN
+    ---
+    int* i = new int;
+    assert(*i == 0); // int.init
+
+    Object o = new Object;
+    //int[] a = new int[]; // error, need length argument
+    ---
+    )
     $(P The $(INLINE_GRAMMAR *Type(NamedArgumentList)*) form allows passing either a single initializer
         of the same type, or multiple arguments for more complex types:)
 
@@ -2873,13 +2882,11 @@ $(GNAME NewExpression):
 
     $(SPEC_RUNNABLE_EXAMPLE_RUN
     ---
-    int* i = new int;
-    assert(*i == 0); // int.init
-    i = new int(5);
+    int* i = new int(5);
     assert(*i == 5);
 
-    Object o = new Object;
     Exception e = new Exception("info");
+    assert(e.msg == "info");
 
     int[] a = new int[](2);
     assert(a.length == 2);


### PR DESCRIPTION
Allocating an array requires a length argument. 
Split example in 2.
Add asserts.
Add link to NewExpression from array page.