### PR TITLE
[spec] Improve `opAssign` docs

### DIFF
--- a/spec/operatoroverloading.dd
+++ b/spec/operatoroverloading.dd
@@ -696,11 +696,12 @@ $(H3 $(LNAME2 static-opcall, Static opCall))
 $(H2 $(LEGACY_LNAME2 Assignment, assignment, Assignment Operator Overloading))
 
         $(P The assignment operator $(CODE =) can be overloaded if the
-        left hand side is a struct aggregate, and $(CODE opAssign)
+        left hand side is an aggregate, and $(CODE opAssign)
         is a member function of that aggregate.)
 
-        For struct types, operator overloading for the identity assignment
-        is allowed.
+        $(P For struct types, operator overloading for the
+        $(DDSUBLINK spec/struct, assign-overload, identity assignment)
+        is allowed, as well as assignment from other types.)
 
     ---
     struct S
@@ -716,14 +717,18 @@ $(H2 $(LEGACY_LNAME2 Assignment, assignment, Assignment Operator Overloading))
     s = 1;        // Rewritten to s.opAssign(1);
     ---
 
-        However for class types, identity assignment is not allowed. All class
-        types have reference semantics, so identity assignment by default rebinds
-        the left-hand-side to the argument at the right, and this is not overridable.
+        $(P However for class types, assignment can only be overridden from a type
+        which does not convert to `typeof(this)`.)
+
+        $(RATIONALE All class types have reference semantics, so identity assignment
+        rebinds the left-hand-side class reference to the one on the right. If this
+        was overridable then it would conflict conceptually with a subclass implicitly
+        converting to its base class.)
 
     ---
     class C
     {
-        // If X is the same type as C or the type which is
+        // If X is the same type as C or a type which is
         // implicitly convertible to C, then opAssign would
         // accept identity assignment, which is disallowed.
         // C opAssign(...);

--- a/spec/struct.dd
+++ b/spec/struct.dd
@@ -2456,7 +2456,7 @@ $(H2 $(LEGACY_LNAME2 AssignOverload, assign-overload, Identity Assignment Overlo
         t = s;    // t is assigned from s
         ---
 
-        $(P Struct assignment $(CODE t=s) is defined to be semantically
+        $(P Struct assignment $(CODE t = s) is defined to be semantically
         equivalent to:
         )
 
@@ -2464,17 +2464,7 @@ $(H2 $(LEGACY_LNAME2 AssignOverload, assign-overload, Identity Assignment Overlo
         t.opAssign(s);
         ---
 
-        $(P where $(CODE opAssign) is a member function of S:)
-
-        ---
-        ref S opAssign(ref S s)
-        {
-            S tmp = this;   // bitcopy this into tmp
-            this = s;       // bitcopy s into this
-            tmp.__dtor();   // call destructor on tmp
-            return this;
-        }
-        ---
+        $(P where $(CODE opAssign) is a member function of `S`.)
 
         $(P An identity assignment overload is required for a struct if one or more of
         these conditions hold:)
@@ -2486,8 +2476,18 @@ $(H2 $(LEGACY_LNAME2 AssignOverload, assign-overload, Identity Assignment Overlo
         )
 
         $(P If an identity assignment overload is required and does not
-        exist, an identity assignment overload function of the type
-        $(CODE ref S opAssign(ref S))  will be automatically generated.)
+        exist, an identity assignment overload function will be automatically generated
+        with the following lowering:)
+
+        ---
+        ref S opAssign(ref S s)
+        {
+            S tmp = this;   // bitcopy this into tmp
+            this = s;       // bitcopy s into this
+            tmp.__dtor();   // call destructor on tmp
+            return this;
+        }
+        ---
 
         $(P A user-defined one can implement the equivalent semantics, but can
         be more efficient.
@@ -2519,9 +2519,8 @@ $(H2 $(LEGACY_LNAME2 AssignOverload, assign-overload, Identity Assignment Overlo
         )
 
         $(P Here, $(CODE S) has a temporary workspace $(CODE buf[]).
-        The normal postblit
-        will pointlessly free and reallocate it. The custom $(CODE opAssign)
-        will reuse the existing storage.
+        A compiler-generated `opAssign` would pointlessly free and reallocate it.
+        The custom $(CODE opAssign) will reuse the existing storage.
         )
 
 $(H2 $(LEGACY_LNAME2 AliasThis, alias-this, Alias This))


### PR DESCRIPTION
`operatoroverloading.dd`:
Link to struct identity assignment.
Add paragraph tags.
Explain class assignment can only be overridden from a type which does not convert to `typeof(this)`. Expand rationale.

`struct.dd`:
Mention 'lowering' for generated `opAssign` & move lowered code.
Don't mention postblit when talking about generated `opAssign`.