### PR TITLE
Fix BUGZILLA_NEW_BUG_URL macro to use github

### DIFF
--- a/404.dd
+++ b/404.dd
@@ -6,7 +6,7 @@ $(D_S $(TITLE),
 $(HTMLTAG3 img, src="$(STATIC images/dman-scared.jpg)")
 
 $(P
-If you think there should be something here, please $(LINK2 $(BUGZILLA_NEW_BUG_URL)$(AMP)bug_severity=normal, report a bug).
+If you think there should be something here, please $(LINK2 $(BUGZILLA_NEW_BUG_URL)$(AMP)label=Severity:normal, report a bug).
 )))
 
 Macros:

--- a/book/d.en/404.d
+++ b/book/d.en/404.d
@@ -6,7 +6,7 @@ $(D_S $(TITLE),
 $(HTMLTAG3 img, src="$(STATIC images/dman-scared.jpg)")
 
 $(P
-If you think there should be something here, please $(LINK2 $(BUGZILLA_NEW_BUG_URL)$(AMP)bug_severity=normal, report a bug).
+If you think there should be something here, please $(LINK2 $(BUGZILLA_NEW_BUG_URL)$(AMP)label=Severity:normal, report a bug).
 )))
 $(RED Some text here)
 Macros:

--- a/book/dlang.org.ddoc
+++ b/book/dlang.org.ddoc
@@ -12,7 +12,7 @@ BLUE=$(SPANC blue, $0)
 BODY_PREFIX=
 BOOKTABLE = $(TC table, book, $(T caption, $1)$+)
 BUGZILLA = $(SPANC bugzilla, $(AHTTPS issues.dlang.org/show_bug.cgi?id=$0, Bugzilla $0))
-BUGZILLA_NEW_BUG_URL=https://issues.dlang.org/enter_bug.cgi?bug_file_loc=http%3A%2F%2Fdlang.org/$(SELF_PATH)$(AMP)component=$(PROJECT)$(AMP)op_sys=All$(AMP)priority=P3$(AMP)product=D$(AMP)rep_platform=All$(AMP)short_desc=%5B$(TITLE)%5D$(AMP)version=D2
+BUGZILLA_NEW_BUG_URL=https://github.com/dlang/$(PROJECT)/issues/new?title=%5B$(TITLE)%5D%20
 _=
 
 CCODE=$(TC pre, ccode notranslate, $0)
@@ -318,7 +318,7 @@ _=
 PAGE_TOOLS=
 $(DIVID tools, $(DIV,
 	$(DIVC tip smallprint,
-		$(HTMLTAG3 a, href="$(BUGZILLA_NEW_BUG_URL)$(AMP)bug_severity=enhancement", Report a bug)
+		$(HTMLTAG3 a, href="$(BUGZILLA_NEW_BUG_URL)$(AMP)label=Severity:Enhancement", Report a bug)
 		$(DIV,
 			If you spot a problem with this page, click here to create a Bugzilla issue.
 		)

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -13,7 +13,7 @@ BLUE=$(SPANC blue, $0)
 BODY_PREFIX=
 BOOKTABLE = $(TC table, book, $(T caption, $1)$+)
 BUGZILLA = $(SPANC bugzilla, $(AHTTPS issues.dlang.org/show_bug.cgi?id=$0, Bugzilla $0))
-BUGZILLA_NEW_BUG_URL=https://issues.dlang.org/enter_bug.cgi?bug_file_loc=http%3A%2F%2Fdlang.org/$(SELF_PATH)$(AMP)component=$(PROJECT)$(AMP)op_sys=All$(AMP)priority=P3$(AMP)product=D$(AMP)rep_platform=All$(AMP)short_desc=%5B$(TITLE)%5D$(AMP)version=D2
+BUGZILLA_NEW_BUG_URL=https://github.com/dlang/$(PROJECT)/issues/new?title=%5B$(TITLE)%5D%20
 _=
 
 CCODE=$(TC pre, ccode notranslate, $0)
@@ -323,7 +323,7 @@ _=
 PAGE_TOOLS=
 $(DIVID tools, $(DIV,
 	$(DIVC tip smallprint,
-		$(HTMLTAG3 a, href="$(BUGZILLA_NEW_BUG_URL)$(AMP)bug_severity=enhancement", Report a bug)
+		$(HTMLTAG3 a, href="$(BUGZILLA_NEW_BUG_URL)$(AMP)label=Severity:Enhancement", Report a bug)
 		$(DIV,
 			If you spot a problem with this page, click here to create a Bugzilla issue.
 		)


### PR DESCRIPTION
Fixes #4266.
I also added a space after the square brackets in the pre-filled bug title, ready for people to type more.