### PR TITLE
fix: guard empty changelogFiles before nav index access

### DIFF
--- a/ddoc/source/preprocessor.d
+++ b/ddoc/source/preprocessor.d
@@ -346,7 +346,7 @@ auto genChangelogVersion(string fileName, string fileText)
         // inject the changelog footer
         auto fileBaseName = fileName.baseName;
         auto r = changelogFiles.chain("pending.dd".only).enumerate.find!(a => a.value.baseName == fileBaseName);
-        if (r.length != 0)
+        if (r.length != 0 && !changelogFiles.empty)
         {
             auto el = r.front;
             macros ~= "\nCHANGELOG_NAV_INJECT=";


### PR DESCRIPTION
## **SUMMARY**

Fixes a crash in `genChangelogVersion` caused by indexing into an empty list when no changelog files exist. Affects `preprocessor.d` in changelog generation.

---

## **FIX**

### **Before**

```d
if (r.length != 0)
{
    auto versions = changelogFiles.map!(a => a.baseName.until(".dd"));
    auto hasPrerelease = versions[$ - 1].canFind("_pre");
}
```

### **After**

```d
if (r.length != 0 && !changelogFiles.empty)
{
    auto versions = changelogFiles.map!(a => a.baseName.until(".dd"));
    auto hasPrerelease = versions[$ - 1].canFind("_pre");
}
```

---

## **VERIFICATION**

Run generation with an empty `changelog/` and confirm there is no crash. Then run it with valid changelog files and confirm everything still works as expected.
