### PR TITLE
[ddoc preprocessor] Highlight multiple `<word>` and nested `[...]` in CLI switches

### DIFF
--- a/ddoc/source/preprocessor.d
+++ b/ddoc/source/preprocessor.d
@@ -479,10 +479,7 @@ private void highlightSpecialWords(ref string flag, ref string helpText)
             const specialWord = caps[1];
             helpText = helpText
                 .splitter(" ")
-                .map!((w) {
-                    auto wPlain = w.filter!(c => !c.among('<', '>', '`', '\'')).to!string;
-                    return wPlain == specialWord ? text("$(I ", wPlain, ")") : w;
-                })
+                .map!(w => w == specialWord ? text("$(I ", w, ")") : w)
                 .joiner(" ")
                 .to!string;
         }


### PR DESCRIPTION
Fixes https://github.com/dlang/dlang.org/issues/4421.

Before only the first <> and first [] was matched in the flag string.
Also inner [ chars were [wrongly italicised](https://dlang.org/dmd-linux.html#switch-HC[).

Before a space was added before the ] presumably because a tall italic character before runs into it. The trouble with that is it can look weird in other places, adding spaces where there shouldn't be any (e.g. `<arch>-<os>`, so I removed that.

*Update:* Also highlight any `<word>` in helpText even if not in flag string.