### PR TITLE
Update gpg_keys.dd with my public key

### DIFF
--- a/gpg_keys.dd
+++ b/gpg_keys.dd
@@ -22,6 +22,11 @@ pub   rsa4096 2015-11-24 [SC] [expires: 2026-03-23]
 uid                      Sebastian Wilzbach $(LT)seb@wilzba.ch$(GT)
 uid                      Sebastian Wilzbach $(LT)sebi@wilzbach.me$(GT)
 
+pub   rsa4096 2025-01-09 [SC]
+      F3F896F3274BBD9BBBA59058710592E7FB7AF6CA
+uid                      Dennis Korpel <dkorpel@gmail.com>
+sub   rsa4096 2025-01-09 [E]
+
 pub   rsa4096 2018-03-26 [SC] [expired: 2020-03-25]
       F771 5881 4C19 E5E0 7BA1  079A 6539 4AFE F4A6 8565
 uid                      DLang Nightly (bot) $(LT)builder@nightlies.dlang.org$(GT)


### PR DESCRIPTION
So that I can sign release binaries, while there still is no shared account for git/ssh/gpg keys.