### PR TITLE
[spec] Tweak `ref` docs

### DIFF
--- a/spec/arrays.dd
+++ b/spec/arrays.dd
@@ -83,7 +83,8 @@ int* p;
         )
 
         $(BEST_PRACTICE Most conventional uses for pointers can be replaced with
-        dynamic arrays, $(D ref) and $(D out) $(DDSUBLINK spec/function, parameters, parameters),
+        dynamic arrays, $(DDSUBLINK spec/declaration, ref-storage, `ref` declarations),
+        $(DDSUBLINK spec/function, ref-params, `out` parameters),
         and reference types.
         )
 

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -863,7 +863,7 @@ $(H4 $(LNAME2 ref-variables, `ref` Variables))
 
         $(P From version 2.111, `ref` can be used to declare local, static, extern, and global variables.)
 
-$(COMMENT SPEC_RUNNABLE_EXAMPLE_RUN)
+$(SPEC_RUNNABLE_EXAMPLE_RUN
 ---
 struct S { int a; }
 
@@ -875,13 +875,14 @@ void main()
     assert(s.a == 3);
 }
 ---
+)
 
         $(BEST_PRACTICE Use a `ref` variable instead of a pointer when pointer
         arithmetic is not needed.)
 
         $(P `auto ref` can also be used to declare local, static, extern, and global variables.)
 
-$(COMMENT SPEC_RUNNABLE_EXAMPLE_COMPILE)
+$(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 void f()
 {
@@ -891,6 +892,7 @@ void f()
     static assert( __traits(isRef, y));
 }
 ---
+)
 
         $(P See also: $(DDSUBLINK spec/template, auto-ref-parameters, `auto ref`)
         template function parameters.)


### PR DESCRIPTION
arrays.dd: Mention `ref` declarations, not just parameters.
declarations.dd: Make examples runnable now.