### PR TITLE
Replace "Leave a Tip!" link in download page

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -315,7 +315,7 @@ Macros:
     IMG=<img src="images/$1">
     DONATE_BUTTON =<td colspan="3" style="padding-bottom:20px">
       $(DIV style="border-radius:5px 5px 5px 5px;font-weight:normal; border:1px solid #000000;box-shadow:none;left: 50%; margin-left: -107.5px;display: block;clear: both; width:215px; height:70px; line-height:2.9; position:relative; font-size:24px; text-align:center;",
-      $(LINK2 https://www.flipcause.com/secure/cause_pdetails/NDMzMzE=, Leave a Tip!)$(BR)$(BR))
+      $(LINK2 https://dlang.org/foundation/donate.html, Leave a Tip!)$(BR)$(BR))
     </td>
 
     _= for sidebard subnavigation


### PR DESCRIPTION
It appears that the Flipacause campaign has ended or is not currently active.

The tip button in the download page should link to the D Language Foundation donation page instead.