### PR TITLE
[spec] Add notes for `scope` attribute/parameter about `-preview=dip1000`

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -856,6 +856,9 @@ $(P
             $(LI Assigning a `scope` variable to a non-scope parameter by calling a function)
             $(LI Putting a `scope` variable in an array literal)
         )
+
+        $(NOTE escape analysis is only done in `@safe` code. The $(D -preview=dip1000) switch
+        must also be enabled.)
 $(P
         The `scope` attribute is part of the variable declaration, not the type, and it only applies to the first level of indirection.
         For example, it is impossible to declare a variable as a dynamic array of scope pointers, because `scope` only applies to the `.ptr`
@@ -953,7 +956,7 @@ struct S
     int x;
 
     // this method may be called on a stack-allocated instance of S
-    void f()
+    void f() @safe
     {
         int* p = &x; // inferred `scope int* p`
         int* q = &this.x; // equivalent

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1927,6 +1927,8 @@ $(H3 $(LNAME2 scope-parameters, Scope Parameters))
     `scope` escape analysis is only done for `@safe` functions. For other functions `scope`
     semantics must be manually enforced.)
 
+    $(NOTE `@safe` escape analysis is only done with the $(D -preview=dip1000) switch.)
+
 ---
 @safe:
 


### PR DESCRIPTION
Also make an example's method `@safe` that mentions inferred scope.