### PR TITLE
[spec] Tweak `GRAMMAR_INLINE` macro formatting

### DIFF
--- a/book/dlang.org.ddoc
+++ b/book/dlang.org.ddoc
@@ -186,7 +186,7 @@ GNAME=<a id="$0">$(SPANC gname, $0)</a>
 GRAMMAR=$(TC pre, bnf notranslate, $0)
 GRAMMAR_INFORMATIVE=$(GRAMMAR $0)
 GRAMMAR_LEX=$(GRAMMAR $0)
-GRAMMAR_INLINE=$(TC tt, bnf notranslate, $0)
+GRAMMAR_INLINE=$(TC tt, bnf_inline notranslate, $0)
 GREEN=$(SPANC green, $0)
 GSELF=$(I $0)
 GT=&gt;

--- a/css/style.css
+++ b/css/style.css
@@ -44,7 +44,7 @@ body, .d_decl .quickindex
     font-family: "Roboto Slab", sans-serif;
 }
 
-pre, code, .tt, .d_inlinecode, td.param_id, .CodeMirror pre, .d_decl
+pre, code, .tt, .d_inlinecode, .bnf_inline, td.param_id, .CodeMirror pre, .d_decl
 {
     font-family: Consolas, "Bitstream Vera Sans Mono", "Andale Mono", Monaco, "DejaVu Sans Mono", "Lucida Console", monospace;
 }
@@ -1200,6 +1200,12 @@ body.dcompiler dt a.anchor:hover:before
 .bnf /* grammar */
 {
     background-color: white;
+}
+
+.bnf_inline
+{
+    font-size: small;
+    background-color: #F5F5F5; /* differentiate grammar from paragraph punctuation */
 }
 
 .ddoccode

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -189,7 +189,7 @@ $(COMMENT GRAMMAR invocations will appear in spec/grammar.html, but NOT the suff
 GRAMMAR=$(TC pre, bnf notranslate, $0)
 GRAMMAR_INFORMATIVE=$(GRAMMAR $0)
 GRAMMAR_LEX=$(GRAMMAR $0)
-GRAMMAR_INLINE=$(TC tt, bnf notranslate, $0)
+GRAMMAR_INLINE=$(TC tt, bnf_inline notranslate, $0)
 GREEN=$(SPANC green, $0)
 GSELF=$(I $0)
 GT=&gt;

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -1911,7 +1911,7 @@ $(GNAME Slice):
         The special variable `$` is declared and set to be the number
         of elements in the $(I PostfixExpression) (when available).
         A new declaration scope is created for the evaluation of the
-        $(GRAMMAR_INLINE *AssignExpression* .. *AssignExpression*) and `$` appears in
+        $(GRAMMAR_INLINE *AssignExpression* `..` *AssignExpression*) and `$` appears in
         that scope only.
     )
 

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -1808,16 +1808,15 @@ L1:
 ---
 )
 
-$(P The second form, $(CODE goto default;), transfers to the innermost $(GLINK
+$(P The second form, $(GRAMMAR_INLINE `goto default`;), transfers to the innermost $(GLINK
 DefaultStatement) of an enclosing $(GLINK SwitchStatement).)
 
-        $(P The third form, $(CODE goto case;), transfers to the
+        $(P The third form, $(GRAMMAR_INLINE `goto case`;), transfers to the
         next $(GLINK CaseStatement) of the innermost enclosing
         $(GLINK SwitchStatement).)
 
-        $(P The fourth form, $(CODE goto case) *Expression*$(D ;), transfers to the
-        $(GLINK CaseStatement) of the innermost enclosing
-        $(GLINK SwitchStatement)
+        $(P The fourth form, $(GRAMMAR_INLINE `goto case` *Expression*;), transfers to the
+        $(GLINK CaseStatement) of the innermost enclosing $(GLINK SwitchStatement)
         with a matching *Expression*.)
 
 $(SPEC_RUNNABLE_EXAMPLE_RUN
@@ -1842,7 +1841,7 @@ switch (x)
 ---
 )
 
-$(P Any intervening finally clauses are executed, along with releasing any
+$(P Any intervening `finally` clauses are executed, along with releasing any
 intervening synchronization mutexes.)
 
         $(P It is illegal for a $(I GotoStatement) to be used to skip
@@ -1850,7 +1849,7 @@ intervening synchronization mutexes.)
 
         $(BEST_PRACTICE Prefer using a higher-level control-flow construct
         or a labelled $(GLINK BreakStatement)/$(GLINK ContinueStatement)
-        rather than the $(GRAMMAR_INLINE *`goto` Identifier;*) form.)
+        rather than the $(GRAMMAR_INLINE `goto` *Identifier*;) form.)
 
 
 $(H2 $(LEGACY_LNAME2 WithStatement, with-statement, With Statement))


### PR DESCRIPTION
Add CSS `bnf_inline` class with distinct `background-color` vs `<p>` and `<body>`. 
Make `GRAMMAR_INLINE` use `bnf_inline` CSS instead of `bnf`.
Use `GRAMMAR_INLINE` consistently for `goto` inline grammar forms.

<img width="530" height="222" alt="image" src="https://github.com/user-attachments/assets/720cb458-0902-42e2-b17d-3f57eaa11a0e" />
