### PR TITLE
fix: detect raw macro leakage after $(' in check_ddoc

### DIFF
--- a/tools/check_ddoc.d
+++ b/tools/check_ddoc.d
@@ -31,9 +31,18 @@ void checkLine(alias errorFun)(string file, size_t lineNr, const(char)[] line)
     if (line.canFind("UNDEFINED MACRO"))
         errorFun(ErrorMessages.undefinedMacro, file, lineNr, line);
 
-    if (line.findSplitAfter("$(")
-            .pipe!(a => !a.expand.only.any!empty && a[1].front != '\''))
-        errorFun(ErrorMessages.rawMacroLeakage, file, lineNr, line);
+    auto rest = line;
+    while (true)
+    {
+        auto parts = rest.findSplitAfter("$(");
+        if (parts[0].empty || parts[1].empty) break;
+        if (parts[1].front != '\'')
+        {
+            errorFun(ErrorMessages.rawMacroLeakage, file, lineNr, line);
+            break;
+        }
+        rest = parts[1];
+    }
 
     if (line.equal(")"))
         errorFun(ErrorMessages.trailingParenthesis, file, lineNr, line);
@@ -74,6 +83,7 @@ unittest
     assert(check("  $('") is null);
     assert(check("  $(") is null);
     assert(check("  $(FOO)") == ErrorMessages.rawMacroLeakage);
+    assert(check("  $(' ) $(FOO)") == ErrorMessages.rawMacroLeakage);
 
     assert(check("  )") is null);
     assert(check(") ") is null);


### PR DESCRIPTION
## SUMMARY

This PR fixes a bug in `tools/check_ddoc.d` where raw macro leakage is missed if a `$('` pattern appears earlier on the same line. The checker previously stopped after the first `$(...)` occurrence, allowing real macros later in the line to pass undetected.

The fix updates `checkLine` to scan all occurrences and adds a test for the mixed-case scenario.

---

## FIX 

**Before**

```d
if (line.findSplitAfter("$(")
        .pipe!(a => !a.expand.only.any!empty && a[1].front != '\''))
    errorFun(ErrorMessages.rawMacroLeakage, file, lineNr, line);
```

**After**

```d
auto rest = line;
while (true)
{
    auto parts = rest.findSplitAfter("$(");
    if (parts[0].empty || parts[1].empty) break;

    if (parts[1].front != '\'')
    {
        errorFun(ErrorMessages.rawMacroLeakage, file, lineNr, line);
        break;
    }

    rest = parts[1];
}
```

---

## VERIFICATION

* Ran `rdmd -unittest -main tools/check_ddoc.d`.
* Before fix: `check(" $(' ) $(FOO)")` returned `null`.
* After fix: correctly returns `ErrorMessages.rawMacroLeakage`.
* Verified valid cases (`$('foo')`) still pass.
* Verified mixed cases now correctly detect macro leakage.
* All unittests pass.

