### PR TITLE
Simplify template parameter specialization and default

### DIFF
--- a/spec/template.dd
+++ b/spec/template.dd
@@ -288,10 +288,7 @@ $(H3 $(LNAME2 template_type_parameters, Type Parameters))
 
 $(GRAMMAR
 $(GNAME TemplateTypeParameter):
-    $(GLINK_LEX Identifier)
-    $(GLINK_LEX Identifier) $(GLINK TemplateTypeParameterSpecialization)
-    $(GLINK_LEX Identifier) $(GLINK TemplateTypeParameterDefault)
-    $(GLINK_LEX Identifier) $(GLINK TemplateTypeParameterSpecialization) $(GLINK TemplateTypeParameterDefault)
+    $(GLINK_LEX Identifier) $(GLINK TemplateTypeParameterSpecialization)$(OPT) $(GLINK TemplateTypeParameterDefault)$(OPT)
 
 $(GNAME TemplateTypeParameterSpecialization):
     $(D :) $(GLINK2 type, Type)
@@ -511,10 +508,7 @@ $(H3 $(LNAME2 template_value_parameter, Value Parameters))
 
 $(GRAMMAR
 $(GNAME TemplateValueParameter):
-    $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator)
-    $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator) $(GLINK TemplateValueParameterSpecialization)
-    $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator) $(GLINK TemplateValueParameterDefault)
-    $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator) $(GLINK TemplateValueParameterSpecialization) $(GLINK TemplateValueParameterDefault)
+    $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator) $(GLINK TemplateValueParameterSpecialization)$(OPT) $(GLINK TemplateValueParameterDefault)$(OPT)
 
 $(GNAME TemplateValueParameterSpecialization):
     $(D :) $(GLINK2 expression, ConditionalExpression)


### PR DESCRIPTION
For template alias parameters, [specialization](https://dlang.org/spec/template.html#TemplateAliasParameterSpecialization) and [default](https://dlang.org/spec/template.html#TemplateAliasParameterDefault) are simply stated as optional, but for template [type](https://dlang.org/spec/template.html#TemplateTypeParameter) and [value](https://dlang.org/spec/template.html#TemplateValueParameter) parameters, the optionality of specialization and default are given in 4 different lines. That is inconsistent and unnecessary. Parsing the optional constructs is simple as each has its own specific introducer, `:` for a specialization and `=` for default.