### PR TITLE
spec/pragma: Fix example for pragma(mangle)

### DIFF
--- a/spec/pragma.dd
+++ b/spec/pragma.dd
@@ -302,7 +302,7 @@ $(H3 $(LNAME2 mangle, $(D pragma mangle)))
         extern(C++) struct _function {}
         template ScopeClass(C)
         {
-            pragma(mangle, C.stringof, C)
+            pragma(mangle, C)
             struct ScopeClass { align(__traits(classInstanceAlignment, C)) void[__traits(classInstanceSize, C)] buffer; }
         }
         extern(C++)


### PR DESCRIPTION
The .stringof property attempts to mangle the type as the string literal "MyClassA!(int)", which isn't what the example expects.