### PR TITLE
[spec/type] Define ArithmeticType

### DIFF
--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -275,7 +275,7 @@ $(H3 $(LNAME2 boolean-conditions, Boolean Conversion))
         $(P The following type instances are supported in a condition:)
 
         $(UL
-        $(LI $(DDSUBLINK spec/type, FundamentalType, Fundamental types) are `true` when non-zero)
+        $(LI $(DDSUBLINK spec/type, ArithmeticType, Arithmetic types) are `true` when non-zero)
         $(LI Pointers are `true` when non-null)
         $(LI Reference types are `true` when non-null)
         $(LI A user-defined type with a valid $(DDSUBLINK spec/operatoroverloading, cast, `opCast!bool()`) method will be called for the result. Otherwise, any

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -103,9 +103,8 @@ $(H2 $(LNAME2 types, Type Traits))
 
 $(H3 $(GNAME isArithmetic))
 
-        $(P If the arguments are all either types that are arithmetic types,
-        or expressions that are typed as arithmetic types, then $(D true)
-        is returned.
+        $(P If the arguments are all either a type that is an $(GLINK2 type, ArithmeticType),
+        or an expression that is typed as such, then $(D true) is returned.
         Otherwise, $(D false) is returned.
         If there are no arguments, $(D false) is returned.)
 
@@ -118,21 +117,12 @@ import std.stdio;
 void main()
 {
     int i;
-    writeln(__traits(isArithmetic, int));
-    writeln(__traits(isArithmetic, i, i+1, int));
-    writeln(__traits(isArithmetic));
-    writeln(__traits(isArithmetic, int*));
+    static assert(__traits(isArithmetic, int));
+    static assert(__traits(isArithmetic, i, i+1, int));
+    static assert(!__traits(isArithmetic));
+    static assert(!__traits(isArithmetic, int*));
 }
 ---
-)
-
-        Prints:
-
-$(CONSOLE
-true
-true
-false
-false
 )
 
 $(H3 $(GNAME isFloating))

--- a/spec/type.dd
+++ b/spec/type.dd
@@ -42,7 +42,10 @@ $(GNAME VectorBaseType):
     $(GLINK Type)
 
 $(GNAME FundamentalType):
-$(MULTICOLS 5,
+    $(D void)
+    $(GLINK ArithmeticType)
+
+$(GNAME ArithmeticType):
     $(D bool)
     $(D byte)
     $(D ubyte)
@@ -66,7 +69,6 @@ $(MULTICOLS 5,
     $(D cfloat)
     $(D cdouble)
     $(D creal)
-    $(D void))
 
 $(GNAME TypeSuffixes):
     $(GLINK TypeSuffix) $(GSELF TypeSuffixes)$(OPT)
@@ -647,8 +649,8 @@ $(P A `bool` value can be implicitly converted to any integral type, with
 
 $(P The numeric literals `0` and `1` can be implicitly converted to the `bool`
 values `false` and `true`, respectively. Casting an expression to `bool` means
-testing `!=0` for arithmetic types, and `!=null` for
-pointers or references. See $(DDSUBLINK spec/statement, boolean-conditions,
+testing `!=0` for an $(GLINK ArithmeticType), and `!=null` for
+pointers or reference types. See $(DDSUBLINK spec/statement, boolean-conditions,
 Boolean Conversion) for details.)
 
 $(UNDEFINED_BEHAVIOR)


### PR DESCRIPTION
Link to it from bool conversion and `__traits(isArithmetic)` docs.
Also use static assert in example instead of `writeln` for clarity.

Fixes #4078.