### PR TITLE
[trivial] [spec/function] Variadic class parameters are deprecated

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -2422,7 +2422,7 @@ $(H4 $(LNAME2 typesafe_variadic_functions, Typesafe Variadic Functions))
         }
         ---
 
-        $(P For class objects:)
+        $(DDOC_DEPRECATED For class objects:)
 
         ---
         int tesla(int x, C c ...)


### PR DESCRIPTION
Or [will be](https://dlang.org/changelog/2.111.0.html#dmd.deprecation-typesafe-variadic-class) anyway.