### PR TITLE
Tweak `final`-related docs

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -79,7 +79,7 @@ $(GNAME StorageClass):
     $(DDSUBLINK spec/attribute, static, `static`)
     $(RELATIVE_LINK2 extern, $(D extern))
     $(DDSUBLINK spec/class, abstract, `abstract`)
-    $(DDSUBLINK spec/class, final, `final`)
+    $(DDSUBLINK spec/attribute, final, `final`)
     $(DDSUBLINK spec/function, virtual-functions, `override`)
     $(DDSUBLINK spec/class, synchronized-classes, `synchronized`)
     $(RELATIVE_LINK2 auto-declaration, `auto`)

--- a/spec/interface.dd
+++ b/spec/interface.dd
@@ -71,7 +71,8 @@ I iface = new I();  // error, cannot create instance of interface
 $(H3 $(LNAME2 method-bodies, Interface Method Bodies))
 
     $(P Virtual interface member functions do not have implementations.
-    Interfaces are expected to implement static or final functions.
+    Interfaces can implement $(DDSUBLINK spec/attribute, static, static)
+    or $(DDSUBLINK spec/function, final, final) functions.
     )
 
 ------


### PR DESCRIPTION
- Interfaces can but are not "expected" to implement static or final functions. Add links.
- declaration.dd: link storage class to [final attribute](https://dlang.org/spec/attribute.html#final) overview, rather than final classes.