### PR TITLE
Fix typo in `oci.dd`

### DIFF
--- a/oci.dd
+++ b/oci.dd
@@ -180,7 +180,7 @@ The $(STRONG maintenance policy) of $(I dlang-dockerized) is outlined in the MAI
 It can be found at $(LINK https://github.com/dlang-dockerized/packaging/blob/main/MAINTENANCE.md).
 )
 
-$(NOTE:
+$(NOTE
 Keep in mind, this is work done by volunteers.
 )
 


### PR DESCRIPTION
Messed up ddoc syntax.