### PR TITLE
Fix for Issue #4149, Added undocumented HexFloat syntax to the specification

### DIFF
--- a/spec/lex.dd
+++ b/spec/lex.dd
@@ -905,6 +905,7 @@ $(GNAME HexFloat):
     $(GLINK HexPrefix) $(GLINK HexDigitsNoSingleUS) $(B .) $(GLINK HexDigitsNoStartingUS) $(GLINK HexExponent)
     $(GLINK HexPrefix) $(B .) $(GLINK HexDigitsNoStartingUS) $(GLINK HexExponent)
     $(GLINK HexPrefix) $(GLINK HexDigitsNoSingleUS) $(GLINK HexExponent)
+    $(GLINK HexPrefix) $(GLINK HexExponent)
 
 $(GNAME HexPrefix):
     $(B 0x)


### PR DESCRIPTION
Fixes #4149

I've added the missing fourth form to the HexFloat grammar definition,
`
HexFloat:
    HexPrefix HexDigitsNoSingleUS . HexDigitsNoStartingUS HexExponent
    HexPrefix . HexDigitsNoStartingUS HexExponent
    HexPrefix HexDigitsNoSingleUS HexExponent
    HexPrefix HexExponent
`
This change documents the existing behavior of the D compiler, which already accepts the 0xp1 syntax. The value of a hex float literal in this form is interpreted as zero (0) shifted left by the exponent value. Also, rather than deprecating the syntax, I've updated the specification.