### PR TITLE
Update to apt command for d-apt

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -182,10 +182,12 @@ $(DOWNLOAD_OTHER $(NIX), $(LINK2 https://search.nixos.org/packages?show=dmd&quer
 $(LINK2 https://github.com/petarkirov/dlang.nix, derivations for various compiler versions)
 )
 
+$(BR)
+
 $(DOWNLOAD_OTHER $(UBUNTU) $(DEBIAN), Ubuntu/Debian, $(LINK2 https://d-apt.sourceforge.net/, APT repository)
 $(CONSOLE sudo wget https://master.dl.sourceforge.net/project/d-apt/files/d-apt.sources -O /etc/apt/sources.list.d/d-apt.sources
 sudo wget https://master.dl.sourceforge.net/project/d-apt/files/d-apt.asc -O /etc/apt/keyrings/d-apt.asc
-sudo apt-get update && sudo apt-get install dmd-compiler dub)
+sudo apt update && sudo apt install dmd-compiler dub)
 )
 
 $(DOWNLOAD_OTHER $(DOCKER) $(PODMAN), $(LINK2 oci.html, Docker and OCI),


### PR DESCRIPTION
Updated commands for installing dmd-compiler and dub on Ubuntu/Debian.