### PR TITLE
[spec/class] Inside non-static method, member vars are in scope

### DIFF
--- a/spec/class.dd
+++ b/spec/class.dd
@@ -256,8 +256,27 @@ $(H2 $(LNAME2 member-functions, Member Functions (a.k.a. Methods)))
         $(P Non-static member functions have an extra hidden parameter
         called $(DDSUBLINK spec/expression, this, `this`) through which the class object's other members
         can be accessed.
+        Inside the function body, the member variables of the class instance
+        are in scope.
         )
 
+$(SPEC_RUNNABLE_EXAMPLE_RUN
+---
+class C
+{
+    int a;
+
+    void foo()
+    {
+        a = 3; // assign to `this.a`
+    }
+}
+
+auto c = new C;
+c.foo();
+assert(c.a == 3);
+---
+)
         $(P Non-static member functions can have, in addition to the usual
         $(GLINK2 function, FunctionAttribute)s, the attributes
         $(D const), $(D immutable), $(D shared), $(D inout), $(D scope) or $(D return scope).
@@ -268,6 +287,7 @@ $(SPEC_RUNNABLE_EXAMPLE_FAIL
 class C
 {
     int a;
+
     void foo() const
     {
         a = 3; // error, 'this' is const

--- a/spec/class.dd
+++ b/spec/class.dd
@@ -253,11 +253,11 @@ $(H3 $(LNAME2 field_properties, Field Properties))
 
 $(H2 $(LNAME2 member-functions, Member Functions (a.k.a. Methods)))
 
-        $(P Non-static member functions have an extra hidden parameter
+        $(P Non-static member functions must be called on an instance of their class.
+        They have an extra hidden parameter
         called $(DDSUBLINK spec/expression, this, `this`) through which the class object's other members
         can be accessed.
-        Inside the function body, the member variables of the class instance
-        are in scope.
+        Inside the function body, the class instance members are in scope.
         )
 
 $(SPEC_RUNNABLE_EXAMPLE_RUN

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2084,7 +2084,8 @@ $(TROW `(` *Expression* `)`, Evaluate an expression - useful as a
 
 $(H3 $(LNAME2 this, this))
 
-    $(P Within a constructor or non-static member function, $(D this) resolves to
+    $(P Within a constructor or $(DDSUBLINK spec/class, member-functions,
+        non-static member function), $(D this) resolves to
         a reference to the object for which the function was called.
     )
     $(P $(DDSUBLINK spec/type, typeof-this, `typeof(this)`) is valid anywhere


### PR DESCRIPTION
Add example.