### PR TITLE
[spec] Improve `noreturn` docs

### DIFF
--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2857,7 +2857,8 @@ $(H4 $(LNAME2 assert-ct, Compile-time Evaluation))
     $(P If the first $(I AssignExpression) consists entirely of compile time constants,
     and evaluates to `false`, it is a special case - it
     signifies that subsequent statements are unreachable code.
-    Compile Time Function Execution (CTFE) is not attempted.
+    Compile Time Function Execution (CTFE) calls are not attempted for the evaluation.
+    Such an $(GLINK AssertExpression) has type $(DDSUBLINK spec/type, noreturn, `noreturn`).
     )
 
     $(P This allows the compiler to suppress an error when there is a

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -894,13 +894,18 @@ $(H3 $(LNAME2 noreturn, $(D noreturn)))
     A value of type `noreturn` will never be produced and the compiler can
     optimize such code accordingly.)
 
+    $(P `noreturn.init` lowers to $(DDSUBLINK spec/expression, assert-ct, `assert(0)`).)
+
     $(P A function that $(DDSUBLINK spec/function, function-return-values, never returns)
     has the return type `noreturn`. This can
-    occur due to an infinite loop or always throwing an exception.)
+    occur due to e.g. an infinite loop or always throwing an exception.
+    A function returning type `noreturn` is covariant with a function returning any other type.)
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
-noreturn abort(const(char)[] message);
+noreturn abort(string message);
+
+int function(string) fp = &abort; // OK
 
 int example(int i)
 {
@@ -916,7 +921,9 @@ int example(int i)
 )
 
     $(P `noreturn` is defined as $(D typeof(*null)). This is because
-    dereferencing a null literal halts execution.)
+    dereferencing a null literal (typically) halts execution.)
+
+    $(P See also: $(GLINK2 expression, ThrowExpression))
 
 
 $(SPEC_SUBNAV_PREV_NEXT declaration, Declarations, property, Properties)


### PR DESCRIPTION
- The type of `assert(0)` is noreturn.
  - Also clarify note about CTFE not being attempted.
- `noreturn.init` lowers to `assert(0)`.
- A function returning type `noreturn` is covariant with a function returning any other type.

See also `throw`.

Fixes https://github.com/dlang/dlang.org/issues/4297.