### PR TITLE
Fix: Editions example states that '+=5' lowers to '+=1'

### DIFF
--- a/spec/editions.dd
+++ b/spec/editions.dd
@@ -60,7 +60,7 @@ $(P would be lowered to:)
 
 ```
 shared int i;
-i.atomicOp!"+="(1);
+i.atomicOp!"+="(5);
 ```
 )
 )


### PR DESCRIPTION
The example code regarding editions changing semantics says that `i += 5` lowers to `i.atomicOp!"+="(1)`. The 5 changes to a 1, presumably by magic.