### PR TITLE
[spec/enum] Tweak named enum docs

### DIFF
--- a/spec/enum.dd
+++ b/spec/enum.dd
@@ -69,6 +69,25 @@ $(H2 $(LNAME2 named_enums, Named Enums))
         enum X { A, B, C }  // named enum
         ---
 
+        $(LEGACY_LNAME2 enum_default_initializer, enum_variables)
+
+        $(P A variable can be of named enum type.
+        Its default initializer is the first member defined for the enum type.
+        )
+
+$(SPEC_RUNNABLE_EXAMPLE_RUN
+------
+enum X { A = 3, B, C }
+
+X x;
+assert(x == X.A);
+x |= X.B;
+assert(x & X.A);
+------
+)
+
+        $(P The result type of a binary operation on a named enum is defined
+        $(DDSUBLINK spec/type, enum-ops, here).)
 
         $(P If the $(GLINK EnumBaseType) is not explicitly set, and the first
         $(I EnumMember) has an *AssignExpression*, it is set to the type of that
@@ -80,10 +99,10 @@ $(H2 $(LNAME2 named_enums, Named Enums))
 
 $(SPEC_RUNNABLE_EXAMPLE_FAIL
 -------------------
-int i;
-
 enum Foo { E }
+
 Foo f;
+int i;
 i = f;           // OK
 f = i;           // error
 f = cast(Foo)i;  // OK
@@ -92,7 +111,11 @@ f = Foo.E;       // OK
 -------------------
 )
 
-        $(P A named enum member does not have an individual $(I Type).)
+        $(P A named enum member cannot declare its own $(I Type).)
+
+        $(P See also: $(DDSUBLINK spec/statement, final-switch-statement, `final switch`) on a named enum.)
+
+$(H3 $(LNAME2 member_values, Enum Member Values))
 
         $(P The value of an $(GLINK EnumMember) is given by its *AssignExpression* if present.
         If there is no *AssignExpression* and it is the first $(I EnumMember),
@@ -152,27 +175,6 @@ enum E : C
         enum X;          // opaque enum
         writeln(X.init); // error: enum X is opaque and has no default initializer
         ---
-
-$(H3 $(LEGACY_LNAME2 enum_default_initializer, enum_variables, Enum Variables))
-
-        $(P A variable can be of named enum type.
-        The default initializer is the first member defined for the enum type.
-        )
-
-$(SPEC_RUNNABLE_EXAMPLE_RUN
-------
-enum X { A = 3, B, C }
-X x;
-assert(x == X.A);
-x |= X.B;
-assert(x & X.A);
-------
-)
-
-        $(P The result type of a binary operation performed when the operands have
-        different types is defined $(DDSUBLINK spec/type, enum-ops, here).)
-
-        $(P See also: $(DDSUBLINK spec/statement, final-switch-statement, `final switch`).)
 
 $(H3 $(LNAME2 enum_properties, Enum Properties))
 


### PR DESCRIPTION
Move enum variables up as they were already used in the implicit conversion example, and remove subheading (keeping anchor).
Move link to `final switch` up too.
Add *Enum Member Values* subheading.