### PR TITLE
Spec: specify what a TemplateMixinDeclaration is

### DIFF
--- a/spec/template-mixin.dd
+++ b/spec/template-mixin.dd
@@ -45,6 +45,10 @@ $(GNAME MixinQualifiedIdentifier):
         template instantiations.
         )
 
+        $(P A $(I TemplateMixinDeclaration) is the same as a $(I TemplateDeclaration),
+        but can not be instantiated outside of a $(I TemplateMixin).
+        )
+
 $(SPEC_RUNNABLE_EXAMPLE_RUN
 ------
 int y = 3;


### PR DESCRIPTION
I haven't checked with the compiler source if this actually holds true, but when trying it out with the compiler I get

```
a.d(10): Error: template instance `foo!()` mixin templates are not regular templates
```

which makes me believe this is how it works. Please correct me if I'm wrong here.