### PR TITLE
Fix pre-release download link

### DIFF
--- a/changelog/prerelease.ddoc
+++ b/changelog/prerelease.ddoc
@@ -1,7 +1,7 @@
 VERSION=
 $(DIVC version,
 $(P
-$(B $(LARGE $(LINK2 https://downloads.dlang.org/pre-releases/2.x/$(VER), Download D $(VER) Beta)))$(BR)
+$(B $(LARGE $(LINK2 http://dlang.org/download.html#dmd_beta, Download D $(VER) Beta)))$(BR)
 $(SMALL to be released $1, $2)
 )
 $4


### PR DESCRIPTION
I have trouble uploading the new index of downloads.dlang.org to backblaze, so the link to that doesn't work. In the mean time, point to the website's download page instead, which does work.