### PR TITLE
[spec/arrays] Improve Assignment and Copying docs

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -187,8 +187,11 @@ assert(a is b);
     using pointer $(RELATIVE_LINK2 slicing, slicing), so that the number of elements
     to copy is then known.)
 
+
+$(H3 $(LNAME2 static-array-assign, Static Array Assignment))
+
     $(P A static array can be assigned from a dynamic array - the data is copied.
-    The lengths must match:)
+    If the lengths do not match at runtime, a `RangeError` is thrown:)
 
 $(SPEC_RUNNABLE_EXAMPLE_RUN
 ---
@@ -352,12 +355,10 @@ i = bar[$-1]; // retrieves last element of the array
 
 $(H2 $(LNAME2 array-copying, Array Copying))
 
-        $(P When the slice operator appears as the left-hand side of an
-        assignment expression, it means that the contents of the array are the
-        target of the assignment rather than a reference to the array.
-        Array copying happens when the left-hand side is a slice, and the
-        right-hand side is an array of or pointer to the same type.
-        )
+        $(P When a slice expression is the left-hand side of an
+        assignment expression, it means that the contents of the slice are the
+        target of the assignment rather than an array reference.
+        The right-hand side must implicitly convert to an array type.)
 
 $(SPEC_RUNNABLE_EXAMPLE_RUN
 ---------
@@ -381,6 +382,11 @@ a[0..2] = s[1..3];
 assert(a == [2, 0]);
 ---------
 )
+
+        $(P If the number of elements does not match at runtime, a `RangeError` is thrown.)
+
+        $(RATIONALE Indexing past the end of a slice is a programming error.)
+
 
 $(H3 $(LNAME2 overlapping-copying, Overlapping Copying))
 


### PR DESCRIPTION
Add Static Array Assignment subheading.
State when a RangeError is thrown.
Reword Array Copying summary and mention implicit element conversion. 
Add short rationale for throwing RangeError.