### PR TITLE
[spec/types] Tweak docs for deprecated complex types

### DIFF
--- a/spec/type.dd
+++ b/spec/type.dd
@@ -112,12 +112,12 @@ $(H2 $(LEGACY_LNAME2 Basic Data Types, basic-data-types, Basic Data Types))
     $(TROW $(D float), $(D float.nan), 32 bit floating point)
     $(TROW $(D double), $(D double.nan), 64 bit floating point)
     $(TROW $(D real), $(D real.nan), largest floating point size available)
-    $(TROW $(D ifloat), $(D float.nan*1.0i), imaginary float)
-    $(TROW $(D idouble), $(D double.nan*1.0i), imaginary double)
-    $(TROW $(D ireal), $(D real.nan*1.0i), imaginary real)
-    $(TROW $(D cfloat), $(D float.nan+float.nan*1.0i), a complex number of two float values)
-    $(TROW $(D cdouble), $(D double.nan+double.nan*1.0i), complex double)
-    $(TROW $(D creal), $(D real.nan+real.nan*1.0i), complex real)
+    $(TROW $(GDEPRECATED $(D ifloat)), $(D float.nan*1.0i), imaginary float)
+    $(TROW $(GDEPRECATED $(D idouble)), $(D double.nan*1.0i), imaginary double)
+    $(TROW $(GDEPRECATED $(D ireal)), $(D real.nan*1.0i), imaginary real)
+    $(TROW $(GDEPRECATED $(D cfloat)), $(D float.nan+float.nan*1.0i), a complex number of two float values)
+    $(TROW $(GDEPRECATED $(D cdouble)), $(D double.nan+double.nan*1.0i), complex double)
+    $(TROW $(GDEPRECATED $(D creal)), $(D real.nan+real.nan*1.0i), complex real)
     $(TROW $(D char), $(D '\xFF'), unsigned 8 bit (UTF-8 code unit))
     $(TROW $(D wchar), $(D '\uFFFF'), unsigned 16 bit (UTF-16 code unit))
     $(TROW $(D dchar), $(D '\U0000FFFF'), unsigned 32 bit (UTF-32 code unit))
@@ -133,8 +133,9 @@ $(H2 $(LEGACY_LNAME2 Basic Data Types, basic-data-types, Basic Data Types))
     $(NOTE 128-bit integer types `cent` and `ucent`
     $(DDSUBLINK deprecate, 128-bit integer types, have been deprecated).)
 
-    $(P NOTE: Complex and imaginary types `ifloat`, `idouble`, `ireal`, `cfloat`, `cdouble`,
-    and `creal` have been deprecated in favor of `std.complex.Complex`.)
+    $(NOTE Complex and imaginary types `ifloat`, `idouble`, `ireal`, `cfloat`, `cdouble`,
+    and `creal` $(DDSUBLINK deprecate, Imaginary and complex types,
+    have been deprecated) in favor of `std.complex.Complex`.)
 
 $(H2 $(LEGACY_LNAME2 Derived Data Types, derived-data-types, Derived Data Types))
 


### PR DESCRIPTION
Use GDEPRECATED macro like for cent, ucent.
Add link.