### PR TITLE
[spec/declaration] Mark `alias target name` syntax as legacy

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2239,3 +2239,10 @@ dt.d_decl:hover .decl_anchor {
     border: 1px solid #E6E6E6;
 }
 
+.legacy {
+    background-color: #E6E6E6;
+}
+
+.legacy::after {
+    content: ' 🕸️';
+}

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -159,6 +159,7 @@ $(COMMENT URL prefix for the site root.
 DPLLINK=$(LINK2 $(ROOT_DIR)$1,$+)
 _=
 
+EDITION=$(DIVC note, $(B $1 Edition:) $+)
 ELABORATE_HEADER=$(TR <th rowspan="2">D</th><th colspan="2">C</th>)
 $(TR <th scope="col">32 bit</th><th scope="col">64 bit</th>)
 _=
@@ -175,6 +176,7 @@ FULL_TITLE=$(TITLE) - D Programming Language
 _=
 
 GDEPRECATED=<del title="deprecated">$0</del>
+GLEGACY=$(SPAN class="legacy" title="legacy", $0)
 GRESERVED=<ins title="reserved">$0</ins>
 GEN_DATETIME=$(DATETIME)
 GLINK=$(RELATIVE_LINK2 $0, $(I $0))

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -341,12 +341,14 @@ $(H3 $(LNAME2 global_static_init, Global and Static Initializers))
 
 $(H2 $(LNAME2 alias, Alias Declarations))
 
-    $(NOTE New code should use the *AliasAssignments* form only.)
+    $(EDITION 2024, Use the *AliasAssignments* form only -
+    $(DDSUBLINK spec/legacy, alias-syntax, see legacy).)
 
 $(GRAMMAR
 $(GNAME AliasDeclaration):
+$(GLEGACY
     $(D alias) $(GLINK StorageClasses)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 type, TypeSuffixes)$(OPT) $(GLINK Identifiers) $(D ;)
-    $(D alias) $(GLINK StorageClasses)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 function, FuncDeclarator) $(D ;)
+    $(D alias) $(GLINK StorageClasses)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 function, FuncDeclarator) $(D ;))
     $(D alias) $(GLINK AliasAssignments) $(D ;)
 
 $(GNAME Identifiers):


### PR DESCRIPTION
Add link to legacy item.
Add EDITION, GLEGACY macros.