### PR TITLE
Fix typo in ctod.dd

### DIFF
--- a/articles/ctod.dd
+++ b/articles/ctod.dd
@@ -650,7 +650,7 @@ unittest
 {
     import std.stdio;
     writeln("number is ", map["goodbye"]);
-    writeln(i"map contains $(str.length) elements");
+    writeln(i"map contains $(map.length) elements");
     writeln("map is ", map);
 }
 ----------------------------


### PR DESCRIPTION
In the example the element was wrong.