### PR TITLE
[spec] Improve delegate docs

### DIFF
--- a/spec/function.dd
+++ b/spec/function.dd
@@ -3379,9 +3379,6 @@ void main()
 {
     Foo f = {7};
     int delegate() dg = &f.get; // bind to an instance of Foo and a method
-    assert(dg.ptr == &f);
-    assert(dg.funcptr == &Foo.get);
-
     int i = add1(dg);
     assert(i == 8);
 

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -717,15 +717,15 @@ $(I function pointer) value as a function type.
 
 $(P Delegates are declared and initialized similarly to function pointers:)
 
-$(SPEC_RUNNABLE_EXAMPLE_COMPILE
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 -------------------
-int func(int);
-int function(int) fp; // fp is a function pointer
-int delegate(int) dg; // dg is a delegate to a function
+void func(int) {}
+void function(int) fp; // fp is a function pointer
+void delegate(int) dg; // dg is a delegate to a function
 
 class OB
 {
-    int member(int);
+    void member(int) {}
 }
 
 void main()
@@ -733,8 +733,12 @@ void main()
     OB o = new OB;
 
     fp = &func; // fp points to function `func`
+
     dg = &o.member; // dg is a delegate to object `o` and member function `member`
-    dg = (int i) => o.member(i); // dg is a delegate to main's context and a delegate literal
+    assert(dg.ptr == cast(void*) o);
+    assert(dg.funcptr == &OB.member);
+
+    dg = (int i) { o.member(i); }; // dg holds a delegate literal with main's execution context
 }
 -------------------
 )


### PR DESCRIPTION
function.dd (how delegates interact with functions):
Add links.
*Method Delegates* should be H3, it's not a subheading of *Delegates and Closures* (oops).
Move `.ptr` and `.funcptr` to delegate type docs.

type.dd (what a delegate is):
Fix wrong `)` pairing.
Explain a delegate is a context pointer and function pointer. 
Fix example to declare `fp` which is referenced below the example.
Show delegate to closure in example.
Add see also links to function.dd delegate docs.