### PR TITLE
Fix examples in DDOX documentation for std.algorithm.mutation.remove

### DIFF
--- a/DDOX_FIXES.md
+++ b/DDOX_FIXES.md
@@ -1,0 +1,33 @@
+# DDOX Documentation Fixes
+
+This branch adds fixes for various documentation issues in the DDOX-generated documentation.
+
+## Fix for `std.algorithm.mutation.remove` examples
+
+GitHub Issue: [#4007](https://github.com/dlang/dlang.org/issues/4007)
+
+### Problem
+
+The examples in the DDOX-generated documentation for `std.algorithm.mutation.remove` had several issues:
+
+1. Missing `std.stdio` import for the examples that use `writeln`
+2. Not showing that assignment of results back to a variable is necessary if you want to modify the original array
+3. Some examples might show incorrect behavior due to improper formatting or explanation
+
+### Solution
+
+We've added a JavaScript fix that:
+
+1. Adds a warning notice to the problematic examples explaining the need for imports
+2. Clarifies that `remove` returns a new array but doesn't change the length of the original array
+3. Shows proper usage with variable reassignment
+
+This solution ensures that users understand how to correctly use the `remove` function while keeping the actual generated DDOX documentation intact.
+
+### Future improvements
+
+For a more permanent solution, consider:
+
+1. Fixing the examples in the source code documentation in Phobos
+2. Enhancing DDOX to validate examples and add necessary imports
+3. Adding a preprocessing step that checks and fixes DDOX examples before generating the documentation 

--- a/css/ddox.css
+++ b/css/ddox.css
@@ -102,3 +102,24 @@ a.inherited:after { content: url(../images/ddox/inherited.png); padding-left: 3p
 /* Don't show simple handcrafted cheat sheets. DDOX does a good job generating
  * them. */
 table.simple-cheatsheet { display: none; }
+
+/* Warning notice for examples that might need additional imports or clarification */
+.example-warning {
+    border-left: 5px solid #f0ad4e;
+    background-color: #fcf8e3;
+    padding: 10px;
+    margin-bottom: 10px;
+    font-size: 0.9em;
+    color: #8a6d3b;
+}
+
+.example-warning code {
+    background-color: #f7f3dd;
+    padding: 2px 4px;
+    border-radius: 3px;
+}
+
+/* Make sure the warning appears before the code */
+section h3 + p + .example-warning + pre.code {
+    margin-top: 5px;
+}

--- a/js/ddox-fix-remove-examples.js
+++ b/js/ddox-fix-remove-examples.js
@@ -1,0 +1,40 @@
+/**
+ * This script fixes the display of problematic examples in the DDOX-generated 
+ * documentation for std.algorithm.mutation.remove
+ */
+$(document).ready(function() {
+    // Only run on the remove page
+    if (window.location.pathname.indexOf('std/algorithm/mutation/remove') === -1) {
+        return;
+    }
+
+    // Find all code examples
+    $('section h3:contains("Example") + p + pre.code').each(function() {
+        const codeBlock = $(this);
+        const codeText = codeBlock.text();
+        
+        // Check if this is one of the problematic examples
+        if (codeText.includes('writeln([') && !codeText.includes('import std.stdio')) {
+            // Create a warning notice
+            const warningMsg = $('<div class="example-warning">')
+                .html('<strong>Note:</strong> The examples below require additional imports to run. ' +
+                      'At minimum, add <code>import std.stdio;</code> for <code>writeln</code>. ' +
+                      'Additionally, remember that <code>remove</code> returns a new array but does not ' +
+                      'change the length of the original array unless you reassign the result.');
+            
+            // Insert the warning before the code block
+            codeBlock.before(warningMsg);
+            
+            // Fix the code display in the block for clarity
+            const fixedCode = codeText.replace(/writeln\(\[/g, function(match) {
+                // Explain the need for reassignment
+                return 'int[] a = [4, 5, 6]; // Defined for example purposes\n' +
+                       '// To modify the original array, you need to reassign: a = a.remove(...);\n' +
+                       'writeln([';
+            });
+            
+            // Update the displayed code
+            codeBlock.find('code').html(fixedCode);
+        }
+    });
+}); 

--- a/std-ddox.ddoc
+++ b/std-ddox.ddoc
@@ -13,4 +13,5 @@ MREF=$(D $(MREF_HELPER $1, $+))
 MREF_ALTTEXT=$(DDOX_NAMED_REF $(MREF_HELPER $+), $1)
 MREF1=$(D $1)
 DDOX_UNITTEST_HEADER=<span class="dlang_runnable"></span>
+EXTRA_JS=<script src="$(ROOT_DIR)js/ddox-fix-remove-examples.js"></script>
 _=


### PR DESCRIPTION
In the issue #4007 where examples in the DDOX-generated documentation for `std.algorithm.mutation.remove` were reported as incorrect.

The examples have several issues:
- Missing `std.stdio` import for examples using `writeln` and not showing that reassignment is necessary to modify the original array which lead to potential confusion in examples

**Solution**
I've implemented a client-side fix that:
- Adds warning notices above problematic examples
- Enhances examples to show proper variable declaration and usage
- Clarifies the need for reassignment when using `remove`

Fixes #4007