### PR TITLE
Ban undefined behavior at CTFE

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -3595,6 +3595,8 @@ void main()
         Casts between signed and unsigned types are permitted.)
 
     $(LI Reinterpretation of overlapped fields in a union is not permitted.)
+
+    $(LI Undefined behavior must not occur.)
     )
 
     $(P Pointers are permitted in CTFE, provided they are used safely:)
@@ -3681,7 +3683,7 @@ static assert(countTen(12) == 12);  // invalid, modifies y.
 
     $(IMPLEMENTATION_DEFINED
     Functions executed via CTFE can give different results
-    from run time when implementation-defined or undefined-behavior occurs.
+    from run time when implementation-defined occurs.
     )
 
 


### PR DESCRIPTION
D should ban undefined behavior (UB) during compile-time function execution (CTFE) to ensure that the results are consistent and predictable. This restriction helps maintain the integrity of CTFE and guarantees that any constant expressions will yield the same result every time they are evaluated, give or take implementation-defined features. By avoiding undefined behavior, the language lives up the goal of being safe and reliable. If UB were allowed at CTFE, deterministic builds become impossible as a feature.

Considering what’s already banned during CTFE, it makes no sense whatsoever that UB is not generally ruled out.

This is not a breaking change because UB being what it is, allows the compiler to issue a diagnostic in the meaning of the old spec. The new spec would require a diagnostic and any remaining UB at CTFE that’s not caught constitutes a compiler bug.

C++ bans UB during CTFE (“constant evaluation” in C++ terminology) for the reasons mentioned in the first paragraph (possibly among others).