### PR TITLE
[spec/traits] Tweak docs

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -1135,7 +1135,7 @@ $(GNAME UserDefinedAttribute):
 )
 
     $(P
-        User-Defined Attributes (UDA) are compile-time annotations that can be attached
+        User-Defined Attributes (UDAs) are compile-time annotations that can be attached
         to a declaration. These attributes can then be queried, extracted, and manipulated
         at compile time. There is no runtime component to them.
     )

--- a/spec/traits.dd
+++ b/spec/traits.dd
@@ -539,8 +539,8 @@ pragma(msg, __traits(getAliasThis, int));
         Prints:
 
 $(CONSOLE
-tuple("var")
-tuple()
+AliasSeq!("var")
+AliasSeq!()
 )
 
 $(H3 $(GNAME getPointerBitmap))
@@ -950,14 +950,15 @@ $(SECTION3 $(GNAME getFunctionVariadicStyle),
         Takes one argument which must either be a function symbol, or a type
         that is a function, delegate or a function pointer.
         It returns a string identifying the kind of
-        $(LINK2 function.html#variadic, variadic arguments) that are supported.
+        $(DDSUBLINK spec/function, variadic, variadic arguments) that are supported.
     )
 
     $(TABLE2 getFunctionVariadicStyle,
         $(THEAD result, kind, access, example)
         $(TROW $(D "none"), not a variadic function, $(NBSP), $(D void foo();))
         $(TROW $(D "argptr"), D style variadic function, $(D _argptr) and $(D _arguments), $(D void bar(...)))
-        $(TROW $(D "stdarg"), C style variadic function, $(LINK2 $(ROOT_DIR)phobos/core_stdc_stdarg.html, $(D core.stdc.stdarg)), $(D extern (C) void abc(int, ...)))
+        $(TROW $(D "stdarg"), C style variadic function, $(MREF core,stdc,stdarg),
+            $(D extern (C) void abc(int, ...)))
         $(TROW $(D "typesafe"), typesafe variadic function, array on stack, $(D void def(int[] ...)))
     )
 
@@ -1025,8 +1026,8 @@ pragma(msg, __traits(getFunctionAttributes, S.test));
         Prints:
 
 $(CONSOLE
-tuple("pure", "nothrow", "@system")
-tuple("const", "@system")
+AliasSeq!("pure", "nothrow", "@system")
+AliasSeq!("const", "@system")
 )
 
     $(P Note that some attributes can be inferred. For example:)
@@ -1040,7 +1041,7 @@ pragma(msg, __traits(getFunctionAttributes, (int x) @trusted { return x * 2; }))
         Prints:
 
 $(CONSOLE
-tuple("pure", "nothrow", "@nogc", "@trusted")
+AliasSeq!("pure", "nothrow", "@nogc", "@trusted")
 )
 )
 )
@@ -1217,7 +1218,7 @@ $(H3 $(GNAME isNested))
     stores a context pointer, otherwise it returns $(D false).
     Nested types can be  $(DDSUBLINK spec/class, nested, classes),
     $(DDSUBLINK spec/struct, nested, structs), and
-    $(DDSUBLINK spec/function, variadicnested, functions).)
+    $(DDSUBLINK spec/function, nested, functions).)
 
 $(H3 $(GNAME isFuture))
 
@@ -1229,7 +1230,8 @@ $(H3 $(GNAME isFuture))
 $(H3 $(GNAME isDeprecated))
 
     $(P Takes one argument. It returns `true` if the argument is a symbol
-    marked with the `deprecated` keyword, otherwise `false`.)
+    marked with the $(DDSUBLINK spec/attribute, deprecated, `deprecated`) keyword,
+    otherwise `false`.)
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
@@ -1357,12 +1359,9 @@ static assert(__traits(identifier, var) == "var");
 
 $(SECTION3 $(GNAME getAttributes),
     $(P
-        Takes one argument, a symbol. Returns a sequence of all attached user-defined attributes.
-        If no UDAs exist it will return an empty sequence
-    )
-
-    $(P
-        For more information, see: $(DDSUBLINK spec/attribute, uda, User-Defined Attributes)
+        Takes one argument, a symbol. Returns a sequence of all attached
+        $(DDSUBLINK spec/attribute, uda, user-defined attributes).
+        If no UDAs exist it will return an empty sequence.
     )
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
@@ -1382,27 +1381,28 @@ pragma(msg, __traits(getAttributes, c));
         Prints:
 
 $(CONSOLE
-tuple(3)
-tuple("string", 7)
-tuple((Foo))
+AliasSeq!(3)
+AliasSeq!("string", 7)
+AliasSeq!((Foo))
 )
 )
 
 $(SECTION3 $(GNAME getBitfieldOffset),
-     $(P Takes one argument, a qualified name that resolve to a field in a struct or class.
+     $(P Takes one argument, a qualified symbol that resolves to a field in a struct or class.
+     The result is a `uint`.
      )
-     $(P If the field is a bitfield, it returns as a `uint` the bit number of the least significant
+     $(P If the field is a bitfield, it returns the bit number of the least significant
      bit in the field. The rightmost bit is at offset 0, the leftmost bit is at offset 31 (for
      32 bit int fields).
      )
-     $(P If the field is a not bitfield, it returns as a `uint` the number 0.
+     $(P If the field is not a bitfield, it returns the number 0.
      )
 
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 struct S
 {
-    int a,b;
+    int a, b;
     int :2, c:3;
 }
 
@@ -1414,18 +1414,19 @@ static assert(__traits(getBitfieldOffset, S.c) == 2);
 )
 
 $(SECTION3 $(GNAME getBitfieldWidth),
-     $(P Takes one argument, a qualified name that resolve to a field in a struct or class.
+     $(P Takes one argument, a qualified symbol that resolves to a field in a struct or class.
+     The result is a `uint`.
      )
-     $(P If the field is a bitfield, it returns as a `uint` the width of the bit field as
+     $(P If the field is a bitfield, it returns the width of the bit field as
      a number of bits.
      )
-     $(P If the field is a not bitfield, it returns the number of bits in the type.
+     $(P If the field is not a bitfield, it returns the number of bits in the type.
      )
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
 struct S
 {
-    int a,b;
+    int a, b;
     int :2, c:3;
 }
 
@@ -1439,7 +1440,7 @@ $(H3 $(GNAME getLinkage))
 
         $(P Takes one argument, which is a declaration symbol, or the type of a function, delegate,
         pointer to function, struct, class, or interface.
-        Returns a string representing the $(LINK2 attribute.html#LinkageAttribute, LinkageAttribute)
+        Returns a string representing the $(GLINK2 attribute, LinkageAttribute)
         of the declaration.
         The string is one of:
         )
@@ -1570,16 +1571,19 @@ bar(int n)
 )
 
 $(H3 $(GNAME getCppNamespaces))
+
     $(P The argument is a symbol.
     The result is a *ValueSeq* of strings, possibly empty, that correspond to the namespaces the symbol resides in.
     )
+
 $(SPEC_RUNNABLE_EXAMPLE_COMPILE
 ---
-extern(C++, "ns")
-struct Foo {}
+extern(C++, "ns") struct Foo {}
 struct Bar {}
 extern(C++, __traits(getCppNamespaces, Foo)) struct Baz {}
+
 static assert(__traits(getCppNamespaces, Foo) ==  __traits(getCppNamespaces, Baz));
+
 void main()
 {
     static assert(__traits(getCppNamespaces, Foo)[0] == "ns");


### PR DESCRIPTION
Compiler prints `AliasSeq!` for sequences now, not `tuple`. 
Avoid using `.html` links.
Fix wrong nested function link.
Add spec links.
Tweak bitfield traits wording.
Tweak whitespace for namespace example.