### PR TITLE
[spec] Tweak GC allocating operations docs

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2203,8 +2203,12 @@ $(H4 $(LNAME2 array-literal-heap, GC Allocation))
     $(P An array literal is not GC allocated if:)
 
     * It initializes or assigns to a static array.
-    * It initializes a $(DDSUBLINK spec/attribute, scope, `scope`) slice.
-    * It is used on one side of a $(GLINK EqualExpression) or $(GLINK RelExpression).
+    * It is an argument to a $(DDSUBLINK spec/function, scope-parameters, `scope`
+      function parameter).
+    * It initializes a $(DDSUBLINK spec/attribute, scope, `scope`) slice (`-preview=dip1000`
+      $(LINK2 $(ROOT_DIR)changelog/2.102.0.html#dmd.scope-array-on-stack,
+      is required for this)).
+    * It is used on one side of an $(GLINK EqualExpression) or $(GLINK RelExpression).
     * It is immediately $(RELATIVE_LINK2 index_operations, indexed) and used as an rvalue.
     * It is used as a `foreach` aggregate where the element variable is not `ref`.
 

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1931,10 +1931,11 @@ int* balin(scope int* q, int* r)
 }
 ---
 
-    $(P As a `scope` parameter must not escape, the compiler can potentially avoid heap-allocating a
+    $(IMPLEMENTATION_DEFINED
+    As a `scope` parameter must not escape, the compiler can potentially avoid heap-allocating a
     unique argument to a `scope` parameter. Due to this, passing an array literal, delegate
     literal or a $(GLINK2 expression, NewExpression) to a scope parameter may be allowed in a
-    `@nogc` context, depending on the compiler implementation.)
+    `@nogc` context.)
 
 $(H3 $(LNAME2 return-scope-parameters, Return Scope Parameters))
 

--- a/spec/garbage.dd
+++ b/spec/garbage.dd
@@ -372,16 +372,19 @@ $(H2 D $(LNAME2 op_involving_gc, Operations That Involve the Garbage Collector))
         $(LI $(GLINK2 expression, NewExpression))
         $(LI Array appending)
         $(LI Array concatenation)
-        $(LI Array literals (except when used to initialize static data))
+        $(LI Array literals (see $(DDSUBLINK spec/expression, array-literal-heap, exceptions)))
         $(LI Associative array literals)
         $(LI Any insertion or removal in an associative array)
         $(LI Extracting keys or values from an associative array)
-                $(LI Taking the address of (i.e. making a delegate to) a nested function that
+        $(LI Taking the address of (i.e. making a delegate to) a nested function that
          accesses variables in an outer scope)
         $(LI A function literal that accesses variables in an outer scope)
-
         $(LI An $(GLINK2 expression, AssertExpression) that fails its condition)
         )
+
+        $(P There is a $(DDSUBLINK spec/function, nogc-functions, `@nogc` function attribute)
+        which will error at compile-time if any construct is used which would make a GC
+        allocation.)
 
 $(H2 $(LNAME2 gc_config, Configuring the Garbage Collector))
 


### PR DESCRIPTION
Add link to scope parameters for array literals.
Add preview caveat for scope slice initialization from array literal. 
Use IMPLEMENTATION_DEFINED for allowing `@nogc` scope arguments.

garbage.dd:
Link to array literal `@nogc` uses.
Mention `@nogc`.