### PR TITLE
Fix missing favicon.ico in offline documentation

### DIFF
--- a/changelog/fix-offline-favicon.dd
+++ b/changelog/fix-offline-favicon.dd
@@ -1,0 +1,5 @@
+Fix for missing favicon.ico in offline documentation
+
+The favicon.ico file is now properly copied to the offline documentation,
+ensuring the browser tab icon appears correctly when viewing the documentation
+offline. 

--- a/tools/chmgen.d
+++ b/tools/chmgen.d
@@ -162,6 +162,13 @@ void main(string[] args)
         only(docRoot ~ `/favicon.ico`)
     ).array();
 
+    // Ensure favicon.ico is explicitly copied to root of offline documentation
+    if (chm && exists(docRoot ~ `/favicon.ico`))
+    {
+        stderr.writeln("Ensuring favicon.ico is properly copied");
+        copy(docRoot ~ `/favicon.ico`, chmDir ~ `/files/favicon.ico`);
+    }
+
     foreach (filePath; files)
     {
         scope(failure) stderr.writeln("Error while processing file: ", filePath);


### PR DESCRIPTION
Fixes #4003

This PR addresses the issue #4003 by explicitly ensuring that the favicon.ico file is properly copied to the root of the offline documentation directory. The fix adds code to the `tools/chmgen.d` file to specifically handle the favicon.ico file. Basically the changes are: 
1. Modified `tools/chmgen.d` to add explicit code that copies the favicon.ico file to the offline documentation root directory.
2. Added a changelog entry to document this fix.