### PR TITLE
[spec/type] Improve Pointer docs

### DIFF
--- a/spec/type.dd
+++ b/spec/type.dd
@@ -219,6 +219,10 @@ assert(i == 4);
         * $(DDSUBLINK spec/expression, slice_expressions, Pointer Slicing)
         * $(RELATIVE_LINK2 pointer-conversions, Pointer Conversions)
 
+        $(BEST_PRACTICE Use a $(DDSUBLINK spec/function, ref-params,
+        `ref` function parameter) or a $(DDSUBLINK spec/declaration, ref-variables,
+        `ref` local variable) when the address doesn't escape.
+
 
 $(H2 $(LEGACY_LNAME2 User Defined Types, user-defined-types, User-Defined Types))
 


### PR DESCRIPTION
A pointer value is a memory address.
Spec should not use 'object' except for class/struct instances. 
Aborting on null dereference is required in safe code (with link).
Mention that `&` requires an lvalue.

*Update:* Add 2 see also links & `ref` best practice (see commits).