### PR TITLE
[spec/function] Improve `return` attribute docs

### DIFF
--- a/spec/attribute.dd
+++ b/spec/attribute.dd
@@ -29,7 +29,6 @@ $(GNAME Attribute):
     $(RELATIVE_LINK2 inout, $(D inout))
     $(RELATIVE_LINK2 override, $(D override))
     $(RELATIVE_LINK2 ref, $(D ref))
-    $(RELATIVE_LINK2 return, $(D return))
     $(RELATIVE_LINK2 __rvalue, $(D __rvalue))
     $(RELATIVE_LINK2 scope, $(D scope))
     $(RELATIVE_LINK2 shared, $(D shared))

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -105,7 +105,7 @@ $(GNAME MemberFunctionAttribute):
     $(D const)
     $(D immutable)
     $(D inout)
-    $(D return)
+    $(RELATIVE_LINK2 struct-return-methods, `return`) `ref`$(OPT)
     $(D scope)
     $(D shared)
     $(GLINK FunctionAttribute)
@@ -1982,7 +1982,8 @@ void uranus()
 $(H4 $(LNAME2 struct-return-methods, Struct Return Methods))
 
         $(P Struct non-static methods can be marked with the `return` attribute to ensure a returned
-        reference will not outlive the struct instance.
+        reference will not outlive the struct instance. This is the same as the
+        `return ref` method attribute.
         )
 
 $(SPEC_RUNNABLE_EXAMPLE_FAIL


### PR DESCRIPTION
Remove `return` from Attribute grammar. Fixes #4391.
Document `return ref` method attribute (introduced in dlang/dmd#21369). Note: Discussion of that [here](https://github.com/dlang/dmd/issues/22451).