### PR TITLE
Add example of associative array

### DIFF
--- a/articles/ctod.dd
+++ b/articles/ctod.dd
@@ -637,6 +637,21 @@ void dostring(string s)
        to generate a fast lookup scheme for it, eliminating the bugs
        and time required in hand-coding one.
 
+       Another possibility of associating a string to a number is to
+       use an associative array.
+
+----------------------------
+ulong[string] map = ["hello"    : 1616515,
+                     "goodbye"  : 42,
+                     "maybe"    : ulong.max
+                    ];     
+string s = "goodbye";
+
+writeln("number is ", map[s]);
+----------------------------
+
+       Any type can be used as key or as value. 
+
 <hr>$(COMMENT  ============================================ )
 $(H2 $(LNAME2 align, Setting struct member alignment))
 

--- a/articles/ctod.dd
+++ b/articles/ctod.dd
@@ -640,6 +640,7 @@ void dostring(string s)
        Another possibility of associating a string to a number is to
        use an associative array.
 
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ----------------------------
 ulong[string] map = ["hello"    : 1616515,
                      "goodbye"  : 42,
@@ -649,6 +650,7 @@ string s = "goodbye";
 
 writeln("number is ", map[s]);
 ----------------------------
+)
 
        Any type can be used as key or as value. 
 

--- a/articles/ctod.dd
+++ b/articles/ctod.dd
@@ -645,14 +645,14 @@ $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ulong[string] map = ["hello"    : 1616515,
                      "goodbye"  : 42,
                      "maybe"    : ulong.max
-                    ];     
+                    ];
 string s = "goodbye";
 
 writeln("number is ", map[s]);
 ----------------------------
 )
 
-       Any type can be used as key or as value. 
+       Any type can be used as key or as value.
 
 <hr>$(COMMENT  ============================================ )
 $(H2 $(LNAME2 align, Setting struct member alignment))

--- a/articles/ctod.dd
+++ b/articles/ctod.dd
@@ -640,7 +640,7 @@ void dostring(string s)
        Another possibility of associating a string to a number is to
        use an associative array.
 
-$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+$(RUNNABLE_EXAMPLE_COMPILE
 ----------------------------
 ulong[string] map = ["hello"    : 1616515,
                      "goodbye"  : 42,


### PR DESCRIPTION
Add another example of string lookup using associative array. It allows to introduce AA type that a pure C developer would not expect as a builtin in language.