### PR TITLE
Update to apt command for d-apt

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -101,8 +101,6 @@ $(DIVC download_channels,
         $(SBTN $(OSXDMG), dmg) $(SBTN $(ARCH osx, tar.xz), tar.xz)
     )
 
-    $(BR)
-
     $(DOWNLOAD Ubuntu/Debian, $(UBUNTU) &nbsp; $(DEBIAN), linux, Linux,
         $(SBTN $(DEB32), i386) $(SBTN $(DEB64), x86_64) $(SBTN $(ARCH linux, tar.xz), tar.xz)
     )
@@ -182,10 +180,12 @@ $(DOWNLOAD_OTHER $(NIX), $(LINK2 https://search.nixos.org/packages?show=dmd&quer
 $(LINK2 https://github.com/petarkirov/dlang.nix, derivations for various compiler versions)
 )
 
+$(BR)
+
 $(DOWNLOAD_OTHER $(UBUNTU) $(DEBIAN), Ubuntu/Debian, $(LINK2 https://d-apt.sourceforge.net/, APT repository)
 $(CONSOLE sudo wget https://master.dl.sourceforge.net/project/d-apt/files/d-apt.sources -O /etc/apt/sources.list.d/d-apt.sources
 sudo wget https://master.dl.sourceforge.net/project/d-apt/files/d-apt.asc -O /etc/apt/keyrings/d-apt.asc
-sudo apt-get update && sudo apt-get install dmd-compiler dub)
+sudo apt update && sudo apt install dmd-compiler dub)
 )
 
 $(DOWNLOAD_OTHER $(DOCKER) $(PODMAN), $(LINK2 oci.html, Docker and OCI),


### PR DESCRIPTION
Removed unnecessary line breaks and updated the installation command for DMD compiler on Ubuntu/Debian.