### PR TITLE
Update function.dd (Lazy Variadic Functions)

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2509,9 +2509,9 @@ $(H4 $(LNAME2 lazy_variadic_functions, Lazy Variadic Functions))
         ---
 
         $(P The variadic delegate array differs from using a lazy
-        variadic array. With the former each array element access
+        variadic array. With the latter each array element access
         would evaluate every array element.
-        With the latter, only the element being accessed would be evaluated.)
+        With the former, only the element being accessed would be evaluated.)
 
         $(SPEC_RUNNABLE_EXAMPLE_RUN
         ---


### PR DESCRIPTION
Switch the terms "former" and "latter" around. Currently the spec sets "former" to variadic delegate array element access causing evaluation of the other array elements, and "latter" to the lazy variadic array element access only evaluating that element. This is contrary to the example code so we just need to switch the positions of "former" and "latter" in the sentence.