### PR TITLE
fix: guard empty sources array access in chmgen lint()

### DIFF
--- a/tools/chmgen.d
+++ b/tools/chmgen.d
@@ -371,7 +371,10 @@ void lint()
             if (brokenLinks.canFind(url))
                 continue;
             stderr.writeln("Warning: Unknown page: " ~ url);
-            stderr.writefln("  (linked from %d pages e.g. %s)", unknownPages[url].length, unknownPages[url][0]);
+            if (unknownPages[url].length > 0)
+                stderr.writefln("  (linked from %d pages e.g. %s)", unknownPages[url].length, unknownPages[url][0]);
+            else
+                stderr.writefln("  (linked from %d pages)", unknownPages[url].length);
         }
     }
 


### PR DESCRIPTION
### **SUMMARY**

This PR prevents a potential crash in `tools/chmgen.d` by safely handling access to a possibly empty array. It updates the `lint()` function to avoid a `RangeError` when no source pages exist.

---

### **FIX**

**Before**

```d
stderr.writefln("  (linked from %d pages e.g. %s)",
    unknownPages[url].length,
    unknownPages[url][0]);
```

**After**

```d
if (unknownPages[url].length > 0)
    stderr.writefln("  (linked from %d pages e.g. %s)",
        unknownPages[url].length,
        unknownPages[url][0]);
else
    stderr.writefln("  (linked from %d pages)",
        unknownPages[url].length);
```

---

### **VERIFICATION**

* Run `chmgen` with a case where `link.sources` is empty
* Before: crashes with `RangeError`
* After: prints a safe message and continues normally
