### PR TITLE
[spec/istring] Use GRAMMAR_LEX

### DIFF
--- a/ddoc/source/preprocessor.d
+++ b/ddoc/source/preprocessor.d
@@ -287,7 +287,7 @@ auto genGrammar(string fileText)
     {
         foreach (i, entry; specTocEntries)
         {
-            if (entry.fileName.endsWith("grammar.dd", "lex.dd", "simd.dd"))
+            if (entry.fileName.endsWith("grammar.dd", "lex.dd", "istring.dd", "simd.dd"))
                 continue;
 
             enum grammarKey = "$(GRAMMAR";

--- a/spec/istring.dd
+++ b/spec/istring.dd
@@ -12,7 +12,7 @@ can be overloaded or handled by template functions.)
 
 $(H2 $(LNAME2 ies, IES Literals))
 
-$(GRAMMAR
+$(GRAMMAR_LEX
 $(GNAME InterpolationExpressionSequence):
     $(GLINK InterpolatedDoubleQuotedLiteral)
     $(GLINK InterpolatedWysiwygLiteral)
@@ -28,7 +28,7 @@ width of the character type for the string expressions.)
 
 $(H3 $(LNAME2 ies_doublequoted, Double Quoted IES Literals))
 
-$(GRAMMAR
+$(GRAMMAR_LEX
 $(GNAME InterpolatedDoubleQuotedLiteral):
     $(B i") $(GLINK InterpolatedDoubleQuotedCharacters)$(OPT) $(B ")
 
@@ -61,7 +61,7 @@ expression, and escapes are not needed inside that part of the expression.)
 
 $(H3 $(LNAME2 ies_wysiwyg, Wysiwyg IES Literals))
 
-$(GRAMMAR
+$(GRAMMAR_LEX
 $(GNAME InterpolatedWysiwygLiteral):
     $(B i$(BACKTICK)) $(GLINK InterpolatedWysiwygCharacters)$(OPT) $(B $(BACKTICK))
 
@@ -80,7 +80,7 @@ escapes are recognized inside these literals.)
 
 $(H3 $(LNAME2 ies_token, Token IES Literals))
 
-$(GRAMMAR
+$(GRAMMAR_LEX
 $(GNAME InterpolatedTokenLiteral):
     $(D iq{) $(GLINK InterpolatedTokenStringTokens)$(OPT) $(D })
 


### PR DESCRIPTION
Stop the lexical grammar sections being included in the parser grammar page.