### PR TITLE
[spec/function] Remove MissingFunctionBody from FunctionBody

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -374,6 +374,7 @@ $(H2 $(LNAME2 constructors, Constructors))
 $(GRAMMAR
 $(GNAME Constructor):
     $(D this) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
+    $(D this) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, MissingFunctionBody)
     $(GLINK2 template, ConstructorTemplate)
 )
 
@@ -741,6 +742,7 @@ $(H2 $(LNAME2 destructors, Destructors))
 $(GRAMMAR
 $(GNAME Destructor):
     $(D ~ this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
+    $(D ~ this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, MissingFunctionBody)
 )
 
         $(P The destructor function is called when:)
@@ -819,6 +821,7 @@ $(H2 $(LNAME2 static-constructor, Static Constructors))
 $(GRAMMAR
 $(GNAME StaticConstructor):
     $(D static this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
+    $(D static this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, MissingFunctionBody)
 )
 
         $(P A static constructor is a function that performs initializations of
@@ -961,6 +964,7 @@ $(H2 $(LNAME2 shared_static_constructors, Shared Static Constructors))
 $(GRAMMAR
 $(GNAME SharedStaticConstructor):
     $(D shared static this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
+    $(D shared static this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, MissingFunctionBody)
 )
 
         $(P Shared static constructors are executed before any $(GLINK StaticConstructor)s,
@@ -972,6 +976,7 @@ $(H2 $(LNAME2 shared_static_destructors, Shared Static Destructors))
 $(GRAMMAR
 $(GNAME SharedStaticDestructor):
     $(D shared static ~ this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
+    $(D shared static ~ this ( )) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, MissingFunctionBody)
 )
 
         $(P Shared static destructors are executed at program termination

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -9,6 +9,7 @@ $(H2 $(LNAME2 grammar, Function Declarations))
 $(GRAMMAR
 $(GNAME FuncDeclaration):
     $(GLINK2 declaration, StorageClasses)$(OPT) $(GLINK2 type, BasicType) $(GLINK FuncDeclarator) $(GLINK FunctionBody)
+    $(GLINK2 declaration, StorageClasses)$(OPT) $(GLINK2 type, BasicType) $(GLINK FuncDeclarator) $(GLINK MissingFunctionBody)
     $(GLINK AutoFuncDeclaration)
 
 $(GNAME AutoFuncDeclaration):
@@ -116,7 +117,6 @@ $(GRAMMAR
 $(GNAME FunctionBody):
     $(GLINK SpecifiedFunctionBody)
     $(GLINK ShortenedFunctionBody)
-    $(GLINK MissingFunctionBody)
 
 $(GNAME SpecifiedFunctionBody):
     $(D do)$(OPT) $(GLINK2 statement, BlockStatement)

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -3448,21 +3448,17 @@ $(H2 $(LNAME2 main, $(D main()) Function))
         $(D main()) must be declared as follows:
         )
 
-        $(GRAMMAR
-        $(GNAME MainFunction):
-            $(GLINK MainReturnDecl) $(D main$(LPAREN)$(RPAREN)) $(GLINK2 statement, MainFunctionBody)
-            $(GLINK MainReturnDecl) $(D main$(LPAREN)string[]) $(GLINK_LEX Identifier)$(D $(RPAREN)) $(GLINK2 statement, MainFunctionBody)
+$(GRAMMAR
+$(GNAME MainFunction):
+    $(GLINK MainReturnDecl) $(D main$(LPAREN)$(RPAREN)) $(GLINK FunctionBody)
+    $(GLINK MainReturnDecl) $(D main$(LPAREN)string[]) $(GLINK_LEX Identifier)$(D $(RPAREN)) $(GLINK FunctionBody)
 
-        $(GNAME MainReturnDecl):
-            $(D void)
-            $(D int)
-            $(GLINK2 type, noreturn)
-            $(RELATIVE_LINK2 auto-functions, $(D auto))
-
-        $(GNAME MainFunctionBody):
-            $(GLINK ShortenedFunctionBody)
-            $(GLINK SpecifiedFunctionBody)
-        )
+$(GNAME MainReturnDecl):
+    $(D void)
+    $(D int)
+    $(GLINK2 type, noreturn)
+    $(RELATIVE_LINK2 auto-functions, $(D auto))
+)
 
         $(UL
         $(LI If `main` returns `void`, the OS will receive a zero value on success.)
@@ -3493,14 +3489,14 @@ $(H2 $(LNAME2 main, $(D main()) Function))
 
         $(P A C $(D main) function must be declared as follows:)
 
-        $(GRAMMAR
-        $(GNAME CMainFunction):
-            $(D extern (C)) $(GLINK MainReturnDecl) $(D main$(LPAREN)$(GLINK CmainParameters)$(OPT)$(RPAREN)) $(GLINK2 statement, BlockStatement)
+$(GRAMMAR
+$(GNAME CMainFunction):
+    $(D extern (C)) $(GLINK MainReturnDecl) $(D main$(LPAREN)$(GLINK CmainParameters)$(OPT)$(RPAREN)) $(GLINK2 statement, BlockStatement)
 
-        $(GNAME CmainParameters):
-            $(D int) $(GLINK_LEX Identifier), $(D char**) $(GLINK_LEX Identifier)
-            $(D int) $(GLINK_LEX Identifier), $(D char**) $(GLINK_LEX Identifier), $(D char**) $(GLINK_LEX Identifier)
-        )
+$(GNAME CmainParameters):
+    $(D int) $(GLINK_LEX Identifier), $(D char**) $(GLINK_LEX Identifier)
+    $(D int) $(GLINK_LEX Identifier), $(D char**) $(GLINK_LEX Identifier), $(D char**) $(GLINK_LEX Identifier)
+)
 
         $(P When defined, the first two parameters denote a C-style array (length + pointer)
         that holds the arguments passed to the program by the OS. The third parameter is a POSIX

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -1379,6 +1379,7 @@ $(H2 $(LEGACY_LNAME2 StructPostblit, struct-postblit, Struct Postblits))
 $(GRAMMAR
 $(GNAME Postblit):
     $(D this $(LPAREN) this $(RPAREN)) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, FunctionBody)
+    $(D this $(LPAREN) this $(RPAREN)) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK2 function, MissingFunctionBody)
 )
 
     $(P $(RED Warning): The postblit is considered legacy and is not recommended for new code.

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -1528,6 +1528,7 @@ $(H2 $(LNAME2 template_ctors, Template Constructors))
 $(GRAMMAR
 $(GNAME ConstructorTemplate):
     $(D this) $(GLINK TemplateParameters) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(GLINK2 function, FunctionBody)
+    $(D this) $(GLINK TemplateParameters) $(GLINK2 function, Parameters) $(GLINK2 function, MemberFunctionAttributes)$(OPT) $(GLINK Constraint)$(OPT) $(GLINK2 function, MissingFunctionBody)
 )
 
     $(P Templates can be used to form constructors for classes and structs.


### PR DESCRIPTION
Fixes #4101.
I think this is more natural - as a prototype does not have a body, so why would it be grouped under something called _FunctionBody_.

Changing the definition resolves an inaccuracy in the spec here:

> A disabled default constructor may not have a FunctionBody.

https://dlang.org/spec/struct.html#disable_default_construction

Which becomes valid with this pull.

I also noticed that [AutoFuncDeclaration](https://dlang.org/spec/function.html#AutoFuncDeclaration) seems to be the only kind of function declaration that gives a parse error on a _MissingFunctionBody_ - `static this()` doesn't (I suppose the body definition could be added at link time).