### PR TITLE
Replace more Bugzilla refs with GitHub

### DIFF
--- a/articles/ctarguments.dd
+++ b/articles/ctarguments.dd
@@ -17,7 +17,7 @@ $(HEADERNAV_TOC)
         commonly exist in other languages. Sequences of values of different types that can be
         returned from functions are provided by $(REF Tuple, std, typecons).
         Using the term "tuple" to mean compile-time sequences is discouraged to avoid confusion, and if encountered
-        should result in a $(LINK2 https://issues.dlang.org, documentation bug report).
+        should result in a $(LINK2 https://github.com/dlang/phobos/issues/new, documentation bug report).
     )
 
     $(P Consider this simple variadic template:)

--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -194,11 +194,11 @@ html(lang='en-US')
                   | page was generated on github.
 
             .tip.smallprint
-              - auto pagename = modname ? path_prefix ~ replace(modname, ".", "/") : "index";
-              a(href="https://issues.dlang.org/enter_bug.cgi?bug_file_loc=http%3A%2F%2Fdlang.org/#{ddox_dir}#{pagename}.html&bug_severity=enhancement&component=#{project}&op_sys=All&priority=P3&product=D&rep_platform=All&short_desc=%5B#{title}%5D&version=D2") Report a bug
+              - auto issue_title = modname ? modname : "Phobos Runtime Library";
+              a(href="https://github.com/dlang/#{project}/issues/new?title=[#{issue_title}]&label=Severity:Enhancement") Report a bug
               div
                 | If you spot a problem with this page, click here to create a
-                | Bugzilla issue.
+                | GitHub issue.
 
             - if( modname )
               .tip.smallprint

--- a/foundation/sponsors.dd
+++ b/foundation/sponsors.dd
@@ -4,7 +4,7 @@ $(D_S $(TITLE),
 
 $(P Development of the D programming language is driven by the passion and dedication of its users. From
 $(LINK2 contributors.html, submitting and reviewing pull requests) to
-$(WEB issues.dlang.org, reporting issues), offering help in $(HTTPS forum.dlang.org, the forums),
+$(LINK2 ../bugstats.html, reporting issues), offering help in $(HTTPS forum.dlang.org, the forums),
 and writing guest posts for $(HTTPS dlang.org/blog, the official blog), the members of the D
 community contribute as and how they can, most often for no compensation other than personal
 satisfaction.

--- a/orgs-using-d.dd
+++ b/orgs-using-d.dd
@@ -324,7 +324,7 @@ $(DIVC orgs-using-d center,
 
 $(P
     Is your organization missing from this page? Please
-    $(LINK2 https://issues.dlang.org/enter_bug.cgi?component=dlang.org&amp;short_desc=Add%20(insert%20your%20organization)%20to%20organizations%20using%20D, create an issue)
+    $(LINK2 $(BUGZILLA_NEW_BUG_URL), create an issue)
     or $(LINK2 https://github.com/dlang/$(PROJECT)/edit/master/$(SRC_FILENAME), open a pull request).
 )
 )


### PR DESCRIPTION
Replace some more Bugzilla refs with GitHub links.
Correctly fixes the [dlang.org/library](https://dlang.org/library/std.html) pages.
#4285