### PR TITLE
Remove outdated info from dmd manual

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -28,12 +28,6 @@ $(H2 $(LNAME2 requirements, Requirements and Downloads))
     $(WINDOWS
     $(LI Windows operating system, Windows 7 or later, 32 or 64 bit)
 
-    $(LI Download
-     <a href="http://ftp.digitalmars.com/dmc.zip" title="download dmc.zip">
-     dmc.zip (C and C++ compiler)</a> for Win32
-     (not required, but it complements dmd for Windows)
-    )
-    )
     $(LINUX
     $(LI 32 bit x86 and 64 bit x86-64 Linux operating system
     ($(LINK2 https://github.com/ldc-developers/ldc, LDC)
@@ -69,16 +63,12 @@ performs these steps automatically.
     Unzip the files in the root directory.
     $(D dmd.zip) will create
     a $(D $(DMDDIR)) directory with all the files in it.
-    $(D dmc.zip) will create
-    a $(D \dm) directory with all the files in it.
-    )
 
     $(P A typical session might look like:)
 
 $(CONSOLE
 C:\Documents and Settings\Your Name&gt;cd \
 C:\\&gt;unzip dmd.zip
-C:\\&gt;unzip dmc.zip
 )
     )
     $(LINUX
@@ -251,19 +241,6 @@ sudo cp $(DMDDIR)/{phobos/std,phobos/etc,druntime/import} /usr/include/d/dmd
     ))
     )
 
-$(WINDOWS
-$(H2 $(H2 $(LNAME2 example, Example)))
-
-    $(P Run:)
-
-$(CONSOLE
-$(DMDDIR)$(SEP)$(OS)$(SEP)bin$(SEP)$(SHELL) all.sh
-)
-
-    $(P in the $(D $(DMDDIR)$(SEP)samples$(SEP)d) directory for several small examples.)
-)
-
-
 $(H2 $(LNAME2 switches, Compiler Arguments and Switches))
 
     $(DL
@@ -277,10 +254,6 @@ $(H2 $(LNAME2 switches, Compiler Arguments and Switches))
         $(TR
         $(TH Extension)
         $(TH File Type)
-        )
-        $(TR
-        $(TD $(I none))
-        $(TD D source files)
         )
         $(TR
         $(TD $(B .c))
@@ -312,10 +285,6 @@ $(H2 $(LNAME2 switches, Compiler Arguments and Switches))
         )
 $(WINDOWS
         $(TR
-        $(TD $(B .exe))
-        $(TD Output executable file)
-        )
-        $(TR
         $(TD $(B .def))
         $(TD $(LINK2 http://www.digitalmars.com/ctg/ctgDefFiles.html, module definition file))
         )
@@ -342,7 +311,7 @@ $(WINDOWS
     )
 
     $(WINDOWS
-    $(P Empty switches, i.e. "", are ignored.)
+    $(P Empty command line arguments, i.e. "", are ignored.)
     )
 
 $(H2 $(LNAME2 files, Files))
@@ -361,53 +330,30 @@ $(H2 $(LNAME2 files, Files))
     $(DD Documentation)
     )
 
-    $(DT $(D $(DMDDIR)$(SEP)samples$(SEP)d$(SEP))
-    $(DD Sample D programs)
-    )
     $(WINDOWS
 
     $(DT $(D $(DMDDIR)\windows\bin\ddemangle.exe)
     $(DD D symbol demangler)
     )
 
-    $(DT $(D $(DMDDIR)\windows\bin\dman.exe)
-    $(DD D manual lookup tool)
-    )
-
     $(DT $(D $(DMDDIR)\windows\bin\dmd.exe)
     $(DD D compiler executable)
     )
 
-    $(DT $(D $(DMDDIR)\windows\bin\$(DUB))
+    $(DT $(D $(DMDDIR)\windows\bin\dub.exe)
     $(DD D's package manager)
     )
 
-    $(DT $(D $(DMDDIR)\windows\bin\$(DUSTMITE))
+    $(DT $(D $(DMDDIR)\windows\bin\dustmite.exe)
     $(DD D source code minimizer)
     )
 
-    $(DT $(D $(DMDDIR)\windows\bin\$(OPTLINK))
-    $(DD OPTLINK)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\$(LINK2 http://www.digitalmars.com/ctg/make.html, make.exe))
-    $(DD Digitalmars Make)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\replace.exe)
-    $(DD Find/replace text in files)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\$(RDMD))
+    $(DT $(D $(DMDDIR)\windows\bin\rdmd.exe)
     $(DD D build tool for script-like D code execution)
     )
 
     $(DT $(D $(SC_INI))
     $(DD Global compiler settings)
-    )
-
-    $(DT $(D $(DMDDIR)\windows\bin\$(LINK2 http://www.digitalmars.com/ctg/shell.html, shell.exe))
-    $(DD Simple command line shell)
     )
 
     $(DT $(D $(DMDDIR)\windows\lib\$(LIB))
@@ -417,10 +363,6 @@ $(H2 $(LNAME2 files, Files))
     $(LINUX
     $(DT $(D $(DMDDIR)/linux/bin/ddemangle)
     $(DD D symbol demangler)
-    )
-
-    $(DT $(D $(DMDDIR)/linux/bin/dman)
-    $(DD D manual lookup tool)
     )
 
     $(DT $(D $(DMDDIR)/linux/bin/dmd)
@@ -435,16 +377,8 @@ $(H2 $(LNAME2 files, Files))
     $(DD D's package manager)
     )
 
-    $(DT $(D $(DMDDIR)/linux/bin/$(DUMPOBJ))
-    $(DD ELF file dumper)
-    )
-
     $(DT $(D $(DMDDIR)/linux/bin/$(DUSTMITE))
     $(DD D source code minimizer)
-    )
-
-    $(DT $(D $(DMDDIR)/linux/bin/$(OBJ2ASM))
-    $(DD ELF file disassembler)
     )
 
     $(DT $(D $(DMDDIR)/linux/bin/$(RDMD))
@@ -458,10 +392,6 @@ $(H2 $(LNAME2 files, Files))
     $(FREEBSD
     $(DT $(D $(DMDDIR)/freesd/bin/ddemangle)
     $(DD D symbol demangler)
-    )
-
-    $(DT $(D $(DMDDIR)/freebsd/bin/dman)
-    $(DD D manual lookup tool)
     )
 
     $(DT $(D $(DMDDIR)/freebsd/bin/dmd)
@@ -903,47 +833,6 @@ dmd -lib foo.d bar.d abc.$(OBJEXT) def.$(LIBEXT)
     up the modules.
     )
     )
-
-$(H2 $(LEGACY_LNAME2 compiling_dmd, compiling-dmd, Compiling dmd))
-
-    $(P Complete source code is provided to build the compiler.
-    Follow these steps:)
-
-$(WINDOWS
-$(CONSOLE
-cd $(DMDDIR)\src\dmd
-make -f win32.mak
-)
-)
-$(UNIX
-$(CONSOLE
-cd ~/$(DMDDIR)/src/dmd
-make -f posix.mak
-)
-)
-
-$(H2 $(LEGACY_LNAME2 compiling_phobos, compiling-phobos, Compiling Phobos))
-
-    $(P Complete source code is provided to build Phobos, the D runtime library.
-    Follow these steps:)
-
-
-$(WINDOWS
-$(CONSOLE
-cd $(DMDDIR)\src\druntime
-make -f win32.mak
-cd ..\phobos
-make -f win32.mak
-)
-)
-$(UNIX
-$(CONSOLE
-cd ../phobos
-make -f posix.mak
-)
-)
-
-
 )
 
 Macros:


### PR DESCRIPTION
A Google Summer of Code contributor came across build instructions here, which are outdated. Upon closer inspection, lots of other info on this page is out of date as well.

- omf support is removed, so the Digital Mars C compiler (dmc) is useless for D now
- dman, obj2asm, dumpobj, optlink, shell, make are not part of a dmd release anymore
- the samples folder is removed
