### PR TITLE
Don't exclude `etc.linux.memoryerror` from sidebar

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -196,7 +196,7 @@ MOD_EXCLUDES_PRERELEASE=$(addprefix --ex=, \
 	core.internal core.stdc.config core.sys \
 	std.algorithm.internal std.c std.internal std.regex.internal \
 	std.digest.digest \
-	std.windows.registry etc.linux.memoryerror \
+	std.windows.registry \
 	std.typetuple \
 	msvc_dmc msvc_lib \
 	dmd.libmach dmd.libmscoff \


### PR DESCRIPTION
I don't know why it was excluded, but the page looks fine: https://dlang.org/phobos/etc_linux_memoryerror.html