### PR TITLE
Update Gentoo installation instructions.

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -172,7 +172,7 @@ $(BR)$(BR)
 
 $(DOWNLOAD_OTHER $(ARCHLINUX), $(LINK2 https://wiki.archlinux.org/index.php/D_(programming_language), Arch Linux), $(CONSOLE pacman -S dlang))
 
-$(DOWNLOAD_OTHER $(GENTOO), $(LINK2 https://wiki.gentoo.org/wiki/Dlang, Gentoo), $(CONSOLE layman -f -a dlang))
+$(DOWNLOAD_OTHER $(GENTOO), $(LINK2 https://wiki.gentoo.org/wiki/Dlang, Gentoo), $(CONSOLE eselect repository enable dlang))
 
 $(DOWNLOAD_OTHER $(HOMEBREW), $(LINK2 https://formulae.brew.sh/formula/dmd, Homebrew), $(CONSOLE brew install dmd))
 


### PR DESCRIPTION
Currently, in the Dlang download webpage (here: https://dlang.org/download.html#third-party-downloads) in the Gentoo entry under the "Third-Party downloads" section, the installation instruction states the following: 

```
layman -f -a dlang
```

However, `layman` is no longer used to manage Portage overlays (this can be seen in the layman Gentoo wiki article: https://wiki.gentoo.org/wiki/Layman). It was replaced with `eselect repository` (great tool btw! Big fan).

This new usage can even be seen in the documentation that's linked above, see here: https://wiki.gentoo.org/wiki/Dlang#Dlang_overlay.

This PR simply updates the documentation with the usage of `eselect repository`.

Cheers!