### PR TITLE
modlist: fix OOB in `indent()`

### DIFF
--- a/tools/modlist.d
+++ b/tools/modlist.d
@@ -104,8 +104,8 @@ int main(string[] args)
 
         private static string indent(size_t len)
         {
-            static immutable spaces = "                    ";
-            return spaces[0 .. 2 * len];
+            import std.array : replicate;
+            return " ".replicate(2 * len);
         }
 
         @disable this(this);


### PR DESCRIPTION
## 1. SUMMARY

This PR fixes an out-of-bounds slice in `indent(size_t len)` by removing the fixed-width string assumption and generating indentation dynamically. The change ensures safe behavior for all input lengths and prevents potential runtime crashes.

---

## 2. FIX

* **Root cause**

  * A fixed 20-character string was used for indentation
  * Slicing with `spaces[0 .. 2 * len]` causes out-of-bounds access when `len > 10`
  * Leads to `RangeError` (debug) or undefined behavior (release)

* **Technical approach**

  * Replace fixed string slicing with dynamic string generation using `std.array.replicate`
  * Removes implicit length constraint and ensures correctness for all inputs

* **Code changes**

**Before (problem pattern):**

```d
static immutable spaces = "                    ";
return spaces[0 .. 2 * len];
```

**After (solution):**

```d
import std.array : replicate;
return "  ".replicate(len);
```

---

## 3. VERIFICATION

* Compiled the tool using:

  ```
  dmd modlist.d
  ```
* Created a test project with deep module nesting (>10 levels)
* Ran:

  ```
  ./modlist /tmp/dtest --dump a
  ```


