### PR TITLE
[spec] Tweak docs for field offsets

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -129,6 +129,7 @@ $(H2 $(LNAME2 fields, Fields))
         $(P Members of a base class can be accessed by prepending the name of
         the base class followed by a dot:)
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 class A { int a; int a2;}
 class B : A { int a; }
@@ -140,9 +141,11 @@ void foo(B b)
     b.A.a = 5; // accesses field A.a
 }
 ---
+)
 
-        $(P The D compiler is free to rearrange the order of fields in a class to
-        optimally pack them in an implementation-defined manner.
+        $(IMPLEMENTATION_DEFINED
+        The D compiler is free to rearrange the order of fields in a class to
+        optimally pack them.
         Consider the fields much like the local
         variables in a function -
         the compiler assigns some to registers and shuffles others around all to
@@ -232,6 +235,9 @@ $(H3 $(LNAME2 field_properties, Field Properties))
 
         $(P The $(D .offsetof) property gives the offset in bytes of the field
         from the beginning of the class instantiation.
+        Note that the compiler can $(RELATIVE_LINK2 fields, rearrange class field offsets).
+        See $(DDSUBLINK spec/attribute, align, the `align` attribute) for a struct-based
+        example.
         )
         $(NOTE `.offsetof` is not available for fields of `extern(Objective-C)` classes
         due to their fields having a dynamic offset.

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -631,7 +631,9 @@ $(H3 $(LNAME2 struct_field_properties, Struct Field Properties))
 
 $(TABLE2 Struct Field Properties,
 $(THEAD Name, Description)
-$(TROW $(D .offsetof), Offset in bytes of field from beginning of struct)
+$(TROW $(D .offsetof), Offset in bytes of field from beginning of struct.
+    See $(DDSUBLINK spec/attribute, align, the `align` attribute) for an example.
+)
 )
 
 $(H2 $(LEGACY_LNAME2 ConstStruct, const-struct, Const, Immutable and Shared Structs))


### PR DESCRIPTION
Make example runnable.
Use IMPLEMENTATION_DEFINED macro for class field offsets and link to this from `.offsetof` section.
Add links to `.offsetof` example.