### PR TITLE
Adds a link to the source code of the current module

### DIFF
--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -202,6 +202,11 @@ html(lang='en-US')
 
             - if( modname )
               .tip.smallprint
+                a(href='https://github.com/dlang/#{project}/blob/master/#{path_prefix}#{filename}#{line_suffix}')
+                  | Source
+                div
+                  | Source code of this page
+              .tip.smallprint
                 a(href='https://github.com/dlang/#{project}/edit/master/#{path_prefix}#{filename}#{line_suffix}')
                   | Improve this page
                 div


### PR DESCRIPTION
Adds a link to the source, without editing enabled. I am found that it is very convenient to have link here.

(Yes, I know there's usually a link to the source at the bottom of the page)