### PR TITLE
[tools/dspec_tester.d] Test `articles` directory

### DIFF
--- a/articles/cpptod.dd
+++ b/articles/cpptod.dd
@@ -928,7 +928,7 @@ void main()
 
     auto d2 = gallery[0];
     d2.id = 1;
-    assert(d2.id == gallery[0].id, "neither ref nor pointer");
+    assert(d2.id != gallery[0].id); // d2 is neither ref nor pointer
 }
 ------
 )

--- a/articles/ctod.dd
+++ b/articles/ctod.dd
@@ -650,7 +650,7 @@ unittest
 {
     import std.stdio;
     writeln("number is ", map["goodbye"]);
-    writeln(i"map contains $(str.length) elements");
+    writeln(i"map contains $(map.length) elements");
     writeln("map is ", map);
 }
 ----------------------------

--- a/tools/dspec_tester.d
+++ b/tools/dspec_tester.d
@@ -72,7 +72,10 @@ unittest
 
 auto findDdocMacro(R)(R text, string ddocKey)
 {
-    return text.splitter(ddocKey).map!untilClosingParentheses.dropOne;
+    auto sr = text.splitter(ddocKey);
+    // don't let RUNNABLE_EXAMPLE match RUNNABLE_EXAMPLE_FOO
+    auto fr = sr.filter!(s => s.length ? s[0] != '_' : true);
+    return fr.map!untilClosingParentheses.dropOne;
 }
 
 auto ddocMacroToCode(R)(R text)
@@ -95,6 +98,7 @@ int main(string[] args)
 
     const rootDir = __FILE_FULL_PATH__.dirName.dirName;
     const specDir = rootDir.buildPath("spec");
+    const articlesDir = rootDir.buildPath("articles");
     const stdDir = rootDir.buildPath("..", "phobos", "std");
 
     config.dmdBinPath = environment.get("DMD", "dmd");
@@ -117,9 +121,12 @@ int main(string[] args)
         SpecType("$(SPEC_RUNNABLE_EXAMPLE_COMPILE", CompileConfig.TestMode.compile),
         SpecType("$(SPEC_RUNNABLE_EXAMPLE_RUN", CompileConfig.TestMode.run),
         SpecType("$(SPEC_RUNNABLE_EXAMPLE_FAIL", CompileConfig.TestMode.fail),
+        SpecType("$(RUNNABLE_EXAMPLE_COMPILE", CompileConfig.TestMode.compile),
         SpecType("$(RUNNABLE_EXAMPLE", CompileConfig.TestMode.run),
+        SpecType("$(RUNNABLE_EXAMPLE_FAIL", CompileConfig.TestMode.fail),
     ];
     auto files = chain(specDir.dirEntries("*.dd", SpanMode.depth),
+        articlesDir.dirEntries("*.dd", SpanMode.depth),
         stdDir.dirEntries("*.d", SpanMode.depth));
     shared bool hasFailed;
     foreach (file; files.parallel(1))


### PR DESCRIPTION
Also find RUNNABLE_EXAMPLE_COMPILE and RUNNABLE_EXAMPLE_FAIL tests in `std`.

Also fix the D for C and C++ programmers article examples.