### PR TITLE
Amazon closed Smile service in 2023. Removing it from DLF donations page.

### DIFF
--- a/foundation/donate.dd
+++ b/foundation/donate.dd
@@ -89,12 +89,6 @@ $(DONATE_ITEM Electronic wire transfers or bank check, money,
     Wire transfer information will be announced soon. In the meantime please use PayPal or $(LINK2 mailto:foundation@dlang.org, contact the D Language Foundation).
 )
 
-$(DONATE_ITEM smile.amazon.com, shopping-cart,
-    Visit $(HTTPS smile.amazon.com, smile.amazon.com) and select the D
-    Language Foundation as your charity. We'll receive a small percentage
-    of every purchase you make through smile.amazon.com (not www.amazon.com or the mobile app).
-)
-
 $(DONATE_ITEM The DLang Swag Emporium, shopping-cart,
     Visit the $(HTTPS www.zazzle.com/store/dlang_swag?rf=238129799288374326,
     DLang Swag Emporium) to purchase D-themed t-shirts, coffee mugs, and other


### PR DESCRIPTION
More about this here: https://www.aboutamazon.com/news/company-news/amazon-closing-amazonsmile-to-focus-its-philanthropic-giving-to-programs-with-greater-impact