### PR TITLE
Update areas-of-d-usage.dd for broken Quantum Break link

### DIFF
--- a/areas-of-d-usage.dd
+++ b/areas-of-d-usage.dd
@@ -84,7 +84,7 @@ $(AREA_SECTION3 $(LNAME2 games, Games), $(ARTICLE_FA_ICON gamepad),
 
     Binary compatibility with existing libraries is important in large-scale
     projects.
-    Remedy Entertainment has successfully shipped the first $(HTTP www.quantumbreak.com,
+    Remedy Entertainment has successfully shipped the first $(HTTPS www.remedygames.com/games/quantum-break,
     AAA game) to use D code for XBox One and Windows 10.
     For more details, see Ethan Watson's
     $(HTTP dconf.org/2016/talks/watson.html, presentation).


### PR DESCRIPTION
As described here: https://news.ycombinator.com/item?id=44724714
the link for Quantum Break is broken. I updated for the new link.