### PR TITLE
[changelog] `opApply` returning a non-zero constant has been deprecated

### DIFF
--- a/changelog/2.112.0.dd
+++ b/changelog/2.112.0.dd
@@ -20,6 +20,7 @@ $(LI $(RELATIVE_LINK2 dmd.extern-std-cpp23,The compiler now accepts `-extern-std
 $(LI $(RELATIVE_LINK2 dmd.external-import-path,External import path switch))
 $(LI $(RELATIVE_LINK2 dmd.import-c-modules,C files can now include a module statement))
 $(LI $(RELATIVE_LINK2 dmd.truncating.conversion,Implicit integer conversions in `int op= float` assignments has been deprecated))
+$(LI $(RELATIVE_LINK2 dmd.opApply.return,`opApply` returning a non-zero constant has been deprecated))
 
 )
 
@@ -246,6 +247,13 @@ a += cast(uint) b;
 ```
 )
 
+$(LI $(LNAME2 dmd.opApply.return,`opApply` returning a non-zero constant has been deprecated)
+
+$(P It is undefined behavior for $(DDSUBLINK spec/statement, foreach_over_struct_and_classes,
+the `opApply` method) to return a non-zero value which is not the result of calling its delegate parameter.
+It is now deprecated to return such a value when it can be detected at compile-time.)
+)
+)
 
 )
 

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -778,6 +778,7 @@ $(GNAME OpApplyParameter):
         If there are no more elements to iterate,
         apply must return 0.)
     )
+    $(UNDEFINED_BEHAVIOR Returning a nonzero value that is not the result of calling the delegate.)
 
     $(P The result of calling the delegate will be nonzero if the *ForeachStatement*
         body executes a matching $(GLINK BreakStatement), $(GLINK ReturnStatement), or


### PR DESCRIPTION
See https://github.com/dlang/dmd/pull/21840.

Add item to 2.112 changelog, as there was no GitHub issue (oops). 
Also update spec to note undefined behaviour case.