### PR TITLE
[spec] Tweak array indexing expression docs & mention array bounds checks

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -237,6 +237,9 @@ assert(b[1] == 2);
 ---------
 )
 
+    $(P Dynamic and static array indexing is $(RELATIVE_LINK2 bounds, bounds checked)
+    by default.)
+
     $(P See also $(GLINK2 expression, IndexOperation).)
 
 $(H3 $(LNAME2 pointer-arithmetic, Pointer Arithmetic))
@@ -292,6 +295,9 @@ b = b[1..2];
 assert(b == [3]);
 ---------
 )
+
+        $(P Each index in the slice expression is $(RELATIVE_LINK2 bounds, bounds checked)
+        by default.)
 
         $(P $(I Expression)`[]` is shorthand for a slice of the entire array.
         )

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1858,22 +1858,22 @@ $(GNAME IndexOperation):
         $(I ArgumentList) and `$` appears in that scope only.
     )
 
-    $(P If the $(I PostfixExpression) is an expression of static or
+      * If the $(I PostfixExpression) is an expression of static or
         dynamic array type, the result of the indexing is an lvalue
         of the *i*th element in the array, where `i` is an integer
         evaluated from $(I ArgumentList).
-        If $(I PostfixExpression) is a pointer `p`, the result is
-        `*(p + i)` (see $(RELATIVE_LINK2 pointer_arithmetic, Pointer Arithmetic)).
-    )
+        See $(DDSUBLINK spec/arrays, indexing, array indexing).
 
-    $(P If the base $(I PostfixExpression) is a $(DDSUBLINK spec/template, variadic-templates, $(I ValueSeq))
+      * If $(I PostfixExpression) is a $(DDSUBLINK spec/type, pointers, pointer) `p`, the result is
+        `*(p + i)` (see $(RELATIVE_LINK2 pointer_arithmetic, Pointer Arithmetic)).
+
+      * If the base $(I PostfixExpression) is a $(DDSUBLINK spec/template, variadic-templates, $(I ValueSeq))
         then the $(I ArgumentList) must consist of only one argument,
         and that must be statically evaluatable to an integral constant.
         That integral constant $(I n) then selects the $(I n)th
         expression in the $(I ValueSeq), which is the result
         of the $(I IndexOperation).
         It is an error if $(I n) is out of bounds of the $(I ValueSeq).
-    )
 
     $(P The index operator can be $(DDSUBLINK spec/operatoroverloading, array, overloaded).
         Using multiple indices in *ArgumentList* is only supported for operator
@@ -1907,6 +1907,7 @@ $(GNAME Slice):
         referencing elements `a[i]` to `a[j-1]` inclusive, where `i`
         and `j` are integers evaluated from the first and second $(I
         AssignExpression) respectively.
+        See $(DDSUBLINK spec/arrays, slicing, array slicing).
 
       * If the base $(I PostfixExpression) is a $(DDSUBLINK spec/type, pointers, pointer) `p`, the result
         will be a dynamic array referencing elements from `p[i]` to `p[j-1]`


### PR DESCRIPTION
Make array.dd indexing/slicing sections mention bounds checks.
Similar to #4282, use list for kinds of base expression to index & add pointer link. 
Link to array indexing/slicing.