### PR TITLE
ddoc: Don't generate undocumented cli options

### DIFF
--- a/ddoc/source/preprocessor.d
+++ b/ddoc/source/preprocessor.d
@@ -394,6 +394,8 @@ auto genSwitches(string fileText)
 
     foreach (option; Usage.options)
     {
+        if (!option.documented)
+            continue;
         string flag = option.flag;
         string helpText = option.helpText;
         if (!option.ddocText.empty)


### PR DESCRIPTION
Noticed that long gone options such as `-wo` are still appearing on the dlang.org site documentation.