### PR TITLE
Updated bugstats.dd to reference GitHub Issues

### DIFF
--- a/bugstats.dd
+++ b/bugstats.dd
@@ -1,49 +1,35 @@
 Ddoc
 
-$(D_S Bug tracker,
+$(D_S Issue tracker,
 
 $(P
-    We use $(B Bugzilla) to track the issues for the D programming language.
+    We use $(B Github) to track the issues for the D programming language.
     $(BR)
-    The home of the D issue tracker is: $(B $(LINK https://issues.dlang.org))
+    The home of the D issue tracker is: $(B $(LINK https://github.com/dlang/dmd/issues))
 )
 
 $(P
-    You can browse through the existing bugs by project $(LINK2 https://issues.dlang.org/describecomponents.cgi?product=D, $(B here)).
+    You can browse through the existing projects $(LINK2 https://github.com/dlang, $(B here)).
 )
 
 $(P
-    If you want to search for a specific bug, you can use the $(LINK2 https://issues.dlang.org/query.cgi?format=specific, $(B search page)).
-)
-
-$(P
-    And if you want to file a new bug, you can use $(LINK2 https://issues.dlang.org/enter_bug.cgi?product=D, $(B this page)),
+    And if you want to file a new issue, you can use $(LINK2 https://github.com/dlang/dmd/issues/new, $(B this page)),
     but please $(HTTPS github.com/dlang/dmd/blob/master/CONTRIBUTING.md#reporting-bugs, check the guidelines) first.
 )
 
-$(H3 Bug Tracker Statistics)
-
-$(BOOKTABLE $(SECTION3 Current bugs <font size="-1">$(LINK2 https://issues.dlang.org/enter_bug.cgi?product=D,[report new bug])$(LINK2 https://issues.dlang.org/query.cgi,[search])</font>),
-$(DISPLAY Regression, y_axis_field=bug_severity&amp;query_format=report-table&amp;product=D&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;bug_severity=regression)
-$(DISPLAY Blocker, y_axis_field=bug_severity&amp;query_format=report-table&amp;product=D&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;bug_severity=blocker)
-$(DISPLAY Critical, y_axis_field=bug_severity&amp;query_format=report-table&amp;product=D&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;bug_severity=critical)
-$(DISPLAY Major, y_axis_field=bug_severity&amp;query_format=report-table&amp;product=D&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;bug_severity=major)
-$(DISPLAY Normal$(COMMA) minor$(COMMA) or trivial, y_axis_field=bug_severity&amp;query_format=report-table&amp;product=D&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;bug_severity=normal&amp;bug_severity=minor&amp;bug_severity=trivial)
-$(DISPLAY Enhancement, y_axis_field=bug_severity&amp;query_format=report-table&amp;product=D&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;bug_severity=enhancement)
-$(DISPLAY All open, y_axis_field=bug_severity&amp;query_format=report-table&amp;product=D&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED&amp;bug_severity=normal&amp;bug_severity=minor&amp;bug_severity=trivial&amp;bug_severity=regression&amp;bug_severity=blocker&amp;bug_severity=critical&amp;bug_severity=major&amp;bug_severity=enhancement)
-$(DISPLAY All closed, y_axis_field=bug_severity&amp;query_format=report-table&amp;product=D&amp;bug_severity=normal&amp;bug_severity=minor&amp;bug_severity=trivial&amp;bug_severity=regression&amp;bug_severity=blocker&amp;bug_severity=critical&amp;bug_severity=major&amp;bug_severity=enhancement&amp;bug_status=RESOLVED&amp;bug_status=VERIFIED&amp;bug_status=CLOSED)
+$(H3 GitHub Labels)
+$(P
+    Issues & PRs are categorized using $(LINK2 https://github.com/dlang/dmd/labels, labels). Common labels include:
+    $(UL
+        $(LI $(B $(LINK2 https://github.com/dlang/dmd/labels/Severity%3AICE, Severity:ICE )) - Internal Compilation Error)
+        $(LI $(B $(LINK2 https://github.com/dlang/dmd/labels/Severity%3AEnhancement, Severity:Enhancement)) - Enhancement requests)
+        $(LI $(B $(LINK2 https://github.com/dlang/dmd/labels/Severity%3ABug%20Fix, Severity:Bug Fix)) - Bug related issues)
+        $(LI $(B $(LINK2 https://github.com/dlang/dmd/labels/Druntime, Druntime)) - Specific to Druntime)
+        $(LI $(B $(LINK2 https://github.com/dlang/dmd/labels/P1, P1)) - High Priority)
+        $(LI $(B $(LINK2 https://github.com/dlang/dmd/labels/Review%3AWIP, Review:WIP)) - Work in Progress)
+    )
 )
-
-<!-- hidden iframe to graph HTML URL, to trigger generating the image linked to below -->
-<iframe width="1" height="1" frameBorder="0" src="$(GRAPH_HTML_URL)"></iframe>
-
-$(P <center>$(LINK2 $(GRAPH_HTML_URL), <img border="1" src="$(GRAPH_IMG_URL)">)</center>)
-
 )
 
 Macros:
-  TITLE=The D Bug Tracker
-  BOOKTABLE = <center><table cellspacing="0" cellpadding="5" class="book"><caption>$1</caption>$2</table></center>
-  DISPLAY=$(TR $(TD $(LINK2 https://issues.dlang.org/buglist.cgi?$2, $1)) $(TD <iframe scrolling="no" frameborder="0" width="4.8em" height="1.4em" style="width:4.8em;height:1.4em;" vspace="0" hspace="0" marginwidth="0" marginheight="0" src="fetch-issue-cnt.php?$2&amp;format=table&amp;action=wrap&amp;ctype=csv"></iframe>))
-  GRAPH_HTML_URL=https://issues.dlang.org/reports.cgi?product=D&amp;datasets=NEW&amp;datasets=ASSIGNED&amp;datasets=REOPENED&amp;datasets=RESOLVED
-  GRAPH_IMG_URL=https://issues.dlang.org/graphs/mVH75HpydPklNqy3BSv8EvqlAOaP1WacmgYB1CsRbiM.png
+  TITLE=The D Issue Tracker


### PR DESCRIPTION
Fixes: #4177 

### Summary
- [X] This PR migrates the bugstats page from Bugzilla to GitHub Issues.
- [X] Tested & verified locally, all links work properly in generated HTML
