### PR TITLE
Add macros for keywords.

### DIFF
--- a/keywords.ddoc
+++ b/keywords.ddoc
@@ -1,0 +1,163 @@
+_= These are to make it easier to have keywords highlighted as keywords inside
+a ddoc comment, whereas by default, they only get highlighted in code examples.
+
+K_ABSTRACT=$(D_KEYWORD abstract)
+K_ALIAS=$(D_KEYWORD alias)
+K_ALIGN=$(D_KEYWORD align)
+K_ASM=$(D_KEYWORD asm)
+K_ASSERT=$(D_KEYWORD assert)
+K_AUTO=$(D_KEYWORD auto)
+_=
+
+K_BOOL=$(D_KEYWORD bool)
+K_BREAK=$(D_KEYWORD break)
+K_BYTE=$(D_KEYWORD byte)
+_=
+
+K_CASE=$(D_KEYWORD case)
+K_CAST=$(D_KEYWORD cast)
+K_CATCH=$(D_KEYWORD catch)
+K_CHAR=$(D_KEYWORD char)
+K_CLASS=$(D_KEYWORD class)
+K_CONST=$(D_KEYWORD const)
+K_CONTINUE=$(D_KEYWORD continue)
+_=
+
+K_DCHAR=$(D_KEYWORD dchar)
+K_DEBUG=$(D_KEYWORD debug)
+K_DEFAULT=$(D_KEYWORD default)
+K_DELEGATE=$(D_KEYWORD delegate)
+K_DEPRECATED=$(D_KEYWORD deprecated)
+K_DO=$(D_KEYWORD do)
+K_DOUBLE=$(D_KEYWORD double)
+_=
+
+K_ELSE=$(D_KEYWORD else)
+K_ENUM=$(D_KEYWORD enum)
+K_EXPORT=$(D_KEYWORD export)
+K_EXTERN=$(D_KEYWORD extern)
+_=
+
+K_FALSE=$(D_KEYWORD false)
+K_FINAL=$(D_KEYWORD final)
+K_FINALLY=$(D_KEYWORD finally)
+K_FLOAT=$(D_KEYWORD float)
+K_FOR=$(D_KEYWORD for)
+K_FOREACH=$(D_KEYWORD foreach)
+K_FOREACH_REVERSE=$(D_KEYWORD foreach_reverse)
+K_FUNCTION=$(D_KEYWORD function)
+_=
+
+K_GOTO=$(D_KEYWORD goto)
+_=
+
+K_IF=$(D_KEYWORD if)
+K_IMMUTABLE=$(D_KEYWORD immutable)
+K_IMPORT=$(D_KEYWORD import)
+K_IN=$(D_KEYWORD in)
+K_INOUT=$(D_KEYWORD inout)
+K_INT=$(D_KEYWORD int)
+K_INTERFACE=$(D_KEYWORD interface)
+K_INVARIANT=$(D_KEYWORD invariant)
+K_IS=$(D_KEYWORD is)
+_=
+
+K_LAZY=$(D_KEYWORD lazy)
+K_LONG=$(D_KEYWORD long)
+_=
+
+K_MACRO=$(D_KEYWORD macro)
+K_MIXIN=$(D_KEYWORD mixin)
+K_MODULE=$(D_KEYWORD module)
+_=
+
+K_NEW=$(D_KEYWORD new)
+K_NOTHROW=$(D_KEYWORD nothrow)
+K_NULL=$(D_KEYWORD null)
+_=
+
+K_OUT=$(D_KEYWORD out)
+K_OVERRIDE=$(D_KEYWORD override)
+_=
+
+K_PACKAGE=$(D_KEYWORD package)
+K_PRAGMA=$(D_KEYWORD pragma)
+K_PRIVATE=$(D_KEYWORD private)
+K_PROTECTED=$(D_KEYWORD protected)
+K_PUBLIC=$(D_KEYWORD public)
+K_PURE=$(D_KEYWORD pure)
+_=
+
+K_REAL=$(D_KEYWORD real)
+K_REF=$(D_KEYWORD ref)
+K_RETURN=$(D_KEYWORD return)
+_=
+
+K_SCOPE=$(D_KEYWORD scope)
+K_SHARED=$(D_KEYWORD shared)
+K_SHORT=$(D_KEYWORD short)
+K_STATIC=$(D_KEYWORD static)
+K_STRUCT=$(D_KEYWORD struct)
+K_SUPER=$(D_KEYWORD super)
+K_SWITCH=$(D_KEYWORD switch)
+K_SYNCHRONIZED=$(D_KEYWORD synchronized)
+_=
+
+K_TEMPLATE=$(D_KEYWORD template)
+K_THIS=$(D_KEYWORD this)
+K_THROW=$(D_KEYWORD throw)
+K_TRUE=$(D_KEYWORD true)
+K_TRY=$(D_KEYWORD try)
+K_TYPEID=$(D_KEYWORD typeid)
+K_TYPEOF=$(D_KEYWORD typeof)
+_=
+
+K_UBYTE=$(D_KEYWORD ubyte)
+K_UINT=$(D_KEYWORD uint)
+K_ULONG=$(D_KEYWORD ulong)
+K_UNION=$(D_KEYWORD union)
+K_UNITTEST=$(D_KEYWORD unittest)
+K_USHORT=$(D_KEYWORD ushort)
+_=
+
+K_VERSION=$(D_KEYWORD version)
+K_VOID=$(D_KEYWORD void)
+_=
+
+K_WCHAR=$(D_KEYWORD wchar)
+K_WHILE=$(D_KEYWORD while)
+K_WITH=$(D_KEYWORD with)
+_=
+
+K___GSHARED=$(D_KEYWORD __gshared)
+K___PARAMETERS=$(D_KEYWORD __parameters)
+K___RVALUE=$(D_KEYWORD __rvalue)
+K___TRAITS=$(D_KEYWORD __traits)
+K___VECTOR=$(D_KEYWORD __vector)
+_=
+
+_= These aren't technically keywords per the spec, but they're effectively
+keywords, so we're treating them as such. The spec treats the @ attributes
+differently because of the @, but they're arguably just keywords listed in
+another part of the spec, and the types are aliases from object.d.
+
+K_DISABLE=$(D_KEYWORD @disable)
+K_NOGC=$(D_KEYWORD @nogc)
+K_PROPERTY=$(D_KEYWORD @property)
+K_SAFE=$(D_KEYWORD @safe)
+K_SYSTEM=$(D_KEYWORD @system)
+K_TRUSTED=$(D_KEYWORD @trusted)
+_=
+
+K_NORETURN=$(D_KEYWORD noreturn)
+_=
+
+K_STRING=$(D_KEYWORD string)
+K_WSTRING=$(D_KEYWORD wstring)
+K_DSTRING=$(D_KEYWORD dstring)
+_=
+
+K_PTRDIFF_T=$(D_KEYWORD ptrdiff_t)
+K_SIZEDIFF_T=$(D_KEYWORD sizediff_t)
+K_SIZE_T=$(D_KEYWORD size_t)
+_=

--- a/posix.mak
+++ b/posix.mak
@@ -301,10 +301,10 @@ STYLES=$(addsuffix .css, $(addprefix css/, \
 # HTML Files
 ################################################################################
 
-DDOC=$(addsuffix .ddoc, macros html dlang.org doc ${GENERATED}/${LATEST}) $(NODATETIME) $G/dblog_latest.ddoc
-STD_DDOC_LATEST=$(addsuffix .ddoc, macros html dlang.org ${GENERATED}/${LATEST} std std_navbar-release ${GENERATED}/modlist-${LATEST}) $(NODATETIME)
-STD_DDOC_RELEASE=$(addsuffix .ddoc, macros html dlang.org ${GENERATED}/${LATEST} std std_navbar-release ${GENERATED}/modlist-release) $(NODATETIME)
-STD_DDOC_PRERELEASE=$(addsuffix .ddoc, macros html dlang.org ${GENERATED}/${LATEST} std std_navbar-prerelease ${GENERATED}/modlist-prerelease) $(NODATETIME)
+DDOC=$(addsuffix .ddoc, macros html dlang.org keywords doc ${GENERATED}/${LATEST}) $(NODATETIME) $G/dblog_latest.ddoc
+STD_DDOC_LATEST=$(addsuffix .ddoc, macros html keywords dlang.org ${GENERATED}/${LATEST} std std_navbar-release ${GENERATED}/modlist-${LATEST}) $(NODATETIME)
+STD_DDOC_RELEASE=$(addsuffix .ddoc, macros html keywords dlang.org ${GENERATED}/${LATEST} std std_navbar-release ${GENERATED}/modlist-release) $(NODATETIME)
+STD_DDOC_PRERELEASE=$(addsuffix .ddoc, macros html keywords dlang.org ${GENERATED}/${LATEST} std std_navbar-prerelease ${GENERATED}/modlist-prerelease) $(NODATETIME)
 SPEC_DDOC=${DDOC} spec/spec.ddoc
 CHANGELOG_DDOC=${DDOC} changelog/changelog.ddoc $(NODATETIME)
 CHANGELOG_PRE_DDOC=${CHANGELOG_DDOC} changelog/prerelease.ddoc
@@ -694,20 +694,23 @@ $(PHOBOS_LIB): $(DMD)
 apidocs-prerelease : $W/library-prerelease/sitemap.xml $W/library-prerelease/.htaccess
 apidocs-latest : $W/library/sitemap.xml $W/library/.htaccess
 apidocs-serve : $G/docs-prerelease.json
-	${DPL_DOCS} ${DPL_DOCS_FLAGS} serve-html --std-macros=html.ddoc --std-macros=dlang.org.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
+	${DPL_DOCS} ${DPL_DOCS_FLAGS} serve-html --std-macros=html.ddoc --std-macros=dlang.org.ddoc --std-macros=std.ddoc \
+		--std-macros=keywords.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
 		--override-macros=std-ddox-override.ddoc --package-order=std \
 		--git-target=master --web-file-dir=. $<
 
 $W/library-prerelease/sitemap.xml : $G/docs-prerelease.json
 	@mkdir -p $(dir $@)
-	${DPL_DOCS} ${DPL_DOCS_FLAGS} generate-html --file-name-style=lowerUnderscored --std-macros=html.ddoc --std-macros=dlang.org.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
+	${DPL_DOCS} ${DPL_DOCS_FLAGS} generate-html --file-name-style=lowerUnderscored --std-macros=html.ddoc --std-macros=dlang.org.ddoc \
+		--std-macros=std.ddoc --std-macros=keywords.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
 		--override-macros=std-ddox-override.ddoc --package-order=std \
 		--git-target=master $(DPL_DOCS_PATH_RUN_FLAGS) \
 		$< $W/library-prerelease
 
 $W/library/sitemap.xml : $G/docs-latest.json
 	@mkdir -p $(dir $@)
-	${DPL_DOCS} ${DPL_DOCS_FLAGS} generate-html --file-name-style=lowerUnderscored --std-macros=html.ddoc --std-macros=dlang.org.ddoc --std-macros=std.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
+	${DPL_DOCS} ${DPL_DOCS_FLAGS} generate-html --file-name-style=lowerUnderscored --std-macros=html.ddoc --std-macros=dlang.org.ddoc \
+		--std-macros=std.ddoc --std-macros=keywords.ddoc --std-macros=macros.ddoc --std-macros=std-ddox.ddoc \
 		--override-macros=std-ddox-override.ddoc --package-order=std \
 		--git-target=v${LATEST} $(DPL_DOCS_PATH_RUN_FLAGS) \
 		$< $W/library


### PR DESCRIPTION
While ddoc will color keywords as keywords in code examples, it won't do so with `$(D )` or \`\`. To highlight them as keywords, you need to use `$(D_KEYWORD )`, but typing out stuff like `$(D_KEYWORD typeof)` or `$(D_KEYWORD @property)` gets pretty verbose, especially if the keyword is mentioned several times in a paragraph.

So, this adds macros for the keywords so that you don't have to type all of that out to get the same effect. So, instead of `$(D_KEYWORD typeof)`, it would be `$(K_TYPEOF)`. Instead of `$(D_KEYWORD @property)`, it would be `$(K_PROPERTY)`. Etc. Each keyword has a similar macro and is thus similarly shortened.